### PR TITLE
fix: security middleware blocks CORS preflight, breaking desktop chat

### DIFF
--- a/src/openjarvis/server/middleware.py
+++ b/src/openjarvis/server/middleware.py
@@ -17,9 +17,11 @@ def create_security_middleware() -> Any:
     - X-Frame-Options: DENY
     - X-XSS-Protection: 1; mode=block
     - Strict-Transport-Security: max-age=31536000; includeSubDomains
-    - Content-Security-Policy: default-src 'self'
     - Referrer-Policy: strict-origin-when-cross-origin
     - Permissions-Policy: camera=(), microphone=(), geolocation=()
+
+    OPTIONS requests are passed through without headers so that
+    CORS preflight is not blocked.
     """
     try:
         from starlette.middleware.base import BaseHTTPMiddleware
@@ -30,6 +32,11 @@ def create_security_middleware() -> Any:
 
     class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         async def dispatch(self, request: Request, call_next: Any) -> Response:
+            # Let CORS preflight requests pass through without
+            # security headers that would conflict with CORS.
+            if request.method == "OPTIONS":
+                return await call_next(request)
+
             response = await call_next(request)
             response.headers["X-Content-Type-Options"] = "nosniff"
             response.headers["X-Frame-Options"] = "DENY"
@@ -37,7 +44,6 @@ def create_security_middleware() -> Any:
             response.headers["Strict-Transport-Security"] = (
                 "max-age=31536000; includeSubDomains"
             )
-            response.headers["Content-Security-Policy"] = "default-src 'self'"
             response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
             response.headers["Permissions-Policy"] = (
                 "camera=(), microphone=(), geolocation=()"
@@ -53,7 +59,6 @@ SECURITY_HEADERS = {
     "X-Frame-Options": "DENY",
     "X-XSS-Protection": "1; mode=block",
     "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-    "Content-Security-Policy": "default-src 'self'",
     "Referrer-Policy": "strict-origin-when-cross-origin",
     "Permissions-Policy": "camera=(), microphone=(), geolocation=()",
 }

--- a/tests/server/test_middleware.py
+++ b/tests/server/test_middleware.py
@@ -17,7 +17,6 @@ class TestSecurityHeaders:
             "X-Frame-Options",
             "X-XSS-Protection",
             "Strict-Transport-Security",
-            "Content-Security-Policy",
             "Referrer-Policy",
             "Permissions-Policy",
         }
@@ -77,3 +76,41 @@ class TestSecurityHeaders:
             assert resp.headers.get(header_name) == header_value, (
                 f"Missing or wrong header: {header_name}"
             )
+
+    def test_middleware_skips_options(self) -> None:
+        """OPTIONS requests pass through without security headers."""
+        import pytest
+        fastapi = pytest.importorskip("fastapi")
+        from fastapi.middleware.cors import CORSMiddleware
+        from fastapi.testclient import TestClient
+
+        app = fastapi.FastAPI()
+
+        # Add CORS first, then security (reverse execution order)
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=["*"],
+            allow_methods=["*"],
+            allow_headers=["*"],
+        )
+        middleware_cls = create_security_middleware()
+        assert middleware_cls is not None
+        app.add_middleware(middleware_cls)
+
+        @app.post("/test")
+        def test_endpoint() -> dict:
+            return {"ok": True}
+
+        client = TestClient(app)
+        resp = client.options(
+            "/test",
+            headers={
+                "Origin": "https://tauri.localhost",
+                "Access-Control-Request-Method": "POST",
+                "Access-Control-Request-Headers": "content-type",
+            },
+        )
+        assert resp.status_code == 200
+        assert "access-control-allow-origin" in resp.headers
+        # Security headers should NOT be present on preflight
+        assert "X-Frame-Options" not in resp.headers


### PR DESCRIPTION
## Summary
- The `SecurityHeadersMiddleware` blocks all chat requests from the desktop app. Starlette executes middleware in LIFO order, so the security middleware (added last) runs **before** `CORSMiddleware`. It adds `Content-Security-Policy: default-src 'self'` to every response, including CORS preflight (`OPTIONS`) responses. This tells the browser to reject cross-origin `fetch()` calls from the Tauri webview (`https://tauri.localhost`) to the API server (`http://127.0.0.1`), causing "Failed to get response" on every chat message.
- Fix: skip all security headers on `OPTIONS` requests so CORS preflight succeeds. Also removes `Content-Security-Policy` from API responses entirely — it's a document-level browser policy that has no meaning for JSON API responses and breaks any cross-origin consumer.

## Test plan
- [ ] `uv run pytest tests/server/test_middleware.py -v` — 5 tests pass including new `test_middleware_skips_options`
- [ ] Open the desktop app and send a chat message — should receive a response from qwen3:0.6b
- [ ] Verify `curl -X OPTIONS http://127.0.0.1:8222/v1/chat/completions -H "Origin: https://tauri.localhost" -H "Access-Control-Request-Method: POST"` returns 200 with `access-control-allow-origin` header