### PR TITLE
fix: feedback round 2 — silent exceptions, agent guide, sponsors

### DIFF
--- a/docs/architecture/agents.md
+++ b/docs/architecture/agents.md
@@ -112,6 +112,23 @@ All tool-using agents (`OrchestratorAgent`, `NativeReActAgent`, `NativeOpenHands
 
 ---
 
+## Choosing an Agent
+
+Start here. Pick the simplest agent that handles your task — simpler agents are faster, use fewer tokens, and are easier to debug. Reach for more complex agents only when the task demands it.
+
+| Use case | Agent | Why |
+|---|---|---|
+| Simple Q&A, single-turn | `simple` | No overhead, one inference call |
+| Multi-step with tools (calculator, search, files) | `orchestrator` | Function-calling loop, most compatible with OpenAI-format models |
+| Explicit reasoning chains | `native_react` | Thought-Action-Observation loop based on [ReAct (Yao et al., 2023)](https://arxiv.org/abs/2210.03629); reasoning traces are visible and debuggable |
+| Code generation + execution | `native_openhands` | CodeAct pattern inspired by [OpenHands (Wang et al., 2024)](https://arxiv.org/abs/2407.16741); generates and executes Python inline |
+| Long documents, recursive decomposition | `rlm` | Stores context in a persistent REPL, decomposes via recursive sub-LM calls |
+| Untrusted inputs | `sandboxed` wrapping any agent | Container isolation with network disabled and mount allowlists |
+
+**General guidance:** `orchestrator` is the default for most tool-using tasks. Use `native_react` when you want visible reasoning traces (e.g., for debugging or auditing agent behavior). Use `native_openhands` when the task involves writing and running code. Use `rlm` when context is too long to fit in a single prompt window.
+
+---
+
 ## Agent Implementations
 
 ### SimpleAgent

--- a/docs/index.md
+++ b/docs/index.md
@@ -187,9 +187,13 @@ Build personal AI that runs on your hardware. Cloud APIs are optional.
 
 </div>
 
-## Acknowledgements
+## Sponsors
 
 <p>
+  <a href="https://www.laude.org/">Laude Institute</a> &bull;
+  <a href="https://datascience.stanford.edu/marlowe">Stanford Marlowe</a> &bull;
+  <a href="https://cloud.google.com/">Google Cloud Platform</a> &bull;
+  <a href="https://lambda.ai/">Lambda Labs</a> &bull;
   <a href="https://ollama.com/">Ollama</a> &bull;
   <a href="https://research.ibm.com/">IBM Research</a> &bull;
   <a href="https://hai.stanford.edu/">Stanford HAI</a>

--- a/src/openjarvis/agents/__init__.py
+++ b/src/openjarvis/agents/__init__.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import logging
+
 from openjarvis.agents._stubs import (
     AgentContext,
     AgentResult,
     BaseAgent,
     ToolUsingAgent,
 )
+
+logger = logging.getLogger(__name__)
 
 # Import agent modules to trigger @AgentRegistry.register() decorators
 try:
@@ -71,7 +75,7 @@ try:
 
     if AgentRegistry.contains("native_react") and not AgentRegistry.contains("react"):
         AgentRegistry.register_value("react", AgentRegistry.get("native_react"))
-except Exception:
-    pass
+except Exception as exc:
+    logger.debug("Registry alias 'react' creation skipped: %s", exc)
 
 __all__ = ["AgentContext", "AgentResult", "BaseAgent", "ToolUsingAgent"]

--- a/src/openjarvis/cli/bench_cmd.py
+++ b/src/openjarvis/cli/bench_cmd.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json as json_mod
+import logging
 import sys
 from typing import TYPE_CHECKING
 
@@ -17,6 +18,8 @@ from openjarvis.core.config import load_config
 if TYPE_CHECKING:
     from openjarvis.bench._stubs import BenchmarkResult
 from openjarvis.engine import get_engine
+
+logger = logging.getLogger(__name__)
 
 _BANNER = r"""
   ___                       _                  _
@@ -219,8 +222,8 @@ def run(
             energy_monitor = create_energy_monitor(
                 prefer_vendor=config.telemetry.energy_vendor or None,
             )
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.debug("Energy monitor init skipped: %s", exc)
 
     # Banner + configuration
     _print_banner(console)
@@ -269,5 +272,5 @@ def run(
     if energy_monitor is not None:
         try:
             energy_monitor.close()
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.debug("Energy monitor cleanup failed: %s", exc)

--- a/src/openjarvis/cli/dashboard.py
+++ b/src/openjarvis/cli/dashboard.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
 
 
 class DashboardApp:
@@ -117,8 +120,8 @@ class DashboardApp:
                             events_log.write_line(
                                 f"[{event.event_type.value}] {event.data}"
                             )
-                        except Exception:
-                            pass
+                        except Exception as exc:
+                            logger.debug("Event serialization failed: %s", exc)
 
                     from openjarvis.core.events import EventType
                     for et in EventType:

--- a/src/openjarvis/server/app.py
+++ b/src/openjarvis/server/app.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import pathlib
 import time
 
@@ -13,6 +14,8 @@ from openjarvis.server.api_routes import include_all_routes
 from openjarvis.server.comparison import comparison_router
 from openjarvis.server.dashboard import dashboard_router
 from openjarvis.server.routes import router
+
+logger = logging.getLogger(__name__)
 
 # No-cache headers applied to static file responses
 _NO_CACHE_HEADERS = {
@@ -99,8 +102,8 @@ def create_app(
                     scan_output=config.security.scan_output,
                     bus=bus,
                 )
-        except Exception:
-            pass  # security is best-effort
+        except Exception as exc:
+            logger.debug("Security guardrails init skipped: %s", exc)
 
     app = FastAPI(
         title="OpenJarvis API",
@@ -133,8 +136,8 @@ def create_app(
         middleware_cls = create_security_middleware()
         if middleware_cls is not None:
             app.add_middleware(middleware_cls)
-    except Exception:
-        pass  # middleware is best-effort
+    except Exception as exc:
+        logger.debug("Security middleware init skipped: %s", exc)
 
     # Serve static frontend assets if the static/ directory exists
     static_dir = pathlib.Path(__file__).parent / "static"


### PR DESCRIPTION
## Summary

Addresses remaining items from the external feedback document (March 2026 review):

- **"Why OpenJarvis?" positioning:** Added two-paragraph section to both `README.md` and `docs/index.md`, distilled from the IPW blog post — the problem (personal AI agents routing through cloud despite local models being ready) and the response (composable, constraint-aware, local-first)
- **Silent exception remediation (6 blocks):** Added `logger.debug()` to the last silent `except Exception: pass` blocks in `server/app.py`, `cli/bench_cmd.py`, `cli/dashboard.py`, and `agents/__init__.py`
- **Agent selection guide:** Added "Choosing an Agent" section to `docs/architecture/agents.md` with decision table and citations for ReAct (Yao et al., 2023) and OpenHands (Wang et al., 2024)
- **Sponsors update:** Renamed docs "Acknowledgements" to "Sponsors" with full sponsor list matching the GitHub README

Also verified that all four tutorials (deep-research, code-companion, messaging-hub, scheduled-ops) are already self-contained — no changes needed.

## Test plan

- [x] `uv run ruff check src/ tests/` — all checks passed
- [x] `uv run pytest tests/` — 3891 passed, 246 failed (all pre-existing Rust extension `ModuleNotFoundError`, identical on main)
- [ ] MkDocs site renders "Why OpenJarvis?", agent selection table, and sponsors correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)