### PR TITLE
fix: clean stale desktop release artifacts and fix frontend port

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -74,8 +74,29 @@ jobs:
         working-directory: desktop/src-tauri
         run: cargo check
 
-  build-and-release:
+  # Remove stale artifacts from the desktop-latest pre-release so that
+  # only the current build's files are available for download.
+  clean-release:
     needs: [validate]
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete old assets from desktop-latest
+        if: "!startsWith(github.ref, 'refs/tags/')"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="desktop-latest"
+          # List all asset IDs on the release and delete them
+          ASSET_IDS=$(gh api "repos/${{ github.repository }}/releases/tags/${TAG}" \
+            --jq '.assets[].id' 2>/dev/null || true)
+          for id in $ASSET_IDS; do
+            echo "Deleting asset $id"
+            gh api -X DELETE "repos/${{ github.repository }}/releases/assets/$id" || true
+          done
+
+  build-and-release:
+    needs: [validate, clean-release]
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
 
     strategy:

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -386,6 +386,11 @@ async fn get_setup_status(
 }
 
 #[tauri::command]
+fn get_api_base() -> String {
+    api_base()
+}
+
+#[tauri::command]
 async fn start_backend(
     backend: tauri::State<'_, SharedBackend>,
     status: tauri::State<'_, SharedStatus>,
@@ -684,6 +689,7 @@ pub fn run() {
         })
         .invoke_handler(tauri::generate_handler![
             get_setup_status,
+            get_api_base,
             start_backend,
             stop_backend,
             check_health,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openjarvis-chat",
   "private": true,
-  "version": "1.0.0",
+  "version": "0.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -15,7 +15,23 @@ declare global {
 
 export const isTauri = () => typeof window !== 'undefined' && !!window.__TAURI_INTERNALS__;
 
-const DESKTOP_API = 'http://127.0.0.1:8000';
+// Cached API base URL fetched from the Tauri backend at startup.
+// This avoids hardcoding the port — the Rust backend is the single
+// source of truth for JARVIS_PORT.
+let _tauriApiBase: string | null = null;
+
+/** Pre-fetch the API base URL from the Tauri backend (call once at init). */
+export async function initApiBase(): Promise<void> {
+  if (!isTauri()) return;
+  try {
+    const { invoke } = await import('@tauri-apps/api/core');
+    _tauriApiBase = await invoke<string>('get_api_base');
+  } catch {
+    // Command may not exist on older builds; fall through to default.
+  }
+}
+
+const DESKTOP_API_FALLBACK = 'http://127.0.0.1:8222';
 
 const getSettingsApiUrl = (): string => {
   try {
@@ -32,7 +48,7 @@ export const getBase = (): string => {
   const settingsUrl = getSettingsApiUrl();
   if (settingsUrl) return settingsUrl;
   if (import.meta.env.VITE_API_URL) return import.meta.env.VITE_API_URL;
-  if (isTauri()) return DESKTOP_API;
+  if (isTauri()) return _tauriApiBase || DESKTOP_API_FALLBACK;
   return '';
 };
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import App from './App';
+import { initApiBase } from './lib/api';
 import './index.css';
 
 function applyTheme() {
@@ -22,12 +23,17 @@ function applyTheme() {
 
 applyTheme();
 
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <ErrorBoundary>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
-    </ErrorBoundary>
-  </StrictMode>,
-);
+// Fetch the API base URL from the Tauri backend before rendering.
+// This ensures JARVIS_PORT is defined in one place (the Rust backend).
+// In non-Tauri environments this is a no-op.
+initApiBase().finally(() => {
+  createRoot(document.getElementById('root')!).render(
+    <StrictMode>
+      <ErrorBoundary>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </ErrorBoundary>
+    </StrictMode>,
+  );
+});


### PR DESCRIPTION
## Summary
- **Stale release artifacts:** The `desktop-latest` pre-release accumulated artifacts across builds because `tauri-action` adds new files without removing old ones. Users could download an outdated DMG that didn't contain recent fixes. Added a `clean-release` job that deletes all existing assets from the `desktop-latest` release before the build matrix uploads new ones. Tagged releases (`desktop-v*`) are unaffected since they create fresh releases.
- **Frontend port mismatch (from PR #51):** The Tauri backend starts the server on port 8222, but the frontend hardcoded port 8000. Added a `get_api_base` Tauri command so the frontend fetches the URL from the Rust backend at startup. The old constant is kept as a fallback for backward compatibility.
- **Version alignment:** `frontend/package.json` was `1.0.0` while `desktop/` and `pyproject.toml` are `0.1.0`, causing duplicate artifact names (e.g. both `OpenJarvis_0.1.0_aarch64.dmg` and `OpenJarvis_1.0.0_aarch64.dmg`).

## Test plan
- [ ] Merge and verify the `desktop-latest` release only contains artifacts from the new build (no stale duplicates)
- [ ] Download the new DMG and send a chat message — should get a response
- [ ] Verify `get_api_base` returns `http://127.0.0.1:8222` in the desktop app
- [ ] Trigger a second build and confirm old artifacts are cleaned before new ones are uploaded