### PR TITLE
fix: add SQL migration to recompute historical leaderboard savings

### DIFF
--- a/scripts/migrate_savings_single_provider.sql
+++ b/scripts/migrate_savings_single_provider.sql
@@ -1,0 +1,37 @@
+-- Migration: Recompute dollar_savings to use only Claude Opus 4.6 pricing
+-- -----------------------------------------------------------------------
+-- Previously the frontend summed hypothetical costs across all 3 cloud
+-- providers (GPT-5.3 + Claude Opus 4.6 + Gemini 3.1 Pro).  This
+-- migration recalculates dollar_savings using Claude Opus 4.6 only.
+--
+-- Derivation
+-- ----------
+-- Let P = prompt_tokens, C = completion_tokens, T = total_tokens = P + C.
+--
+--   old = (P/1M)*(2+5+2) + (C/1M)*(10+25+12) = (P/1M)*9 + (C/1M)*47
+--   new = (P/1M)*5 + (C/1M)*25
+--
+-- Solving the system {T = P + C, old = 9P/1M + 47C/1M} for P and C and
+-- substituting into the "new" formula gives:
+--
+--   new = T / 3_800_000 + 10 * old / 19
+--
+-- Run this in the Supabase SQL Editor (Dashboard > SQL Editor).
+-- -----------------------------------------------------------------------
+
+BEGIN;
+
+-- Preview the changes first (uncomment the SELECT, comment the UPDATE)
+-- SELECT
+--   display_name,
+--   dollar_savings AS old_savings,
+--   total_tokens / 3800000.0 + 10.0 * dollar_savings / 19.0 AS new_savings
+-- FROM savings_entries
+-- WHERE dollar_savings > 0
+-- ORDER BY dollar_savings DESC;
+
+UPDATE savings_entries
+SET dollar_savings = total_tokens / 3800000.0 + 10.0 * dollar_savings / 19.0
+WHERE dollar_savings > 0;
+
+COMMIT;


### PR DESCRIPTION
## Summary
- Adds a SQL migration script (`scripts/migrate_savings_single_provider.sql`) to recompute existing `dollar_savings` values in Supabase
- Companion to #143 which fixed the frontend to use Claude Opus 4.6 as the sole baseline — this fixes the historical data
- Uses the exact closed-form formula: `new = T / 3,800,000 + 10 * old / 19` (derived algebraically from the original triple-provider formula, no approximation)

## How to run
1. Open Supabase Dashboard > SQL Editor
2. Paste the contents of `scripts/migrate_savings_single_provider.sql`
3. Optionally uncomment the `SELECT` preview query first to verify expected values
4. Run the `UPDATE` within the transaction

## Test plan
- [x] `uv run pytest tests/ -v` — 4790 passed
- [x] `uv run ruff check src/ tests/` — all checks passed
- [x] Formula verified: e.g. Sonny ($1171.39, 35.7M tokens) → ~$625.92

🤖 Generated with [Claude Code](https://claude.com/claude-code)