### PR TITLE
Running `uv run jarvis start` failed

### DIFF
--- a/src/openjarvis/cli/__main__.py
+++ b/src/openjarvis/cli/__main__.py
@@ -1,0 +1,6 @@
+"""Entry point for CLI execution."""
+
+from openjarvis.cli import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# CLI module execution fails

## Problem
Running `uv run jarvis start` does not successfully start the server process. The process starts but immediately exits.

## Error
```
No module named openjarvis.cli.__main__; 'openjarvis.cli' is a package and cannot be directly executed
```

## Root Cause
The CLI package (`src/openjarvis/cli/`) lacks an entry point file (`__main__.py`), preventing execution via `python -m openjarvis.cli`.

## Fix
Added `src/openjarvis/cli/__main__.py` with entry point that calls the `main()` function, enabling proper module execution.