### PR TITLE
fix: use Claude Opus 4.6 as sole baseline for leaderboard savings

### DIFF
--- a/docs/leaderboard.md
+++ b/docs/leaderboard.md
@@ -16,7 +16,7 @@ See how the OpenJarvis community saves money, energy, and compute by running AI 
     <div class="lb-stat-value" id="stat-members">—</div>
   </div>
   <div class="lb-stat-card">
-    <div class="lb-stat-label">Total Saved</div>
+    <div class="lb-stat-label">Total Saved*</div>
     <div class="lb-stat-value" id="stat-dollars">—</div>
   </div>
   <div class="lb-stat-card">
@@ -35,7 +35,7 @@ See how the OpenJarvis community saves money, energy, and compute by running AI 
       <tr>
         <th style="width:50px">#</th>
         <th>Name</th>
-        <th style="text-align:right">$ Saved</th>
+        <th style="text-align:right">$ Saved*</th>
         <th style="text-align:right">Energy (Wh)</th>
         <th style="text-align:right">FLOPs</th>
         <th style="text-align:right">Requests</th>
@@ -55,5 +55,5 @@ See how the OpenJarvis community saves money, energy, and compute by running AI 
 <div id="leaderboard-pagination" class="lb-pagination"></div>
 
 <p style="font-size:12px;opacity:0.6;margin-top:12px">
-*Dollar savings estimates assume local open-source models (e.g. Qwen, Nemotron, Kimi) produce roughly the same number of tokens per request, on average, as closed-source cloud models.
+*Dollar savings estimated vs. Claude Opus 4.6 API pricing ($5/1M input, $25/1M output tokens). Assumes local open-source models produce roughly the same number of tokens per request as cloud models.
 </p>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -67,10 +67,10 @@ export default function App() {
         .then((data) => {
           setSavings(data);
           if (optInEnabled && optInDisplayName && data) {
-            const dollarSavings = data.per_provider.reduce(
-              (sum, p) => sum + p.total_cost,
-              0,
+            const claudeEntry = data.per_provider.find(
+              (p) => p.provider === 'claude-opus-4.6',
             );
+            const dollarSavings = claudeEntry ? claudeEntry.total_cost : 0;
             const energySaved = data.per_provider.reduce(
               (sum, p) => sum + (p.energy_wh || 0),
               0,


### PR DESCRIPTION
## Summary
- **Dollar savings were triple-counted** — the frontend summed hypothetical costs across all 3 cloud providers (GPT-5.3 + Claude Opus 4.6 + Gemini 3.1 Pro), inflating the reported savings by ~3x
- Now uses only **Claude Opus 4.6** ($5/1M input, $25/1M output) as the single baseline
- Added asterisk + footnote on the leaderboard page noting the baseline model and pricing

## Changes
- `frontend/src/App.tsx`: Find the `claude-opus-4.6` entry from `per_provider` instead of reducing across all providers
- `docs/leaderboard.md`: Asterisk on "Total Saved" stat card and "$ Saved" column header; updated footnote with Claude Opus 4.6 pricing details

## Test plan
- [x] `uv run pytest tests/ -v` — 4790 passed (4 pre-existing gemma.cpp live failures unrelated)
- [x] `uv run ruff check src/ tests/` — all checks passed
- [ ] Verify leaderboard page renders asterisk and footnote correctly
- [ ] Confirm new savings submissions use single-provider value

> **Note:** Existing Supabase entries still have old triple-counted values. A data migration may be needed to recompute historical `dollar_savings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)