### PR TITLE
fix(desktop): download Ollama for both macOS archs in universal build

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -132,7 +132,13 @@ jobs:
       - name: Download Ollama sidecar
         shell: bash
         run: |
-          cd desktop/scripts && chmod +x download-ollama.sh && ./download-ollama.sh
+          cd desktop/scripts && chmod +x download-ollama.sh
+          if [[ "${{ matrix.platform }}" == "macos-latest" ]]; then
+            ./download-ollama.sh aarch64-apple-darwin
+            ./download-ollama.sh x86_64-apple-darwin
+          else
+            ./download-ollama.sh
+          fi
 
       - name: Determine release info
         id: release-info


### PR DESCRIPTION
## Summary
- The universal binary build requires Ollama sidecars for **both** `aarch64-apple-darwin` and `x86_64-apple-darwin`
- The download script was only called once (auto-detect), which fetched only the runner's native arch (arm64)
- This caused the x86_64 build to fail: `resource path 'binaries/ollama-x86_64-apple-darwin' doesn't exist`
- Fix: on macOS, explicitly call the download script for both architectures

## Test plan
- [ ] Merge and delete the stale `desktop-v0.0.1-rc1` tag, then re-tag to trigger a fresh build
- [ ] Verify macOS CI job passes the Ollama sidecar step with both binaries downloaded
- [ ] Verify the universal binary build completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)