### PR TITLE
fix: pin macOS desktop build to macos-14 to fix DMG bundling

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -105,7 +105,7 @@ jobs:
         include:
           - platform: ubuntu-22.04
             args: ''
-          - platform: macos-latest
+          - platform: macos-14
             args: '--target universal-apple-darwin'
           - platform: windows-latest
             args: ''
@@ -130,7 +130,7 @@ jobs:
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+          targets: ${{ matrix.platform == 'macos-14' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
       - name: Rust cache
         uses: swatinem/rust-cache@v2
@@ -154,7 +154,7 @@ jobs:
         shell: bash
         run: |
           cd desktop/scripts && chmod +x download-ollama.sh
-          if [[ "${{ matrix.platform }}" == "macos-latest" ]]; then
+          if [[ "${{ matrix.platform }}" == "macos-14" ]]; then
             ./download-ollama.sh aarch64-apple-darwin
             ./download-ollama.sh x86_64-apple-darwin
           else


### PR DESCRIPTION
## Summary

- **Root cause**: `macos-latest` now resolves to macOS 15 (Sequoia), which removed `SetFile` from Xcode Command Line Tools. Tauri's `bundle_dmg.sh` uses `SetFile -a C` to set custom icon attributes on the DMG volume, causing the [Desktop Build & Release workflow to fail](https://github.com/open-jarvis/OpenJarvis/actions/runs/23121749775) on the macOS runner.
- **Fix**: Pin the macOS build runner to `macos-14` (Apple Silicon M1, Sonoma), which still includes `SetFile` and fully supports universal binary (`aarch64-apple-darwin` + `x86_64-apple-darwin`) builds.
- Updates all three references to the macOS platform string in the workflow: matrix entry, Rust target conditional, and Ollama sidecar download conditional.

## Test plan

- [ ] Desktop Build & Release CI passes on all three platforms (ubuntu-22.04, macos-14, windows-latest)
- [ ] CI workflow (Python tests/lint) remains green
- [ ] Docs workflow unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)