### PR TITLE
fix: make Roadmap a nav section with Roadmap + Contributing Guide

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -164,4 +164,6 @@ nav:
       - Design Principles: architecture/design-principles.md
   - API Reference: api-reference/
   - Leaderboard: leaderboard.md
-  - Roadmap: development/roadmap.md
+  - Roadmap:
+      - Roadmap: development/roadmap.md
+      - Contributing Guide: development/contributing.md


### PR DESCRIPTION
## Summary

- Changed MkDocs nav so "Roadmap" is a tab/section (not a single page link)
- Two sub-pages: **Roadmap** and **Contributing Guide**
- Follows up on #86 which removed the Development section

## Test plan

- [ ] Verify MkDocs renders "Roadmap" as a tab with two sub-pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)