### PR TITLE
fix(ci): skip live and cloud tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         run: uv run maturin develop --manifest-path rust/crates/openjarvis-python/Cargo.toml
 
       - name: Run tests
-        run: uv run pytest tests/ -v --tb=short
+        run: uv run pytest tests/ -v --tb=short -m "not live and not cloud"
 
   rust:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- CI was running `live`- and `cloud`-marked tests that require local model weights or API keys, causing 4 gemma_cpp failures since #123 was merged
- Adds `-m "not live and not cloud"` to the pytest invocation in `ci.yml`

## Test plan
- [x] `uv run pytest tests/engine/test_gemma_cpp.py -v -m "not live and not cloud"` — 27 passed, 4 deselected
- [ ] CI passes on this PR (self-validating — if the workflow runs green, the fix works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)