### PR TITLE
fix: pass temperature and max_tokens from UI settings to backend

### DIFF
--- a/frontend/src/components/Chat/InputArea.tsx
+++ b/frontend/src/components/Chat/InputArea.tsx
@@ -18,6 +18,8 @@ export function InputArea() {
   const streamState = useAppStore((s) => s.streamState);
   const messages = useAppStore((s) => s.messages);
   const speechEnabled = useAppStore((s) => s.settings.speechEnabled);
+  const maxTokens = useAppStore((s) => s.settings.maxTokens);
+  const temperature = useAppStore((s) => s.settings.temperature);
   const createConversation = useAppStore((s) => s.createConversation);
   const addMessage = useAppStore((s) => s.addMessage);
   const updateLastAssistant = useAppStore((s) => s.updateLastAssistant);
@@ -147,7 +149,7 @@ export function InputArea() {
 
     try {
       for await (const sseEvent of streamChat(
-        { model: selectedModel, messages: apiMessages, stream: true },
+        { model: selectedModel, messages: apiMessages, stream: true, temperature, max_tokens: maxTokens },
         controller.signal,
       )) {
         const eventName = sseEvent.event;

--- a/frontend/src/lib/sse.ts
+++ b/frontend/src/lib/sse.ts
@@ -5,6 +5,8 @@ export interface ChatRequest {
   model: string;
   messages: Array<{ role: string; content: string }>;
   stream: true;
+  temperature?: number;
+  max_tokens?: number;
 }
 
 export async function* streamChat(


### PR DESCRIPTION
## Summary

- Include `temperature` and `max_tokens` from the frontend settings store in the chat API request payload
- Add both fields as optional properties on the `ChatRequest` TypeScript interface

Without this fix, the backend `ChatCompletionRequest` Pydantic model defaults `max_tokens` to `1024` whenever the field is absent. This is too low for thinking models (e.g. qwen3.5) which consume all tokens on reasoning and return empty content to the user.

## Test plan

- [ ] Open the UI, set max_tokens to 4096+ in Settings
- [ ] Send a message using a thinking model (e.g. qwen3.5:35b)
- [ ] Verify the response is no longer empty
- [ ] Verify temperature changes in Settings are reflected in model output


🤖 Generated with [Claude Code](https://claude.com/claude-code)