### PR TITLE
fix: respect config.toml ollama host instead of env var override

### DIFF
--- a/src/openjarvis/cli/model.py
+++ b/src/openjarvis/cli/model.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import sys
 
 import click
@@ -154,7 +155,11 @@ def pull(model_name: str) -> None:
     """Download a model (Ollama only)."""
     console = Console()
     config = load_config()
-    host = config.engine.ollama_host.rstrip("/")
+    host = (
+        config.engine.ollama_host
+        or os.environ.get("OLLAMA_HOST")
+        or "http://localhost:11434"
+    ).rstrip("/")
 
     console.print(f"Pulling [cyan]{model_name}[/cyan] via Ollama...")
     try:

--- a/src/openjarvis/core/config.py
+++ b/src/openjarvis/core/config.py
@@ -257,7 +257,7 @@ def recommend_model(hw: HardwareInfo, engine: str) -> str:
 class OllamaEngineConfig:
     """Per-engine config for Ollama."""
 
-    host: str = "http://localhost:11434"
+    host: str = ""
 
 
 @dataclass(slots=True)

--- a/src/openjarvis/engine/ollama.py
+++ b/src/openjarvis/engine/ollama.py
@@ -27,16 +27,18 @@ class OllamaEngine(InferenceEngine):
 
     engine_id = "ollama"
 
+    _DEFAULT_HOST = "http://localhost:11434"
+
     def __init__(
         self,
-        host: str = "http://localhost:11434",
+        host: str | None = None,
         *,
         timeout: float = 1800.0,
     ) -> None:
-        # Allow OLLAMA_HOST env var to override the default
-        env_host = os.environ.get("OLLAMA_HOST")
-        if env_host:
-            host = env_host
+        # Priority: explicit host (from config.toml) > OLLAMA_HOST env var > default
+        if host is None:
+            env_host = os.environ.get("OLLAMA_HOST")
+            host = env_host or self._DEFAULT_HOST
         self._host = host.rstrip("/")
         self._client = httpx.Client(base_url=self._host, timeout=timeout)
 

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -33,13 +33,13 @@ class TestDefaults:
     def test_engine_config_defaults(self) -> None:
         ec = EngineConfig()
         # Nested configs
-        assert ec.ollama.host == "http://localhost:11434"
+        assert ec.ollama.host == ""
         assert ec.vllm.host == "http://localhost:8000"
         assert ec.sglang.host == "http://localhost:30000"
         assert ec.llamacpp.host == "http://localhost:8080"
         assert ec.llamacpp.binary_path == ""
         # Backward-compat properties still work
-        assert ec.ollama_host == "http://localhost:11434"
+        assert ec.ollama_host == ""
         assert ec.vllm_host == "http://localhost:8000"
 
 
@@ -208,7 +208,7 @@ class TestAgentConfigNew:
 class TestNestedEngineConfig:
     def test_nested_access(self) -> None:
         ec = EngineConfig()
-        assert ec.ollama.host == "http://localhost:11434"
+        assert ec.ollama.host == ""
         assert ec.vllm.host == "http://localhost:8000"
         assert ec.sglang.host == "http://localhost:30000"
         assert ec.llamacpp.host == "http://localhost:8080"


### PR DESCRIPTION
OLLAMA_HOST env var was unconditionally overriding the host parameter in OllamaEngine.__init__, even when explicitly set via config.toml. 

Priority is now: config.toml > OLLAMA_HOST env var > hardcoded default.

Repairs issue #42 