### PR TITLE
fix: frontend now uses settings API URL for all backend requests

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -17,7 +17,20 @@ export const isTauri = () => typeof window !== 'undefined' && !!window.__TAURI_I
 
 const DESKTOP_API = 'http://127.0.0.1:8000';
 
-const getBase = () => {
+const getSettingsApiUrl = (): string => {
+  try {
+    const raw = localStorage.getItem('openjarvis-settings');
+    if (raw) {
+      const parsed = JSON.parse(raw);
+      if (parsed.apiUrl) return parsed.apiUrl.replace(/\/+$/, '');
+    }
+  } catch {}
+  return '';
+};
+
+export const getBase = (): string => {
+  const settingsUrl = getSettingsApiUrl();
+  if (settingsUrl) return settingsUrl;
   if (import.meta.env.VITE_API_URL) return import.meta.env.VITE_API_URL;
   if (isTauri()) return DESKTOP_API;
   return '';

--- a/frontend/src/lib/sse.ts
+++ b/frontend/src/lib/sse.ts
@@ -1,5 +1,5 @@
 import type { SSEEvent } from '../types';
-import { isTauri } from './api';
+import { getBase } from './api';
 
 export interface ChatRequest {
   model: string;
@@ -7,13 +7,11 @@ export interface ChatRequest {
   stream: true;
 }
 
-const DESKTOP_API = 'http://127.0.0.1:8000';
-
 export async function* streamChat(
   request: ChatRequest,
   signal?: AbortSignal,
 ): AsyncGenerator<SSEEvent> {
-  const base = import.meta.env.VITE_API_URL || (isTauri() ? DESKTOP_API : '');
+  const base = getBase();
   const response = await fetch(`${base}/v1/chat/completions`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -188,7 +188,7 @@ export function SettingsPage() {
                 </span>
               </div>
             </SettingRow>
-            <SettingRow label="API URL" description="Leave empty for same-origin">
+            <SettingRow label="API URL" description="Set if backend runs on a different port or host">
               <input
                 type="text"
                 value={settings.apiUrl}
@@ -322,7 +322,7 @@ export function SettingsPage() {
               </p>
               <div className="flex gap-3 mt-3 text-xs">
                 <a
-                  href="https://www.intelligence-per-watt.ai/"
+                  href="https://scalingintelligence.stanford.edu/blogs/openjarvis/"
                   target="_blank"
                   rel="noopener noreferrer"
                   style={{ color: 'var(--color-accent)' }}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -46,8 +46,8 @@ export default defineConfig({
   server: {
     port: 5173,
     proxy: {
-      '/v1': 'http://localhost:8000',
-      '/health': 'http://localhost:8000',
+      '/v1': process.env.VITE_API_URL || 'http://localhost:8000',
+      '/health': process.env.VITE_API_URL || 'http://localhost:8000',
     },
   },
 });


### PR DESCRIPTION
getBase() reads settings.apiUrl from localStorage so the API URL configured in the Settings page is actually used by api.ts and sse.ts. Previously hardcoded to localhost:8000, causing "Failed to get response" when the backend ran on a different port.

Resolves issue #48 