### PR TITLE
fix(desktop): macOS code signing & notarization

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -85,7 +85,7 @@ jobs:
           - platform: ubuntu-22.04
             args: ''
           - platform: macos-latest
-            args: '--target aarch64-apple-darwin'
+            args: '--target universal-apple-darwin'
           - platform: windows-latest
             args: ''
 
@@ -109,7 +109,7 @@ jobs:
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin' || '' }}
+          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
       - name: Rust cache
         uses: swatinem/rust-cache@v2
@@ -168,10 +168,15 @@ jobs:
             echo "APPLE_TEAM_ID=$A_TEAM" >> "$GITHUB_ENV"
             echo "Apple signing configured"
           else
+            if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+              echo "::error::Apple signing secrets are required for release builds"
+              exit 1
+            fi
             echo "No Apple certificate configured, skipping code signing"
           fi
 
       - name: Build and release
+        timeout-minutes: 30
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -79,16 +79,29 @@ Set the public key in `src-tauri/tauri.conf.json` under `plugins.updater.pubkey`
 | `TAURI_SIGNING_PRIVATE_KEY` | Contents of the `.key` file |
 | `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` | Password used during generation |
 
-### macOS Notarization (Optional)
+### macOS Code Signing & Notarization (Required for Distribution)
 
-| Secret | Description |
-|--------|-------------|
-| `APPLE_CERTIFICATE` | Base64-encoded `.p12` certificate |
-| `APPLE_CERTIFICATE_PASSWORD` | Certificate password |
-| `APPLE_SIGNING_IDENTITY` | e.g., `Developer ID Application: Name (TEAMID)` |
-| `APPLE_ID` | Apple ID email |
-| `APPLE_PASSWORD` | App-specific password |
-| `APPLE_TEAM_ID` | 10-character team ID |
+Without these secrets, macOS users will see *"OpenJarvis is damaged and can't be opened"* due to Gatekeeper. The CI workflow will **fail release builds** (tag pushes) if signing secrets are missing.
+
+**Prerequisites:** Apple Developer Program membership ($99/year) — [developer.apple.com/programs](https://developer.apple.com/programs/)
+
+| Secret | How to obtain |
+|--------|---------------|
+| `APPLE_CERTIFICATE` | In Keychain Access, export your **Developer ID Application** certificate as `.p12`. Then: `base64 -i cert.p12 \| pbcopy` |
+| `APPLE_CERTIFICATE_PASSWORD` | The password you set during the `.p12` export |
+| `APPLE_SIGNING_IDENTITY` | Full CN string from the certificate, e.g. `"Developer ID Application: Open Jarvis Inc (XXXXXXXXXX)"` |
+| `APPLE_ID` | The Apple ID email associated with your Developer account |
+| `APPLE_PASSWORD` | An **app-specific password** generated at [appleid.apple.com](https://appleid.apple.com) (not your account password) |
+| `APPLE_TEAM_ID` | 10-character team ID from [developer.apple.com/account](https://developer.apple.com/account) |
+
+Add all 6 secrets in **GitHub → Settings → Secrets and variables → Actions**.
+
+#### Local Signing Test
+
+```bash
+export APPLE_SIGNING_IDENTITY="Developer ID Application: ..."
+cd desktop && npm run tauri build -- --target universal-apple-darwin
+```
 
 ### Windows Authenticode (Optional)
 
@@ -97,7 +110,7 @@ Set the public key in `src-tauri/tauri.conf.json` under `plugins.updater.pubkey`
 | `WINDOWS_CERTIFICATE` | Base64-encoded `.pfx` certificate |
 | `WINDOWS_CERTIFICATE_PASSWORD` | Certificate password |
 
-All signing is optional — unsigned builds work without any secrets configured.
+Windows signing is optional — unsigned Windows builds work but show a SmartScreen warning on first launch.
 
 ## Dashboard Panels
 

--- a/desktop/src-tauri/Entitlements.plist
+++ b/desktop/src-tauri/Entitlements.plist
@@ -10,5 +10,11 @@
     <true/>
     <key>com.apple.security.files.user-selected.read-write</key>
     <true/>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- **Entitlements**: Add 3 hardened-runtime entitlements (`allow-jit`, `allow-unsigned-executable-memory`, `disable-library-validation`) required for WKWebView under notarized builds
- **Universal binary**: Build `universal-apple-darwin` (arm64 + x86_64) so Intel Mac users are supported
- **Release gate**: Tag-triggered builds fail loudly if Apple signing secrets are missing, preventing unsigned `.dmg` releases from shipping
- **Build timeout**: 30-minute timeout on Tauri build step to prevent runaway builds during notarization
- **Docs**: Rewrote macOS signing section from "Optional" to "Required for Distribution" with step-by-step secret setup instructions

## Test plan
- [ ] Push a test tag (e.g., `desktop-v0.0.1-rc1`) to trigger the release workflow
- [ ] Verify CI logs show "Apple code signing configured", `codesign` output, `notarytool` "status: Accepted"
- [ ] Download the `.dmg` from the GitHub release and install on a clean Mac — no Gatekeeper "damaged" dialog
- [ ] Verify universal binary: `lipo -info /Applications/OpenJarvis.app/Contents/MacOS/OpenJarvis` shows both x86_64 and arm64

🤖 Generated with [Claude Code](https://claude.com/claude-code)