### PR TITLE
feat: feature gap closure — model catalog, eval framework v2, docs, and benchmark results

### DIFF
--- a/rust/crates/openjarvis-python/uv.lock
+++ b/rust/crates/openjarvis-python/uv.lock
@@ -1,0 +1,8 @@
+version = 1
+revision = 3
+requires-python = ">=3.10"
+
+[[package]]
+name = "openjarvis-rust"
+version = "1.0.0"
+source = { editable = "." }

--- a/src/openjarvis/evals/configs/use_case_v2_granite.toml
+++ b/src/openjarvis/evals/configs/use_case_v2_granite.toml
@@ -1,0 +1,52 @@
+[meta]
+name = "use-case-v2-granite"
+description = "5 use-case benchmarks x 3 IBM Granite models"
+
+[defaults]
+temperature = 0.0
+max_tokens = 4096
+
+[judge]
+model = "gpt-5-mini"
+
+[run]
+max_workers = 2
+output_dir = "results/use-cases-v2-granite/"
+seed = 42
+
+[[models]]
+name = "granite4-micro:latest"
+engine = "ollama"
+
+[[models]]
+name = "granite3.3:8b"
+engine = "ollama"
+
+[[models]]
+name = "granite4-h-small:latest"
+engine = "ollama"
+
+[[benchmarks]]
+name = "coding_assistant"
+backend = "jarvis-direct"
+max_samples = 30
+
+[[benchmarks]]
+name = "security_scanner"
+backend = "jarvis-direct"
+max_samples = 30
+
+[[benchmarks]]
+name = "daily_digest"
+backend = "jarvis-direct"
+max_samples = 30
+
+[[benchmarks]]
+name = "doc_qa"
+backend = "jarvis-direct"
+max_samples = 30
+
+[[benchmarks]]
+name = "browser_assistant"
+backend = "jarvis-direct"
+max_samples = 30


### PR DESCRIPTION
## Summary

Closes the feature gap between OpenJarvis and production readiness across model catalog, eval framework, documentation, and engine support.

- **Model catalog expansion**: Added Qwen3.5 family (4B→397B MoE), GLM-4.7/GLM-5, LFM2.5, Unsloth GGUF models, Gemini 3.1 Flash Lite, Claude Haiku 4.5 to cloud engine
- **Eval framework v2**: Use-case benchmarks (coding_assistant, security_scanner, daily_digest, doc_qa, browser_assistant) with telemetry integration — GPU power/energy/utilization, IPW, IPJ, throughput, normalized statistics, hardware info in outputs
- **Benchmark results**: 11 models (5 local MoE + 6 cloud) × 5 benchmarks. Top local model (Qwen3.5:122B-A10B, 0.840) outperforms all cloud models including Claude Opus 4.6 (0.820) and GPT-5.4 (0.807)
- **Documentation overhaul**: Purged OpenClaw references, expanded agent/tool/channel/engine/eval docs, unified "Five Primitives" terminology
- **Silent exception remediation**: Added structured logging to all bare `except: pass` handlers across the codebase
- **Engine improvements**: OLLAMA_HOST env var support, increased timeout for large MoE models, engine-model test matrix expanded to 10 engines × 6 models

### Key Benchmark Finding

Local MoE models are competitive with cloud APIs:
```
#1  Qwen3.5:122B-A10B    Local  0.840  ← beats all cloud models
#2  Claude Opus 4.6      Cloud  0.820
#3  Qwen3.5:35B-A3B      Local  0.818
#4  Gemini 3.1 Flash Lite Cloud 0.813
#5  GPT-5.4              Cloud  0.807
```

## Test plan

- [ ] `uv run pytest -m "not live and not cloud" tests/ -v --tb=short` — all unit tests pass
- [ ] `uv run ruff check src/ tests/` — lint clean
- [ ] Eval configs parse correctly: `uv run python -c "from openjarvis.evals.core.config import load_eval_config; load_eval_config('src/openjarvis/evals/configs/use_case_v2_cloud.toml')"`
- [ ] Engine-model matrix tests pass: `uv run pytest tests/engine/test_engine_model_matrix.py -v`
- [ ] Export tests pass: `uv run pytest tests/evals/test_export.py -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)