### PR TITLE
fix(ui): center input, 2x3 energy grid, unify token counts

### DIFF
--- a/frontend/src/components/Chat/InputArea.tsx
+++ b/frontend/src/components/Chat/InputArea.tsx
@@ -293,7 +293,7 @@ export function InputArea() {
   return (
     <div className="px-4 pb-4 pt-2" style={{ maxWidth: 'var(--chat-max-width)', margin: '0 auto', width: '100%' }}>
       <div
-        className="flex items-end gap-2 rounded-2xl px-4 py-3 transition-shadow"
+        className="flex items-center gap-2 rounded-2xl px-4 py-3 transition-shadow"
         style={{
           background: 'var(--color-input-bg)',
           border: '1px solid var(--color-input-border)',

--- a/frontend/src/components/Dashboard/CostComparison.tsx
+++ b/frontend/src/components/Dashboard/CostComparison.tsx
@@ -97,24 +97,11 @@ export function CostComparison() {
         })}
       </div>
 
-      {/* Savings from API if available */}
-      {savings.per_provider.length > 0 && (
-        <div className="mt-3 pt-3" style={{ borderTop: '1px solid var(--color-border)' }}>
-          <div className="text-xs mb-2" style={{ color: 'var(--color-text-tertiary)' }}>
-            Server-reported savings
-          </div>
-          {savings.per_provider.map((p) => (
-            <div key={p.provider} className="flex justify-between text-xs py-1">
-              <span style={{ color: 'var(--color-text-secondary)' }}>{p.label}</span>
-              <span style={{ color: 'var(--color-success)' }}>${p.total_cost.toFixed(4)}</span>
-            </div>
-          ))}
-        </div>
-      )}
-
-      <p className="text-[10px] mt-3 leading-relaxed" style={{ color: 'var(--color-text-tertiary)' }}>
-        *Savings estimates assume local models (e.g. Qwen, Nemotron, Kimi) produce roughly the same number of tokens per request, on average, as closed-source cloud models.
-      </p>
+      <div className="mt-3 pt-3" style={{ borderTop: '1px solid var(--color-border)' }}>
+        <p className="text-[10px] leading-relaxed" style={{ color: 'var(--color-text-tertiary)' }}>
+          *Savings estimates assume local models (e.g. Qwen, Nemotron, Kimi) produce roughly the same number of tokens per request, on average, as closed-source cloud models.
+        </p>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/Dashboard/EnergyDashboard.tsx
+++ b/frontend/src/components/Dashboard/EnergyDashboard.tsx
@@ -8,8 +8,9 @@ import {
   Tooltip,
   ResponsiveContainer,
 } from 'recharts';
-import { Zap, Activity, Thermometer, Hash } from 'lucide-react';
+import { Zap, Activity, Thermometer, Hash, Gauge } from 'lucide-react';
 import { fetchEnergy, fetchTelemetry } from '../../lib/api';
+import { useAppStore } from '../../lib/store';
 
 interface EnergySample {
   timestamp: string;
@@ -56,7 +57,7 @@ function StatCard({
           {label}
         </span>
       </div>
-      <div className="text-xl font-semibold" style={{ color: 'var(--color-text)' }}>
+      <div className="text-xl font-semibold truncate" style={{ color: 'var(--color-text)' }}>
         {value}
         {unit && (
           <span className="text-xs font-normal ml-1" style={{ color: 'var(--color-text-tertiary)' }}>
@@ -69,6 +70,7 @@ function StatCard({
 }
 
 export function EnergyDashboard() {
+  const savings = useAppStore((s) => s.savings);
   const [energy, setEnergy] = useState<EnergyData | null>(null);
   const [telemetry, setTelemetry] = useState<TelemetryStats | null>(null);
   const [chartData, setChartData] = useState<ChartPoint[]>([]);
@@ -141,7 +143,7 @@ export function EnergyDashboard() {
         Energy Monitoring
       </h3>
 
-      <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 mb-4">
+      <div className="grid grid-cols-2 gap-3 mb-4">
         <StatCard
           icon={Zap}
           label="Total Energy"
@@ -163,15 +165,18 @@ export function EnergyDashboard() {
         <StatCard
           icon={Hash}
           label="Total Requests"
-          value={String(telemetry?.total_requests ?? 0)}
+          value={String(savings?.total_calls ?? telemetry?.total_requests ?? 0)}
         />
-      </div>
-
-      {/* Thermal indicator */}
-      <div className="flex items-center gap-2 mb-4 text-xs" style={{ color: 'var(--color-text-secondary)' }}>
-        <span className="w-2 h-2 rounded-full" style={{ background: thermalStatus.color }} />
-        Thermal: {thermalStatus.label}
-        <span className="ml-auto">{telemetry?.total_tokens ?? 0} tokens processed</span>
+        <StatCard
+          icon={Gauge}
+          label="Thermal"
+          value={thermalStatus.label}
+        />
+        <StatCard
+          icon={Hash}
+          label="Tokens Processed"
+          value={formatNumber(savings?.total_tokens ?? telemetry?.total_tokens ?? 0)}
+        />
       </div>
 
       {/* Chart */}
@@ -198,4 +203,10 @@ export function EnergyDashboard() {
       )}
     </div>
   );
+}
+
+function formatNumber(n: number): string {
+  if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M';
+  if (n >= 1_000) return (n / 1_000).toFixed(1) + 'K';
+  return String(n);
 }


### PR DESCRIPTION
## Summary
- Center "Message OpenJarvis..." placeholder vertically in the chat input area
- Restructure Energy Monitoring dashboard from 4-card row + inline thermal to a 2x3 grid with thermal and tokens as their own stat cards
- Remove redundant "Server-reported savings" section from Cost Comparison; shift asterisk text up below the divider
- Fix token count discrepancy: Energy Monitoring now uses `savings` store (same source as Cost Comparison) instead of separate server telemetry endpoint

## Test plan
- [ ] Verify "Message OpenJarvis..." text is vertically centered in the input box
- [ ] Verify Energy Monitoring shows 2x3 grid: Total Energy, Energy/Token, Avg Power, Total Requests, Thermal, Tokens Processed
- [ ] Verify stat card values don't overflow their containers
- [ ] Verify "Server-reported savings" section is gone from Cost Comparison
- [ ] Verify asterisk text sits directly below the divider line
- [ ] Verify tokens count matches between Energy Monitoring and Cost Comparison

🤖 Generated with [Claude Code](https://claude.com/claude-code)