### PR TITLE
docs: add "Why OpenJarvis?" positioning to README and docs landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ results = j.memory.search("attention mechanism")  # semantic retrieval
 j.close()
 ```
 
+## Why OpenJarvis?
+
+Personal AI agents are taking off — but nearly all of them route your data through cloud APIs. Our [Intelligence Per Watt](https://www.intelligence-per-watt.ai/) research found that local language models already handle 88.7% of queries accurately, with efficiency improving 5.3× from 2023 to 2025. The models and hardware are ready. What's been missing is the software stack.
+
+OpenJarvis provides that stack. It replaces ad-hoc integration with five composable primitives (Intelligence, Engine, Agents, Tools & Memory, and Learning) that share a common architecture. It treats energy and dollar cost as first-class objectives alongside accuracy — not afterthoughts. And every primitive is local-first, designed to discover and adapt to the accelerators on your device. The critical path is written in Rust for memory safety and predictable latency; Python handles orchestration and ML pipelines. The goal is to serve both as a research platform and as production-grade infrastructure.
+
 ## Installation
 
 ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,14 @@ Build personal AI that runs on your hardware. Cloud APIs are optional.
 
 ---
 
+## Why OpenJarvis?
+
+Personal AI agents are exploding in popularity — but nearly all of them route intelligence, tools, and even memory through cloud APIs. Your "personal" AI still lives on someone else's server. Our [Intelligence Per Watt](https://www.intelligence-per-watt.ai/) research showed that local language models already handle 88.7% of single-turn chat and reasoning queries, with intelligence efficiency improving 5.3× from 2023 to 2025. The models and hardware are ready. What's been missing is the software stack.
+
+OpenJarvis is that stack. Three design principles guide every decision: **composable** — five interoperable primitives replacing bespoke integration; **constraint-aware** — energy, latency, and dollar cost are first-class objectives alongside accuracy; and **local-first** — every primitive discovers and adapts to the accelerators on your device. A hybrid Rust + Python architecture keeps the critical path (security, sandboxing, tool execution) fast and memory-safe, while Python handles orchestration, ML pipelines, and the evaluation harness.
+
+---
+
 ## Get Started
 
 === "Browser App"


### PR DESCRIPTION
## Summary

- Added a "Why OpenJarvis?" section to both `README.md` and `docs/index.md`, distilled from the IPW blog post
- Two paragraphs: the problem (personal AI agents routing through cloud despite local models being ready) and the response (composable, constraint-aware, local-first stack with hybrid Rust + Python architecture)

## Test plan

- [x] No code changes — docs only
- [ ] README renders correctly on GitHub
- [ ] MkDocs site renders "Why OpenJarvis?" section before "Get Started"

🤖 Generated with [Claude Code](https://claude.com/claude-code)