### PR TITLE
fix: parse tool_call arguments as dicts for OpenAI-compatible engines

### DIFF
--- a/src/openjarvis/engine/_openai_compat.py
+++ b/src/openjarvis/engine/_openai_compat.py
@@ -32,6 +32,26 @@ class _OpenAICompatibleEngine(InferenceEngine):
 
     # -- InferenceEngine interface ------------------------------------------
 
+    @staticmethod
+    def _fix_tool_call_arguments(msg_dicts: list) -> list:
+        """Ensure tool_call arguments are dicts, not JSON strings.
+
+        OpenAI-compatible servers (vLLM, SGLang, llama.cpp, etc.) expect
+        tool_call arguments as JSON objects.  ``messages_to_dicts`` may
+        serialize them as strings, which causes 400 errors on multi-turn
+        tool-calling conversations.
+        """
+        for md in msg_dicts:
+            for tc in md.get("tool_calls", []):
+                fn = tc.get("function", {})
+                args = fn.get("arguments")
+                if isinstance(args, str):
+                    try:
+                        fn["arguments"] = json.loads(args)
+                    except (json.JSONDecodeError, TypeError):
+                        pass
+        return msg_dicts
+
     def generate(
         self,
         messages: Sequence[Message],
@@ -41,9 +61,10 @@ class _OpenAICompatibleEngine(InferenceEngine):
         max_tokens: int = 1024,
         **kwargs: Any,
     ) -> Dict[str, Any]:
+        msg_dicts = self._fix_tool_call_arguments(messages_to_dicts(messages))
         payload: Dict[str, Any] = {
             "model": model,
-            "messages": messages_to_dicts(messages),
+            "messages": msg_dicts,
             "temperature": temperature,
             "max_tokens": max_tokens,
             "stream": False,
@@ -105,9 +126,10 @@ class _OpenAICompatibleEngine(InferenceEngine):
         max_tokens: int = 1024,
         **kwargs: Any,
     ) -> AsyncIterator[str]:
+        msg_dicts = self._fix_tool_call_arguments(messages_to_dicts(messages))
         payload: Dict[str, Any] = {
             "model": model,
-            "messages": messages_to_dicts(messages),
+            "messages": msg_dicts,
             "temperature": temperature,
             "max_tokens": max_tokens,
             "stream": True,


### PR DESCRIPTION
## Summary
- Fix 400 Bad Request errors on multi-turn tool-calling for all OpenAI-compatible engines (vLLM, SGLang, llama.cpp, MLX, etc.)
- `messages_to_dicts()` serializes tool_call arguments as JSON strings, but these servers expect JSON objects — added `_fix_tool_call_arguments()` to parse them back to dicts
- Same fix as commit 45c0e44 (Ollama), now applied to the shared `_OpenAICompatibleEngine` base class

## Impact
This was the root cause of DeepPlanning being N/A and low sample counts on GAIA/LifelongAgent for all local vLLM models. With this fix, multi-turn agentic benchmarks should work properly on local inference.

## Test plan
- [x] 273/273 engine tests pass (`tests/engine/`)
- [x] `test_openai_compat_tools.py` passes
- [ ] Re-run long-horizon benchmarks (GAIA, DeepPlanning, LifelongAgent) on local models to confirm improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)