### PR TITLE
fix: Apple Silicon GPU detection and energy monitor test

### DIFF
--- a/rust/crates/openjarvis-core/src/hardware.rs
+++ b/rust/crates/openjarvis-core/src/hardware.rs
@@ -151,19 +151,31 @@ fn detect_apple_gpu() -> Option<GpuInfo> {
         let trimmed = line.trim();
         if trimmed.contains("Chipset Model") {
             let name = trimmed.split(':').next_back().unwrap_or("Apple Silicon").trim();
+            let ram_gb = run_cmd(&["sysctl", "-n", "hw.memsize"])
+                .trim()
+                .parse::<u64>()
+                .map(|b| b as f64 / (1024.0 * 1024.0 * 1024.0))
+                .unwrap_or(0.0);
             return Some(GpuInfo {
                 vendor: "apple".into(),
                 name: name.to_string(),
-                vram_gb: 0.0,
+                vram_gb: ram_gb,
                 count: 1,
                 compute_capability: String::new(),
             });
         }
     }
+    let ram_gb = run_cmd(&["sysctl", "-n", "hw.memsize"])
+        .trim()
+        .parse::<u64>()
+        .map(|b| b as f64 / (1024.0 * 1024.0 * 1024.0))
+        .unwrap_or(0.0);
     Some(GpuInfo {
         vendor: "apple".into(),
         name: "Apple Silicon".into(),
-        ..GpuInfo::default()
+        vram_gb: ram_gb,
+        count: 1,
+        compute_capability: String::new(),
     })
 }
 

--- a/src/openjarvis/cli/init_cmd.py
+++ b/src/openjarvis/cli/init_cmd.py
@@ -141,8 +141,10 @@ def init(force: bool, config: Optional[Path]) -> None:
     console.print(f"  CPU      : {hw.cpu_brand} ({hw.cpu_count} cores)")
     console.print(f"  RAM      : {hw.ram_gb} GB")
     if hw.gpu:
+        mem_label = "unified memory" if hw.gpu.vendor == "apple" else "VRAM"
+        gpu = hw.gpu
         console.print(
-            f"  GPU      : {hw.gpu.name} ({hw.gpu.vram_gb} GB VRAM, x{hw.gpu.count})"
+            f"  GPU      : {gpu.name} ({gpu.vram_gb} GB {mem_label}, x{gpu.count})"
         )
     else:
         console.print("  GPU      : none detected")

--- a/src/openjarvis/core/config.py
+++ b/src/openjarvis/core/config.py
@@ -133,12 +133,13 @@ def _detect_apple_gpu() -> Optional[GpuInfo]:
     if "Apple" not in raw:
         return None
     # Rough extraction — "Apple M2 Max" etc.
+    ram_gb = _total_ram_gb()
     for line in raw.splitlines():
         line = line.strip()
         if "Chipset Model" in line:
             name = line.split(":")[-1].strip()
-            return GpuInfo(vendor="apple", name=name)
-    return GpuInfo(vendor="apple", name="Apple Silicon")
+            return GpuInfo(vendor="apple", name=name, vram_gb=ram_gb, count=1)
+    return GpuInfo(vendor="apple", name="Apple Silicon", vram_gb=ram_gb, count=1)
 
 
 def _detect_cpu_brand() -> str:

--- a/tests/telemetry/test_energy_apple.py
+++ b/tests/telemetry/test_energy_apple.py
@@ -43,14 +43,20 @@ class TestAvailable:
 
             assert AppleEnergyMonitor.available() is False
 
-    def test_available_false_when_zeus_not_importable(self):
+    def test_available_true_without_zeus(self):
+        """Monitor is available on Apple Silicon even without Zeus."""
         import openjarvis.telemetry.energy_apple as mod
 
         orig = mod._ZEUS_APPLE_AVAILABLE
         mod._ZEUS_APPLE_AVAILABLE = False
         try:
-            with patch("platform.system", return_value="Darwin"):
-                assert mod.AppleEnergyMonitor.available() is False
+            with patch("platform.system", return_value="Darwin"), patch(
+                "platform.machine", return_value="arm64"
+            ):
+                assert mod.AppleEnergyMonitor.available() is True
+                monitor = mod.AppleEnergyMonitor.__new__(mod.AppleEnergyMonitor)
+                monitor._zeus_ok = False
+                assert monitor.energy_method() == "cpu_time_estimate"
         finally:
             mod._ZEUS_APPLE_AVAILABLE = orig
 


### PR DESCRIPTION
## Summary
- **Fix GPU detection**: `_detect_apple_gpu()` (Python and Rust) now reports system RAM as unified memory and sets `count=1`, instead of defaulting to `0.0 GB VRAM, x0`
- **Fix display label**: `jarvis init` shows "unified memory" instead of "VRAM" for Apple Silicon chips
- **Fix incorrect test**: `test_available_false_when_zeus_not_importable` was asserting `available()=False` when Zeus is missing, but the monitor IS available via CPU-time fallback — test now correctly verifies `available()=True` and `energy_method()="cpu_time_estimate"`

## Test plan
- [x] `uv run pytest tests/telemetry/test_energy_apple.py -v` — 6/6 pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — all pass
- [x] Verified `_detect_apple_gpu()` returns e.g. `Apple M4 (32.0 GB, x1)` on real hardware

🤖 Generated with [Claude Code](https://claude.com/claude-code)