### PR TITLE
feat: auto-clone repo on desktop app first launch

### DIFF
--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -477,11 +477,11 @@ async fn boot_backend(backend: SharedBackend, status: SharedStatus) {
             return;
         }
 
-        let clone_target = format!("{}/OpenJarvis", home_dir());
-        let target_path = std::path::PathBuf::from(&clone_target);
+        let target_path = std::path::PathBuf::from(home_dir()).join("OpenJarvis");
+        let clone_target = target_path.display().to_string();
 
         // If the directory exists but is not a valid project, don't overwrite
-        if target_path.exists() {
+        if target_path.exists() && !target_path.join("pyproject.toml").exists() {
             let mut s = status.lock().await;
             s.error = Some(format!(
                 "{} exists but is not a valid OpenJarvis project. \


### PR DESCRIPTION
## Summary

Closes #122.

The desktop app now auto-clones the OpenJarvis repository on first launch instead of showing an error asking the user to manually `git clone`. When `find_project_root()` returns `None`, the app:

1. Checks that `git` is installed (clear error if not)
2. Validates the clone target (`~/OpenJarvis`) isn't occupied by a non-project directory
3. Updates the UI status: "Downloading OpenJarvis (first launch)..."
4. Runs `git clone --depth 1` (shallow clone for speed)
5. Continues normal startup on success

On subsequent launches, `find_project_root()` finds `~/OpenJarvis` immediately.

### Error handling

| Scenario | Behavior |
|----------|----------|
| `git` not installed | Error with https://git-scm.com install link |
| `~/OpenJarvis` exists but invalid | Error suggesting removal or `OPENJARVIS_ROOT` |
| Clone fails (network, etc.) | Error with stderr + manual clone fallback |
| Clone succeeds | Seamless startup |

### Changes

- `desktop/src-tauri/src/lib.rs` — replaced the static error block in `boot_backend()` with auto-clone logic using `tokio::process::Command`

## Test plan

- [ ] Build desktop app: `cd desktop/src-tauri && cargo build`
- [ ] With no `~/OpenJarvis` and no `OPENJARVIS_ROOT` set, launch the app — should auto-clone and start
- [ ] With a valid `~/OpenJarvis` already present — should start normally (no re-clone)
- [ ] With git uninstalled — should show "Install git" error
- [ ] On Windows — verify path separators in error messages are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)