### PR TITLE
revert: remove _fix_tool_call_arguments from OpenAI-compatible engines

### DIFF
--- a/src/openjarvis/engine/_openai_compat.py
+++ b/src/openjarvis/engine/_openai_compat.py
@@ -32,26 +32,6 @@ class _OpenAICompatibleEngine(InferenceEngine):
 
     # -- InferenceEngine interface ------------------------------------------
 
-    @staticmethod
-    def _fix_tool_call_arguments(msg_dicts: list) -> list:
-        """Ensure tool_call arguments are dicts, not JSON strings.
-
-        OpenAI-compatible servers (vLLM, SGLang, llama.cpp, etc.) expect
-        tool_call arguments as JSON objects.  ``messages_to_dicts`` may
-        serialize them as strings, which causes 400 errors on multi-turn
-        tool-calling conversations.
-        """
-        for md in msg_dicts:
-            for tc in md.get("tool_calls", []):
-                fn = tc.get("function", {})
-                args = fn.get("arguments")
-                if isinstance(args, str):
-                    try:
-                        fn["arguments"] = json.loads(args)
-                    except (json.JSONDecodeError, TypeError):
-                        pass
-        return msg_dicts
-
     def generate(
         self,
         messages: Sequence[Message],
@@ -61,10 +41,9 @@ class _OpenAICompatibleEngine(InferenceEngine):
         max_tokens: int = 1024,
         **kwargs: Any,
     ) -> Dict[str, Any]:
-        msg_dicts = self._fix_tool_call_arguments(messages_to_dicts(messages))
         payload: Dict[str, Any] = {
             "model": model,
-            "messages": msg_dicts,
+            "messages": messages_to_dicts(messages),
             "temperature": temperature,
             "max_tokens": max_tokens,
             "stream": False,
@@ -125,10 +104,9 @@ class _OpenAICompatibleEngine(InferenceEngine):
         max_tokens: int = 1024,
         **kwargs: Any,
     ) -> AsyncIterator[str]:
-        msg_dicts = self._fix_tool_call_arguments(messages_to_dicts(messages))
         payload: Dict[str, Any] = {
             "model": model,
-            "messages": msg_dicts,
+            "messages": messages_to_dicts(messages),
             "temperature": temperature,
             "max_tokens": max_tokens,
             "stream": True,


### PR DESCRIPTION
## Summary
- Reverts PR #69's `_fix_tool_call_arguments` method that converted tool_call arguments from strings to dicts
- The OpenAI API spec requires arguments as JSON **strings**, not dicts
- vLLM with `--enable-auto-tool-choice` validates this strictly and returns 400 errors when receiving dicts
- The original 400 errors were caused by missing `--enable-auto-tool-choice --tool-call-parser hermes` flags on vLLM startup, not by the arguments format

## Root cause
PR #69 misidentified the source of 400 errors during local model benchmarks. The actual issue was that vLLM rejects the `tools` parameter entirely unless started with `--enable-auto-tool-choice`. With that flag enabled, tool-calling works correctly with the original string-format arguments.

## Test plan
- [x] All 277 engine tests pass (`uv run pytest tests/engine/ -v`)
- [x] Verified with live vLLM + `--enable-auto-tool-choice --tool-call-parser hermes`: multi-turn tool calls succeed with string arguments
- [x] Verified dicts cause 400 with vLLM's Pydantic validation when `--enable-auto-tool-choice` is enabled
- [x] Ollama's separate dict conversion (in `ollama.py`) is unaffected