### PR TITLE
fix(desktop): increase build timeout for Apple notarization

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -182,7 +182,7 @@ jobs:
           fi
 
       - name: Build and release
-        timeout-minutes: 30
+        timeout-minutes: 60
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Apple's notary service took 25+ minutes to respond on the rc1 build, exceeding the 30-minute step timeout
- The build itself compiled, codesigned, and submitted successfully — it just timed out waiting for Apple's response
- Bumps timeout from 30 to 60 minutes

## Test plan
- [ ] Merge, retag `desktop-v0.0.1-rc1`, and verify macOS job completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)