### PR TITLE
fix: address installation failures and SDK bugs (#100)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,12 @@ git clone https://github.com/open-jarvis/OpenJarvis.git
 cd OpenJarvis
 uv sync                           # core framework
 uv sync --extra server             # + FastAPI server
+
+# Build the Rust extension (requires Rust: https://rustup.rs/)
+uv run maturin develop -m rust/crates/openjarvis-python/Cargo.toml
 ```
+
+> **Python 3.14+:** set `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1` before the `maturin` command.
 
 You also need a local inference backend: [Ollama](https://ollama.com), [vLLM](https://github.com/vllm-project/vllm), [SGLang](https://github.com/sgl-project/sglang), or [llama.cpp](https://github.com/ggerganov/llama.cpp). Alternatively, use the `cloud` engine with [OpenAI](https://openai.com), [Anthropic](https://anthropic.com), [Google Gemini](https://ai.google.dev), [OpenRouter](https://openrouter.ai), or [MiniMax](https://www.minimax.io) by setting the corresponding API key environment variable.
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -42,8 +42,13 @@ If you prefer to run each step yourself:
     git clone https://github.com/open-jarvis/OpenJarvis.git
     cd OpenJarvis
     uv sync --extra server
+    uv run maturin develop -m rust/crates/openjarvis-python/Cargo.toml
     cd frontend && npm install && cd ..
     ```
+
+    !!! note "Prerequisites"
+        Requires [Rust](https://rustup.rs/) (`curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`).
+        On Python 3.14+, set `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1` before the `maturin` command.
 
 === "Step 2: Start Ollama"
 
@@ -131,7 +136,10 @@ programmatically. Every feature is accessible from the terminal.
 git clone https://github.com/open-jarvis/OpenJarvis.git
 cd OpenJarvis
 uv sync
+uv run maturin develop -m rust/crates/openjarvis-python/Cargo.toml
 ```
+
+Requires [Rust](https://rustup.rs/). On Python 3.14+, set `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1` before the `maturin` command.
 
 ### Verify
 
@@ -172,7 +180,10 @@ For programmatic access, the `Jarvis` class provides a high-level sync API.
 git clone https://github.com/open-jarvis/OpenJarvis.git
 cd OpenJarvis
 uv sync
+uv run maturin develop -m rust/crates/openjarvis-python/Cargo.toml
 ```
+
+Requires [Rust](https://rustup.rs/). On Python 3.14+, set `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1` before the `maturin` command.
 
 ### Quick example
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,8 +108,8 @@ jarvis = "openjarvis.cli:main"
 packages = ["src/openjarvis"]
 
 [tool.hatch.build.targets.wheel.force-include]
-"src/openjarvis/agents/claude_code_runner" = "openjarvis/agents/claude_code_runner"
-"src/openjarvis/channels/whatsapp_baileys_bridge" = "openjarvis/channels/whatsapp_baileys_bridge"
+"src/openjarvis/agents/claude_code_runner" = "_node_modules/claude_code_runner"
+"src/openjarvis/channels/whatsapp_baileys_bridge" = "_node_modules/whatsapp_baileys_bridge"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -146,6 +146,12 @@ info "Installing Python dependencies..."
 uv sync --extra server --quiet 2>/dev/null || uv sync --extra server
 ok "Python dependencies installed"
 
+# ── 7b. Build Rust extension ──────────────────────────────────────
+info "Building Rust extension..."
+uv run maturin develop -m rust/crates/openjarvis-python/Cargo.toml --quiet 2>/dev/null \
+  || uv run maturin develop -m rust/crates/openjarvis-python/Cargo.toml
+ok "Rust extension built"
+
 # ── 8. Install frontend dependencies ────────────────────────────────
 info "Installing frontend dependencies..."
 (cd frontend && npm install --silent 2>/dev/null || npm install)

--- a/src/openjarvis/agents/claude_code.py
+++ b/src/openjarvis/agents/claude_code.py
@@ -29,8 +29,16 @@ logger = logging.getLogger(__name__)
 _OUTPUT_START = "---OPENJARVIS_OUTPUT_START---"
 _OUTPUT_END = "---OPENJARVIS_OUTPUT_END---"
 
-# Path to the bundled runner source (relative to this module)
+# Path to the bundled runner source (relative to this module).
+# In editable installs this lives next to this file; in wheel installs
+# it is placed under _node_modules/ to avoid namespace package conflicts.
 _RUNNER_SRC = Path(__file__).resolve().parent / "claude_code_runner"
+if not _RUNNER_SRC.exists():
+    _RUNNER_SRC = (
+        Path(__file__).resolve().parents[2]
+        / "_node_modules"
+        / "claude_code_runner"
+    )
 
 
 @AgentRegistry.register("claude_code")

--- a/src/openjarvis/channels/whatsapp_baileys.py
+++ b/src/openjarvis/channels/whatsapp_baileys.py
@@ -27,7 +27,15 @@ from openjarvis.core.registry import ChannelRegistry
 logger = logging.getLogger(__name__)
 
 # Path to the bundled bridge shipped inside the package.
+# In editable installs this lives next to this file; in wheel installs
+# it is placed under _node_modules/ to avoid namespace package conflicts.
 _BRIDGE_SRC = Path(__file__).resolve().parent / "whatsapp_baileys_bridge"
+if not _BRIDGE_SRC.exists():
+    _BRIDGE_SRC = (
+        Path(__file__).resolve().parents[2]
+        / "_node_modules"
+        / "whatsapp_baileys_bridge"
+    )
 
 # Default runtime directory (npm install + auth state).
 _DEFAULT_RUNTIME_DIR = Path.home() / ".openjarvis" / "whatsapp_baileys_bridge"

--- a/src/openjarvis/core/config.py
+++ b/src/openjarvis/core/config.py
@@ -762,7 +762,7 @@ class TelemetryConfig:
 class TracesConfig:
     """Trace system settings."""
 
-    enabled: bool = False
+    enabled: bool = True
     db_path: str = str(DEFAULT_CONFIG_DIR / "traces.db")
 
 

--- a/src/openjarvis/engine/_openai_compat.py
+++ b/src/openjarvis/engine/_openai_compat.py
@@ -68,7 +68,6 @@ class _OpenAICompatibleEngine(InferenceEngine):
             "temperature": temperature,
             "max_tokens": max_tokens,
             "stream": False,
-            "chat_template_kwargs": {"enable_thinking": False},
             **kwargs,
         }
         try:

--- a/src/openjarvis/server/api_routes.py
+++ b/src/openjarvis/server/api_routes.py
@@ -179,13 +179,13 @@ traces_router = APIRouter(prefix="/v1/traces", tags=["traces"])
 async def list_traces(request: Request, limit: int = 20):
     """List recent traces."""
     try:
-        from openjarvis.traces.store import TraceStore
-        store = TraceStore()
-        traces = store.recent(limit=limit)
-        items = [
-            t.to_dict() if hasattr(t, "to_dict") else str(t)
-            for t in traces
-        ]
+        from dataclasses import asdict
+
+        store = getattr(request.app.state, "trace_store", None)
+        if store is None:
+            return {"traces": []}
+        traces = store.list_traces(limit=limit)
+        items = [asdict(t) for t in traces]
         return {"traces": items}
     except Exception as exc:
         return {"traces": [], "error": str(exc)}
@@ -194,12 +194,15 @@ async def list_traces(request: Request, limit: int = 20):
 async def get_trace(trace_id: str, request: Request):
     """Get a specific trace by ID."""
     try:
-        from openjarvis.traces.store import TraceStore
-        store = TraceStore()
+        from dataclasses import asdict
+
+        store = getattr(request.app.state, "trace_store", None)
+        if store is None:
+            raise HTTPException(status_code=404, detail="Trace not found")
         trace = store.get(trace_id)
         if trace is None:
             raise HTTPException(status_code=404, detail="Trace not found")
-        return trace.to_dict() if hasattr(trace, 'to_dict') else {"id": trace_id}
+        return asdict(trace)
     except HTTPException:
         raise
     except Exception as exc:

--- a/src/openjarvis/server/app.py
+++ b/src/openjarvis/server/app.py
@@ -110,6 +110,18 @@ def create_app(
     app.state.agent_scheduler = agent_scheduler
     app.state.session_start = time.time()
 
+    # Wire up trace store if traces are enabled
+    app.state.trace_store = None
+    try:
+        from openjarvis.core.config import load_config
+        from openjarvis.traces.store import TraceStore
+
+        cfg = config if config is not None else load_config()
+        if cfg.traces.enabled:
+            app.state.trace_store = TraceStore(db_path=cfg.traces.db_path)
+    except Exception:
+        pass  # traces are optional; don't block server startup
+
     app.include_router(router)
     app.include_router(dashboard_router)
     app.include_router(comparison_router)


### PR DESCRIPTION
## Summary

Fixes all 4 bugs reported in #100:

- **Bug 1 — Rust toolchain not documented:** Added `maturin develop` build step to README, `docs/getting-started/installation.md` (Browser App, CLI, Python SDK sections), and `scripts/quickstart.sh`. Added Python 3.14 `PYO3_USE_ABI3_FORWARD_COMPATIBILITY` note.

- **Bug 2 — Namespace package conflict:** Moved `pyproject.toml` force-include targets from `openjarvis/` to `_node_modules/` so the Node.js modules no longer create a namespace package that shadows the real Python package in editable installs. Added fallback path resolution in `claude_code.py` and `whatsapp_baileys.py` for wheel installs.

- **Bug 3 — Trace Debugger always empty:** Enabled traces by default (`TracesConfig.enabled = True`). Fixed `api_routes.py` trace endpoint to use `store.list_traces()` (not the non-existent `.recent()`), `dataclasses.asdict()` (not the non-existent `.to_dict()`), and read the store from `app.state` instead of instantiating a new `TraceStore()` without arguments. Wired `TraceStore` into `app.state` in `app.py`.

- **Bug 4 — Thinking models return empty responses:** Removed hardcoded `"chat_template_kwargs": {"enable_thinking": False}` from `_openai_compat.py` that was suppressing thinking output for Qwen3, DeepSeek-R1, and other reasoning models on OpenAI-compatible engines (vLLM, SGLang, llama.cpp). The streaming path already didn't set this flag.

## Test plan

- [x] `uv run ruff check` on all changed files — passes
- [x] 777 related tests pass (server, engine, learning)
- [x] No new test failures introduced
- [ ] Manual: `jarvis serve` → send query → Dashboard Trace Debugger shows traces
- [ ] Manual: thinking model via vLLM/SGLang returns non-empty content

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)