### PR TITLE
feat: add local voice assistant pipeline with wake word, STT, and TTS

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -46,6 +46,9 @@
         "typescript": "~5.7.0",
         "vite": "^6.0.0",
         "vite-plugin-pwa": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@apideck/better-ajv-errors": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,23 @@ sandbox-docker = ["docker>=7.0"]
 dashboard = ["textual>=0.80"]
 speech = ["faster-whisper>=1.0"]
 speech-deepgram = ["deepgram-sdk>=3.0"]
+voice = [
+    "sounddevice>=0.4",
+    "numpy>=1.24",
+    "faster-whisper>=1.0",
+]
+voice-wake = [
+    "sounddevice>=0.4",
+    "numpy>=1.24",
+    "faster-whisper>=1.0",
+    "openwakeword>=0.6",
+]
+voice-piper = [
+    "sounddevice>=0.4",
+    "numpy>=1.24",
+    "faster-whisper>=1.0",
+    "piper-tts>=1.2",
+]
 eval-wandb = ["wandb>=0.17"]
 eval-sheets = ["gspread>=6.0", "google-auth>=2.0"]
 docs = [

--- a/src/openjarvis/cli/__init__.py
+++ b/src/openjarvis/cli/__init__.py
@@ -36,6 +36,7 @@ from openjarvis.cli.skill_cmd import skill
 from openjarvis.cli.telemetry_cmd import telemetry
 from openjarvis.cli.tool_cmd import tool
 from openjarvis.cli.vault_cmd import vault
+from openjarvis.cli.voice_cmd import voice
 from openjarvis.cli.workflow_cmd import workflow
 
 
@@ -94,6 +95,7 @@ cli.add_command(registry, "registry")
 cli.add_command(config, "config")
 cli.add_command(scan, "scan")
 cli.add_command(connect, "connect")
+cli.add_command(voice, "voice")
 cli.add_command(deep_research_setup, "deep-research-setup")
 cli.add_command(deep_research_setup, "research")
 

--- a/src/openjarvis/cli/voice_cmd.py
+++ b/src/openjarvis/cli/voice_cmd.py
@@ -1,0 +1,136 @@
+"""``jarvis voice`` — always-on desktop voice assistant mode."""
+
+from __future__ import annotations
+
+import sys
+from typing import Optional
+
+import click
+from rich.console import Console
+
+from openjarvis.cli._tool_names import resolve_tool_names
+from openjarvis.core.config import load_config
+
+
+@click.command()
+@click.option("-e", "--engine", "engine_key", default=None, help="Engine backend (ollama, cloud, …).")
+@click.option("-m", "--model", "model_name", default=None, help="Model name.")
+@click.option("--tts", "tts_backend", default=None, type=click.Choice(["piper", "say", "silent"]), help="TTS backend.")
+@click.option("--wake-word", "wake_word", default=None, help="Custom wake word / model path.")
+@click.option("--energy", "energy_threshold", default=300, show_default=True, help="VAD energy threshold (0–32767).")
+@click.option("--no-wake", is_flag=True, default=False, help="Skip wake word — always listen (push-to-talk feel).")
+def voice(
+    engine_key: Optional[str],
+    model_name: Optional[str],
+    tts_backend: Optional[str],
+    wake_word: Optional[str],
+    energy_threshold: int,
+    no_wake: bool,
+) -> None:
+    """Start always-on voice assistant mode.
+
+    \b
+    Requires:
+      uv pip install sounddevice numpy faster-whisper
+      uv pip install openwakeword          # wake word detection
+      uv pip install piper-tts             # optional: best TTS quality
+
+    \b
+    Wake word (default): "Hey Jarvis"
+    Interrupt:           Say the wake word again while Jarvis is speaking
+    Quit:                Ctrl-C
+    """
+    console = Console(stderr=True)
+
+    # ── check audio deps ──────────────────────────────────────────────────────
+    missing = []
+    try:
+        import sounddevice  # noqa: F401
+    except ImportError:
+        missing.append("sounddevice")
+    try:
+        import numpy  # noqa: F401
+    except ImportError:
+        missing.append("numpy")
+    try:
+        import faster_whisper  # noqa: F401
+    except ImportError:
+        missing.append("faster-whisper")
+
+    if missing:
+        console.print(
+            f"[red]Missing dependencies:[/red] {', '.join(missing)}\n"
+            f"Install with:  [bold]uv pip install {' '.join(missing)}[/bold]"
+        )
+        sys.exit(1)
+
+    # ── engine setup ─────────────────────────────────────────────────────────
+    config = load_config()
+
+    from openjarvis.engine import get_engine
+    from openjarvis.intelligence import register_builtin_models
+
+    register_builtin_models()
+    resolved = get_engine(config, engine_key)
+    if resolved is None:
+        console.print("[red]No inference engine available.[/red]")
+        sys.exit(1)
+
+    engine_name, engine = resolved
+    model = model_name or config.intelligence.default_model
+    if not model:
+        from openjarvis.engine import discover_engines, discover_models
+        all_engines = discover_engines(config)
+        all_models = discover_models(all_engines)
+        engine_models = all_models.get(engine_name, [])
+        if engine_models:
+            model = engine_models[0]
+        else:
+            console.print("[red]No model available.[/red]")
+            sys.exit(1)
+
+    console.print(
+        f"[dim]engine:[/dim] [cyan]{engine_name}[/cyan]  "
+        f"[dim]model:[/dim] [cyan]{model}[/cyan]"
+    )
+
+    # ── TTS ───────────────────────────────────────────────────────────────────
+    from openjarvis.voice.tts import build_tts
+    tts = build_tts(prefer=tts_backend)
+
+    # ── wake word ─────────────────────────────────────────────────────────────
+    from openjarvis.voice.wake_word import WakeWordListener, _build_default_detector
+
+    if no_wake:
+        # Swap in an energy detector so it fires immediately when you speak
+        from openjarvis.voice.wake_word import EnergyWakeWordDetector
+        detector = EnergyWakeWordDetector(energy_threshold=energy_threshold)
+        wake_listener = WakeWordListener(detector=detector)
+    elif wake_word:
+        from openjarvis.voice.wake_word import OpenWakeWordDetector
+        try:
+            detector = OpenWakeWordDetector(wake_words=[wake_word])
+            wake_listener = WakeWordListener(detector=detector)
+        except ImportError:
+            console.print("[yellow]openwakeword not installed — using energy fallback[/yellow]")
+            wake_listener = WakeWordListener()
+    else:
+        wake_listener = WakeWordListener()
+
+    # ── build & run loop ──────────────────────────────────────────────────────
+    from openjarvis.voice.loop import VoiceLoop
+
+    loop = VoiceLoop(
+        engine=engine,
+        model=model,
+        tts=tts,
+        energy_threshold=energy_threshold,
+    )
+
+    # Inject the configured wake listener
+    loop._wake_listener = wake_listener
+
+    loop.run()
+
+
+__all__ = ["voice"]

--- a/src/openjarvis/voice/__init__.py
+++ b/src/openjarvis/voice/__init__.py
@@ -1,0 +1,16 @@
+"""Voice assistant subsystem for OpenJarvis.
+
+Components
+----------
+listener    — microphone input + VAD
+wake_word   — wake word detection (openwakeword / energy fallback)
+tts         — text-to-speech (Piper / macOS say / silent)
+speech_filter — cleans LLM responses for spoken delivery
+loop        — main always-on voice loop
+"""
+
+from openjarvis.voice.loop import VoiceLoop
+from openjarvis.voice.tts import build_tts
+from openjarvis.voice.speech_filter import prepare_for_speech
+
+__all__ = ["VoiceLoop", "build_tts", "prepare_for_speech"]

--- a/src/openjarvis/voice/_stubs.py
+++ b/src/openjarvis/voice/_stubs.py
@@ -1,0 +1,62 @@
+"""Abstract base classes for the voice subsystem."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from typing import Callable, Iterator, Optional
+
+
+class VoiceState(Enum):
+    IDLE = auto()
+    WAKE_DETECTED = auto()
+    LISTENING = auto()
+    THINKING = auto()
+    SPEAKING = auto()
+
+
+@dataclass
+class AudioChunk:
+    """Raw audio data from the microphone."""
+    data: bytes          # raw PCM bytes
+    sample_rate: int     # e.g. 16000
+    channels: int = 1
+    sample_width: int = 2  # bytes per sample (int16 = 2)
+
+
+@dataclass
+class WakeWordResult:
+    word: str
+    confidence: float = 1.0
+
+
+class WakeWordDetector(ABC):
+    """Detects a wake word in a stream of audio chunks."""
+
+    @abstractmethod
+    def process_chunk(self, chunk: AudioChunk) -> Optional[WakeWordResult]:
+        """Return a result if the wake word was detected, else None."""
+
+    @abstractmethod
+    def reset(self) -> None:
+        """Reset internal state after a wake event."""
+
+
+class TTSBackend(ABC):
+    """Text-to-speech backend."""
+
+    @abstractmethod
+    def speak(self, text: str, *, on_word: Optional[Callable[[str], None]] = None) -> None:
+        """Synthesize and play text. Blocks until complete or interrupted."""
+
+    @abstractmethod
+    def stop(self) -> None:
+        """Interrupt any ongoing playback immediately."""
+
+    @abstractmethod
+    def is_speaking(self) -> bool:
+        """Return True if audio is currently playing."""
+
+
+__all__ = ["AudioChunk", "TTSBackend", "VoiceState", "WakeWordDetector", "WakeWordResult"]

--- a/src/openjarvis/voice/listener.py
+++ b/src/openjarvis/voice/listener.py
@@ -1,0 +1,159 @@
+"""Microphone listener with energy-based Voice Activity Detection (VAD).
+
+Records audio until silence is detected after speech begins.
+Requires: sounddevice, numpy
+"""
+
+from __future__ import annotations
+
+import logging
+import queue
+import threading
+import time
+from typing import Optional
+
+import numpy as np
+
+from openjarvis.voice._stubs import AudioChunk
+
+logger = logging.getLogger(__name__)
+
+try:
+    import sounddevice as sd
+    _SD_AVAILABLE = True
+except ImportError:
+    _SD_AVAILABLE = False
+    sd = None  # type: ignore[assignment]
+
+
+# ── constants ──────────────────────────────────────────────────────────────────
+SAMPLE_RATE = 16_000   # Hz  (Whisper expects 16 kHz)
+CHANNELS = 1
+DTYPE = "int16"
+CHUNK_FRAMES = 512     # ~32 ms per callback at 16 kHz
+ENERGY_THRESHOLD = 300  # RMS threshold; tune per environment
+SILENCE_TIMEOUT = 1.2  # seconds of silence to end utterance
+MAX_RECORD_SECONDS = 30
+
+
+class MicrophoneListener:
+    """Streams mic audio and records a single utterance via VAD.
+
+    Usage
+    -----
+    listener = MicrophoneListener()
+    audio_bytes = listener.record_utterance()   # blocks; returns WAV-compatible PCM
+    """
+
+    def __init__(
+        self,
+        sample_rate: int = SAMPLE_RATE,
+        energy_threshold: int = ENERGY_THRESHOLD,
+        silence_timeout: float = SILENCE_TIMEOUT,
+        max_seconds: float = MAX_RECORD_SECONDS,
+    ) -> None:
+        if not _SD_AVAILABLE:
+            raise ImportError(
+                "sounddevice is not installed. Run: uv pip install sounddevice numpy"
+            )
+        self._sample_rate = sample_rate
+        self._energy_threshold = energy_threshold
+        self._silence_timeout = silence_timeout
+        self._max_seconds = max_seconds
+        self._cancel_event = threading.Event()
+
+    # ── public ─────────────────────────────────────────────────────────────────
+
+    def cancel(self) -> None:
+        """Signal the current recording to abort."""
+        self._cancel_event.set()
+
+    def record_utterance(self) -> Optional[bytes]:
+        """Record until silence follows speech, or max_seconds hit.
+
+        Returns raw 16-bit PCM bytes at SAMPLE_RATE, or None if cancelled.
+        """
+        self._cancel_event.clear()
+        audio_q: queue.Queue[np.ndarray] = queue.Queue()
+
+        def _callback(indata: np.ndarray, frames: int, time_info, status) -> None:  # noqa: ANN001
+            if status:
+                logger.debug("sounddevice status: %s", status)
+            audio_q.put(indata.copy())
+
+        frames_collected: list[np.ndarray] = []
+        speech_started = False
+        last_speech_time = 0.0
+        start_time = time.monotonic()
+
+        with sd.InputStream(
+            samplerate=self._sample_rate,
+            channels=CHANNELS,
+            dtype=DTYPE,
+            blocksize=CHUNK_FRAMES,
+            callback=_callback,
+        ):
+            while not self._cancel_event.is_set():
+                now = time.monotonic()
+                if now - start_time > self._max_seconds:
+                    logger.debug("max record time reached")
+                    break
+
+                try:
+                    chunk = audio_q.get(timeout=0.05)
+                except queue.Empty:
+                    continue
+
+                rms = int(np.sqrt(np.mean(chunk.astype(np.float32) ** 2)))
+
+                if rms > self._energy_threshold:
+                    if not speech_started:
+                        logger.debug("speech started (rms=%d)", rms)
+                    speech_started = True
+                    last_speech_time = time.monotonic()
+
+                if speech_started:
+                    frames_collected.append(chunk)
+                    # end of utterance: silence after speech
+                    if time.monotonic() - last_speech_time > self._silence_timeout:
+                        logger.debug("silence detected — utterance complete")
+                        break
+
+        if self._cancel_event.is_set() or not frames_collected:
+            return None
+
+        audio_array = np.concatenate(frames_collected, axis=0)
+        return audio_array.astype(np.int16).tobytes()
+
+    def stream_chunks(self, chunk_callback) -> None:  # type: ignore[type-arg]
+        """Continuously feed raw chunks to ``chunk_callback(AudioChunk)``
+        until ``cancel()`` is called. Used by wake word detector."""
+        self._cancel_event.clear()
+        audio_q: queue.Queue[np.ndarray] = queue.Queue()
+
+        def _callback(indata: np.ndarray, frames: int, time_info, status) -> None:  # noqa: ANN001
+            if status:
+                logger.debug("sounddevice status: %s", status)
+            audio_q.put(indata.copy())
+
+        with sd.InputStream(
+            samplerate=self._sample_rate,
+            channels=CHANNELS,
+            dtype=DTYPE,
+            blocksize=CHUNK_FRAMES,
+            callback=_callback,
+        ):
+            while not self._cancel_event.is_set():
+                try:
+                    chunk = audio_q.get(timeout=0.05)
+                except queue.Empty:
+                    continue
+                chunk_callback(
+                    AudioChunk(
+                        data=chunk.astype(np.int16).tobytes(),
+                        sample_rate=self._sample_rate,
+                    )
+                )
+
+
+__all__ = ["MicrophoneListener", "SAMPLE_RATE"]

--- a/src/openjarvis/voice/loop.py
+++ b/src/openjarvis/voice/loop.py
@@ -1,0 +1,303 @@
+"""Main voice assistant loop.
+
+State machine
+─────────────
+  IDLE
+    └─(wake word)──► LISTENING
+                        │
+                        ├─(silence after speech)──► THINKING
+                        │                               │
+                        │                        (response ready)
+                        │                               ▼
+                        │                           SPEAKING
+                        │                               │
+                        ├─(wake word during SPEAKING)───┘  ← interrupts TTS,
+                        │                                     jumps back to LISTENING
+                        └─(timeout / no speech)──► IDLE
+
+Usage
+─────
+    from openjarvis.voice.loop import VoiceLoop
+    loop = VoiceLoop(engine=engine, model="qwen3:0.6b")
+    loop.run()   # blocks; Ctrl-C to quit
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import threading
+import time
+from typing import Optional
+
+from rich.console import Console
+from rich.text import Text
+
+from openjarvis.core.types import Message, Role
+from openjarvis.voice._stubs import VoiceState
+from openjarvis.voice.listener import MicrophoneListener
+from openjarvis.voice.speech_filter import is_detail_request, prepare_for_speech
+from openjarvis.voice.tts import TTSBackend, build_tts
+from openjarvis.voice.wake_word import WakeWordListener
+
+logger = logging.getLogger(__name__)
+
+
+# ── display helpers ────────────────────────────────────────────────────────────
+
+_STATE_LABEL = {
+    VoiceState.IDLE: ("[dim]● idle[/dim]", "dim"),
+    VoiceState.WAKE_DETECTED: ("[bold cyan]◉ wake![/bold cyan]", "cyan"),
+    VoiceState.LISTENING: ("[bold green]◎ listening[/bold green]", "green"),
+    VoiceState.THINKING: ("[bold yellow]◌ thinking[/bold yellow]", "yellow"),
+    VoiceState.SPEAKING: ("[bold blue]◉ speaking[/bold blue]", "blue"),
+}
+
+_BANNER = """
+  [bold white]J A R V I S[/bold white]  [dim]— always on[/dim]
+
+  [dim]wake word:[/dim]  [cyan]"Hey Jarvis"[/cyan]
+  [dim]interrupt:[/dim]  say the wake word again while it's speaking
+  [dim]quit:[/dim]       Ctrl-C
+"""
+
+
+class VoiceLoop:
+    """Orchestrates wake word → STT → LLM → TTS pipeline."""
+
+    def __init__(
+        self,
+        engine,
+        model: str,
+        *,
+        tts: Optional[TTSBackend] = None,
+        system_prompt: Optional[str] = None,
+        history_limit: int = 20,
+        listen_timeout: float = 8.0,
+        energy_threshold: int = 300,
+    ) -> None:
+        self._engine = engine
+        self._model = model
+        self._tts = tts or build_tts()
+        self._system_prompt = system_prompt or _default_system_prompt()
+        self._history_limit = history_limit
+        self._listen_timeout = listen_timeout
+        self._energy_threshold = energy_threshold
+
+        self._console = Console()
+        self._state = VoiceState.IDLE
+        self._history: list[Message] = [
+            Message(role=Role.SYSTEM, content=self._system_prompt)
+        ]
+
+        # STT backend (faster-whisper, lazy loaded)
+        self._stt = None
+
+        # Components (created on run())
+        self._wake_listener: Optional[WakeWordListener] = None
+        self._mic: Optional[MicrophoneListener] = None
+
+        # Interrupt flag: set when a new wake fires mid-speech
+        self._interrupt = threading.Event()
+
+    # ── public ─────────────────────────────────────────────────────────────────
+
+    def run(self) -> None:
+        """Block and run the voice loop until Ctrl-C."""
+        self._console.print(_BANNER)
+        self._setup()
+
+        try:
+            while True:
+                self._tick()
+        except KeyboardInterrupt:
+            self._console.print("\n[dim]Shutting down. Later.[/dim]")
+        finally:
+            self._teardown()
+
+    # ── setup / teardown ───────────────────────────────────────────────────────
+
+    def _setup(self) -> None:
+        self._mic = MicrophoneListener(energy_threshold=self._energy_threshold)
+        self._wake_listener = WakeWordListener()
+        self._wake_listener.start()
+        self._set_state(VoiceState.IDLE)
+        self._console.print(self._status_line())
+
+    def _teardown(self) -> None:
+        if self._wake_listener:
+            self._wake_listener.stop()
+        if self._tts:
+            self._tts.stop()
+
+    # ── main tick ──────────────────────────────────────────────────────────────
+
+    def _tick(self) -> None:
+        """Single iteration of the state machine."""
+
+        # ── IDLE: wait for wake word ──────────────────────────────────────────
+        if self._state == VoiceState.IDLE:
+            result = self._wake_listener.wait_for_wake(timeout=1.0)
+            if result:
+                self._wake_listener.drain()
+                self._set_state(VoiceState.LISTENING)
+                self._handle_listening()
+            return
+
+        # States other than IDLE are driven by _handle_* methods; if we
+        # somehow land here in a non-IDLE state reset to IDLE.
+        self._set_state(VoiceState.IDLE)
+
+    # ── state handlers ─────────────────────────────────────────────────────────
+
+    def _handle_listening(self) -> None:
+        self._console.print(self._status_line())
+        self._interrupt.clear()
+
+        # Start a background thread watching for another wake word (interruption)
+        interrupt_thread = threading.Thread(
+            target=self._watch_for_interrupt, daemon=True
+        )
+        interrupt_thread.start()
+
+        audio_bytes = self._mic.record_utterance()
+
+        if self._interrupt.is_set() or audio_bytes is None:
+            self._set_state(VoiceState.IDLE)
+            self._console.print(self._status_line())
+            return
+
+        # ── THINKING ─────────────────────────────────────────────────────────
+        self._set_state(VoiceState.THINKING)
+        self._console.print(self._status_line())
+
+        transcription = self._transcribe(audio_bytes)
+        if not transcription:
+            self._console.print("[dim]  (nothing heard)[/dim]")
+            self._set_state(VoiceState.IDLE)
+            self._console.print(self._status_line())
+            return
+
+        self._console.print(f"\n  [bold]You:[/bold] {transcription}")
+
+        response = self._generate(transcription)
+        if not response:
+            self._set_state(VoiceState.IDLE)
+            self._console.print(self._status_line())
+            return
+
+        full_response = is_detail_request(transcription)
+        spoken = prepare_for_speech(response, full_response=full_response)
+
+        self._console.print(f"  [bold cyan]Jarvis:[/bold cyan] {spoken}\n")
+
+        # ── SPEAKING ─────────────────────────────────────────────────────────
+        self._set_state(VoiceState.SPEAKING)
+        self._console.print(self._status_line())
+
+        tts_thread = threading.Thread(
+            target=self._speak_async, args=(spoken,), daemon=True
+        )
+        tts_thread.start()
+
+        # While speaking, watch for interrupt
+        while tts_thread.is_alive():
+            if self._interrupt.is_set():
+                self._tts.stop()
+                break
+            time.sleep(0.05)
+
+        tts_thread.join(timeout=1.0)
+
+        if self._interrupt.is_set():
+            # Jump straight back to listening for the interrupted utterance
+            self._interrupt.clear()
+            self._set_state(VoiceState.LISTENING)
+            self._wake_listener.drain()
+            self._handle_listening()
+        else:
+            self._set_state(VoiceState.IDLE)
+            self._console.print(self._status_line())
+
+    def _watch_for_interrupt(self) -> None:
+        """Background: fires _interrupt if wake word detected."""
+        result = self._wake_listener.wait_for_wake(timeout=self._listen_timeout + 30)
+        if result:
+            self._interrupt.set()
+            self._mic.cancel()
+
+    def _speak_async(self, text: str) -> None:
+        try:
+            self._tts.speak(text)
+        except Exception as exc:
+            logger.warning("TTS error: %s", exc)
+
+    # ── STT ────────────────────────────────────────────────────────────────────
+
+    def _transcribe(self, audio_bytes: bytes) -> Optional[str]:
+        try:
+            backend = self._get_stt()
+            result = backend.transcribe(audio_bytes, format="wav")
+            return result.text.strip() or None
+        except Exception as exc:
+            logger.warning("STT error: %s", exc)
+            return None
+
+    def _get_stt(self):
+        if self._stt is None:
+            from openjarvis.speech.faster_whisper import FasterWhisperBackend
+            self._stt = FasterWhisperBackend(model_size="base", device="auto", compute_type="int8")
+        return self._stt
+
+    # ── LLM ────────────────────────────────────────────────────────────────────
+
+    def _generate(self, user_text: str) -> Optional[str]:
+        self._history.append(Message(role=Role.USER, content=user_text))
+        # Keep history bounded
+        if len(self._history) > self._history_limit + 1:
+            self._history = [self._history[0]] + self._history[-(self._history_limit):]
+        try:
+            result = self._engine.generate(self._history, model=self._model)
+            content = (
+                result.get("content", "") if isinstance(result, dict) else str(result)
+            )
+            self._history.append(Message(role=Role.ASSISTANT, content=content))
+            return content or None
+        except Exception as exc:
+            logger.warning("LLM error: %s", exc)
+            return None
+
+    # ── helpers ────────────────────────────────────────────────────────────────
+
+    def _set_state(self, state: VoiceState) -> None:
+        self._state = state
+
+    def _status_line(self) -> str:
+        label, _ = _STATE_LABEL.get(self._state, ("[dim]unknown[/dim]", "dim"))
+        return f"  {label}"
+
+
+# ── default personality ────────────────────────────────────────────────────────
+
+def _default_system_prompt() -> str:
+    """Load soul.md if present, else return a built-in personality."""
+    import pathlib
+
+    base = pathlib.Path("~/.openjarvis").expanduser()
+    for name in ("SOUL.md", "soul.md"):
+        soul = base / name
+        if soul.exists():
+            return soul.read_text()
+
+    return (
+        "You are Jarvis.\n\n"
+        "Speak like a sharp, casual assistant with dry humor. "
+        "Keep responses short and natural — like talking to someone you know. "
+        "Avoid formal phrases like 'Here are…' or 'According to…'. "
+        "Give the answer directly, optionally add a quick remark, then stop. "
+        "Only go into detail if the user asks. "
+        "Never start with 'Certainly', 'Of course', or 'Great question'."
+    )
+
+
+__all__ = ["VoiceLoop"]

--- a/src/openjarvis/voice/speech_filter.py
+++ b/src/openjarvis/voice/speech_filter.py
@@ -1,0 +1,107 @@
+"""Speech response filter — strips robotic filler, trims for TTS delivery.
+
+Before any response goes to TTS, run it through ``prepare_for_speech()``.
+This removes walls of text, filler openers, and markdown artifacts that sound
+awful when read aloud.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+# Phrases that sound stiff/robotic when spoken
+_BANNED_OPENERS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"^here are[\s,]+", re.I), ""),
+    (re.compile(r"^according to[\s,]+", re.I), ""),
+    (re.compile(r"^in summary[\s,]*", re.I), ""),
+    (re.compile(r"^in conclusion[\s,]*", re.I), ""),
+    (re.compile(r"^certainly[!,.]?\s*", re.I), ""),
+    (re.compile(r"^of course[!,.]?\s*", re.I), ""),
+    (re.compile(r"^absolutely[!,.]?\s*", re.I), ""),
+    (re.compile(r"^great question[!,.]?\s*", re.I), ""),
+    (re.compile(r"^sure[!,.]?\s*", re.I), ""),
+    (re.compile(r"^i'?d be happy to[\s,]+", re.I), ""),
+    (re.compile(r"^as an ai[,.]?\s*", re.I), ""),
+    (re.compile(r"^as your (ai |personal )?assistant[,.]?\s*", re.I), ""),
+    (re.compile(r"^let me (know|explain|break|walk)[\s\w]*[.,]\s*", re.I), ""),
+]
+
+# Markdown that doesn't play well as speech
+_MARKDOWN_CLEAN: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"\*\*(.+?)\*\*"), r"\1"),          # bold
+    (re.compile(r"\*(.+?)\*"), r"\1"),               # italic
+    (re.compile(r"`{1,3}(.+?)`{1,3}", re.S), r"\1"),  # code
+    (re.compile(r"#{1,6}\s+"), ""),                   # headings
+    (re.compile(r"^[\-*]\s+", re.M), ""),             # bullet points
+    (re.compile(r"\[([^\]]+)\]\([^\)]+\)"), r"\1"),   # links → text only
+    (re.compile(r"<[^>]+>"), ""),                      # HTML tags
+]
+
+# Max sentences to speak (unless user asked for more detail)
+_DEFAULT_SENTENCE_LIMIT = 3
+
+
+def _strip_markdown(text: str) -> str:
+    for pattern, repl in _MARKDOWN_CLEAN:
+        text = pattern.sub(repl, text)
+    return text
+
+
+def _strip_openers(text: str) -> str:
+    for pattern, repl in _BANNED_OPENERS:
+        text = pattern.sub(repl, text, count=1)
+    return text.lstrip()
+
+
+def _split_sentences(text: str) -> list[str]:
+    # Naive sentence splitter; good enough for TTS trimming
+    raw = re.split(r"(?<=[.!?])\s+", text.strip())
+    return [s.strip() for s in raw if s.strip()]
+
+
+def prepare_for_speech(
+    text: str,
+    *,
+    max_sentences: int = _DEFAULT_SENTENCE_LIMIT,
+    full_response: bool = False,
+) -> str:
+    """Clean and trim a model response for spoken delivery.
+
+    Parameters
+    ----------
+    text:
+        Raw LLM response.
+    max_sentences:
+        Number of sentences to keep (ignored when ``full_response`` is True).
+    full_response:
+        Set True when the user explicitly asked for detail — skip trimming.
+    """
+    if not text:
+        return text
+
+    text = _strip_markdown(text)
+    text = _strip_openers(text)
+
+    # Collapse extra whitespace / blank lines
+    text = re.sub(r"\n{2,}", " ", text)
+    text = re.sub(r"\s{2,}", " ", text).strip()
+
+    if not full_response:
+        sentences = _split_sentences(text)
+        text = " ".join(sentences[:max_sentences])
+
+    return text.strip()
+
+
+def is_detail_request(text: str) -> bool:
+    """Heuristic: did the user ask for more detail / full answer?"""
+    patterns = [
+        r"\bmore detail\b", r"\bfull (answer|response|explanation)\b",
+        r"\btell me more\b", r"\bexpand\b", r"\belaborate\b",
+        r"\bexplain\b", r"\bwalk me through\b", r"\bbreak.?down\b",
+    ]
+    return any(re.search(p, text, re.I) for p in patterns)
+
+
+__all__ = ["is_detail_request", "prepare_for_speech"]

--- a/src/openjarvis/voice/tts.py
+++ b/src/openjarvis/voice/tts.py
@@ -1,0 +1,219 @@
+"""Text-to-speech backends with interruption support.
+
+Priority chain:
+  1. PiperTTS  — local ONNX, fast, high quality (requires piper-tts + a voice model)
+  2. MacOSSayTTS — wraps the built-in `say` command (macOS only, no install needed)
+  3. SilentTTS  — print-only fallback (always works)
+
+Usage
+-----
+from openjarvis.voice.tts import build_tts
+tts = build_tts()        # auto-selects best available
+tts.speak("Hey there")   # plays audio
+tts.stop()               # interrupts mid-sentence
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import subprocess
+import sys
+import threading
+from typing import Callable, Optional
+
+from openjarvis.voice._stubs import TTSBackend
+
+logger = logging.getLogger(__name__)
+
+
+# ── Piper TTS ─────────────────────────────────────────────────────────────────
+
+class PiperTTS(TTSBackend):
+    """Local neural TTS via piper-tts ONNX.
+
+    Requires:
+        uv pip install piper-tts
+    And a voice model (.onnx + .onnx.json), e.g.:
+        python -m piper --download-dir ~/.local/share/piper-tts en_US-lessac-medium
+
+    If model_path is None we try ~/.local/share/piper-tts/en_US-lessac-medium.onnx.
+    """
+
+    DEFAULT_MODEL_DIRS = [
+        "~/.local/share/piper-tts",
+        "~/.piper",
+        "/usr/share/piper-tts",
+    ]
+    DEFAULT_VOICE = "en_US-lessac-medium"
+
+    def __init__(self, model_path: Optional[str] = None) -> None:
+        self._model_path = model_path or self._find_model()
+        self._voice = None
+        self._stop_event = threading.Event()
+        self._lock = threading.Lock()
+        self._playing = False
+        self._playback_thread: Optional[threading.Thread] = None
+
+    def _find_model(self) -> Optional[str]:
+        import pathlib
+        for d in self.DEFAULT_MODEL_DIRS:
+            base = pathlib.Path(d).expanduser()
+            for candidate in base.glob(f"{self.DEFAULT_VOICE}.onnx"):
+                return str(candidate)
+        return None
+
+    def _load(self) -> bool:
+        if self._voice is not None:
+            return True
+        if not self._model_path:
+            logger.warning(
+                "No piper voice model found. Download with:\n"
+                "  python -m piper --download-dir ~/.local/share/piper-tts en_US-lessac-medium"
+            )
+            return False
+        try:
+            from piper import PiperVoice
+            self._voice = PiperVoice.load(self._model_path)
+            logger.info("Piper TTS loaded: %s", self._model_path)
+            return True
+        except ImportError:
+            logger.warning("piper-tts not installed. Run: uv pip install piper-tts")
+            return False
+        except Exception as exc:
+            logger.warning("Piper TTS load failed: %s", exc)
+            return False
+
+    def speak(self, text: str, *, on_word: Optional[Callable[[str], None]] = None) -> None:
+        if not self._load() or not self._voice:
+            return
+        try:
+            import sounddevice as sd
+        except ImportError:
+            logger.warning("sounddevice not installed — cannot play audio")
+            return
+
+        self._stop_event.clear()
+
+        try:
+            import wave
+            buf = io.BytesIO()
+            with wave.open(buf, "wb") as wf:
+                self._voice.synthesize(text, wf)
+            buf.seek(0)
+            with wave.open(buf, "rb") as wf:
+                sample_rate = wf.getframerate()
+                n_frames = wf.getnframes()
+                raw = wf.readframes(n_frames)
+
+            import numpy as np
+            audio = np.frombuffer(raw, dtype=np.int16).astype(np.float32) / 32768.0
+
+            CHUNK = 4096
+            with self._lock:
+                self._playing = True
+            i = 0
+            while i < len(audio) and not self._stop_event.is_set():
+                chunk = audio[i : i + CHUNK]
+                sd.play(chunk, samplerate=sample_rate, blocking=True)
+                i += CHUNK
+        except Exception as exc:
+            logger.warning("Piper TTS speak error: %s", exc)
+        finally:
+            with self._lock:
+                self._playing = False
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        try:
+            import sounddevice as sd
+            sd.stop()
+        except Exception:
+            pass
+
+    def is_speaking(self) -> bool:
+        with self._lock:
+            return self._playing
+
+
+# ── macOS say ─────────────────────────────────────────────────────────────────
+
+class MacOSSayTTS(TTSBackend):
+    """Wraps macOS `say` command. Zero dependencies, decent quality."""
+
+    def __init__(self, voice: str = "Samantha", rate: int = 185) -> None:
+        self._voice = voice
+        self._rate = rate
+        self._proc: Optional[subprocess.Popen] = None  # type: ignore[type-arg]
+        self._lock = threading.Lock()
+
+    def speak(self, text: str, *, on_word: Optional[Callable[[str], None]] = None) -> None:
+        if sys.platform != "darwin":
+            logger.warning("MacOSSayTTS only works on macOS")
+            return
+        self.stop()
+        cmd = ["say", "-v", self._voice, "-r", str(self._rate), text]
+        with self._lock:
+            self._proc = subprocess.Popen(cmd)
+        self._proc.wait()
+        with self._lock:
+            self._proc = None
+
+    def stop(self) -> None:
+        with self._lock:
+            proc = self._proc
+        if proc and proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=1.0)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+        with self._lock:
+            self._proc = None
+
+    def is_speaking(self) -> bool:
+        with self._lock:
+            return self._proc is not None and self._proc.poll() is None
+
+
+# ── silent fallback ───────────────────────────────────────────────────────────
+
+class SilentTTS(TTSBackend):
+    """No audio — just prints to stdout. Always works."""
+
+    def speak(self, text: str, *, on_word: Optional[Callable[[str], None]] = None) -> None:
+        print(f"[TTS] {text}")
+
+    def stop(self) -> None:
+        pass
+
+    def is_speaking(self) -> bool:
+        return False
+
+
+# ── factory ───────────────────────────────────────────────────────────────────
+
+def build_tts(prefer: Optional[str] = None) -> TTSBackend:
+    """Auto-select the best available TTS backend.
+
+    prefer: 'piper' | 'say' | 'silent'
+    """
+    order = [prefer] if prefer else ["piper", "say", "silent"]
+    for name in order:
+        if name == "piper":
+            t = PiperTTS()
+            if t._load():
+                logger.info("TTS: using Piper")
+                return t
+        elif name == "say" and sys.platform == "darwin":
+            # Verify `say` exists
+            if subprocess.run(["which", "say"], capture_output=True).returncode == 0:
+                logger.info("TTS: using macOS say")
+                return MacOSSayTTS()
+        elif name == "silent":
+            logger.info("TTS: using silent (text-only) fallback")
+            return SilentTTS()
+    return SilentTTS()
+
+
+__all__ = ["MacOSSayTTS", "PiperTTS", "SilentTTS", "TTSBackend", "build_tts"]

--- a/src/openjarvis/voice/wake_word.py
+++ b/src/openjarvis/voice/wake_word.py
@@ -1,0 +1,205 @@
+"""Wake word detection.
+
+Primary: openwakeword (open-source ONNX, no API key needed).
+Fallback: energy spike + keyword match via STT (if openwakeword not installed).
+
+Install openwakeword:
+    uv pip install openwakeword
+"""
+
+from __future__ import annotations
+
+import logging
+import queue
+import threading
+from typing import Optional
+
+import numpy as np
+
+from openjarvis.voice._stubs import AudioChunk, WakeWordDetector, WakeWordResult
+
+logger = logging.getLogger(__name__)
+
+try:
+    from openwakeword.model import Model as OWWModel
+    _OWW_AVAILABLE = True
+except ImportError:
+    _OWW_AVAILABLE = False
+    OWWModel = None  # type: ignore[assignment, misc]
+
+
+# ── openwakeword backend ───────────────────────────────────────────────────────
+
+class OpenWakeWordDetector(WakeWordDetector):
+    """Uses openwakeword to detect 'hey jarvis' (or a custom word)."""
+
+    # Shipped models: hey_jarvis, alexa, hey_mycroft, etc.
+    # Pass a path to a custom .onnx to load your own.
+    DEFAULT_WORDS = ["hey_jarvis"]
+
+    def __init__(
+        self,
+        wake_words: Optional[list[str]] = None,
+        threshold: float = 0.5,
+        inference_framework: str = "onnx",
+    ) -> None:
+        if not _OWW_AVAILABLE:
+            raise ImportError(
+                "openwakeword not installed. Run: uv pip install openwakeword"
+            )
+        self._words = wake_words or self.DEFAULT_WORDS
+        self._threshold = threshold
+        self._model = OWWModel(
+            wakeword_models=self._words,
+            inference_framework=inference_framework,
+        )
+
+    def process_chunk(self, chunk: AudioChunk) -> Optional[WakeWordResult]:
+        audio_int16 = np.frombuffer(chunk.data, dtype=np.int16)
+        predictions = self._model.predict(audio_int16)
+        for word, score in predictions.items():
+            if score >= self._threshold:
+                logger.info("Wake word detected: %s (%.2f)", word, score)
+                return WakeWordResult(word=word, confidence=float(score))
+        return None
+
+    def reset(self) -> None:
+        # Clear openwakeword internal buffer
+        self._model.reset()
+
+
+# ── energy-based fallback ──────────────────────────────────────────────────────
+
+class EnergyWakeWordDetector(WakeWordDetector):
+    """Simple energy-spike detector — fires on loud enough sound above threshold.
+
+    Not truly a wake-word detector, but a useful press-to-talk substitute when
+    openwakeword is not available.  Combine with a short STT check if needed.
+    """
+
+    def __init__(self, energy_threshold: int = 800, consecutive_chunks: int = 3) -> None:
+        self._threshold = energy_threshold
+        self._needed = consecutive_chunks
+        self._count = 0
+
+    def process_chunk(self, chunk: AudioChunk) -> Optional[WakeWordResult]:
+        arr = np.frombuffer(chunk.data, dtype=np.int16).astype(np.float32)
+        rms = int(np.sqrt(np.mean(arr ** 2)))
+        if rms > self._threshold:
+            self._count += 1
+            if self._count >= self._needed:
+                self._count = 0
+                return WakeWordResult(word="energy_spike", confidence=1.0)
+        else:
+            self._count = 0
+        return None
+
+    def reset(self) -> None:
+        self._count = 0
+
+
+# ── background detection thread ───────────────────────────────────────────────
+
+class WakeWordListener:
+    """Runs wake word detection in a background thread.
+
+    Usage
+    -----
+    listener = WakeWordListener()
+    listener.start()
+    # blocks until a wake word fires:
+    result = listener.wait_for_wake()
+    listener.stop()
+    """
+
+    def __init__(self, detector: Optional[WakeWordDetector] = None) -> None:
+        self._detector = detector or _build_default_detector()
+        self._wake_q: queue.Queue[WakeWordResult] = queue.Queue()
+        self._stop_event = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+
+    # ── lifecycle ──────────────────────────────────────────────────────────────
+
+    def start(self) -> None:
+        """Start background detection thread."""
+        if self._thread and self._thread.is_alive():
+            return
+        self._stop_event.clear()
+        self._thread = threading.Thread(target=self._run, daemon=True, name="wake-word")
+        self._thread.start()
+        logger.debug("WakeWordListener started")
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        if self._thread:
+            self._thread.join(timeout=2.0)
+
+    def wait_for_wake(self, timeout: Optional[float] = None) -> Optional[WakeWordResult]:
+        """Block until a wake word fires or timeout elapses."""
+        try:
+            return self._wake_q.get(timeout=timeout)
+        except queue.Empty:
+            return None
+
+    def drain(self) -> None:
+        """Discard any pending wake events (e.g. after handling one)."""
+        while not self._wake_q.empty():
+            try:
+                self._wake_q.get_nowait()
+            except queue.Empty:
+                break
+        self._detector.reset()
+
+    # ── internal ──────────────────────────────────────────────────────────────
+
+    def _run(self) -> None:
+        from openjarvis.voice.listener import SAMPLE_RATE
+
+        try:
+            import sounddevice as sd
+        except ImportError:
+            logger.error("sounddevice not installed — wake word detection disabled")
+            return
+
+        CHUNK = 512
+        audio_q: queue.Queue[np.ndarray] = queue.Queue()
+
+        def _cb(indata: np.ndarray, frames: int, ti, status) -> None:  # noqa: ANN001
+            audio_q.put(indata.copy())
+
+        with sd.InputStream(
+            samplerate=SAMPLE_RATE,
+            channels=1,
+            dtype="int16",
+            blocksize=CHUNK,
+            callback=_cb,
+        ):
+            while not self._stop_event.is_set():
+                try:
+                    raw = audio_q.get(timeout=0.1)
+                except queue.Empty:
+                    continue
+                chunk = AudioChunk(
+                    data=raw.astype(np.int16).tobytes(),
+                    sample_rate=SAMPLE_RATE,
+                )
+                result = self._detector.process_chunk(chunk)
+                if result:
+                    self._wake_q.put(result)
+
+
+def _build_default_detector() -> WakeWordDetector:
+    if _OWW_AVAILABLE:
+        try:
+            return OpenWakeWordDetector()
+        except Exception as exc:
+            logger.warning("openwakeword init failed (%s) — using energy fallback", exc)
+    logger.info("Using energy-spike wake detector (openwakeword not available)")
+    return EnergyWakeWordDetector()
+
+
+__all__ = [
+    "EnergyWakeWordDetector",
+    "OpenWakeWordDetector",
+    "WakeWordListener",
+]

--- a/uv.lock
+++ b/uv.lock
@@ -4968,6 +4968,23 @@ tools-search = [
     { name = "ddgs" },
     { name = "tavily-python" },
 ]
+voice = [
+    { name = "faster-whisper" },
+    { name = "numpy" },
+    { name = "sounddevice" },
+]
+voice-piper = [
+    { name = "faster-whisper" },
+    { name = "numpy" },
+    { name = "piper-tts" },
+    { name = "sounddevice" },
+]
+voice-wake = [
+    { name = "faster-whisper" },
+    { name = "numpy" },
+    { name = "openwakeword" },
+    { name = "sounddevice" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -4993,6 +5010,9 @@ requires-dist = [
     { name = "faiss-cpu", marker = "extra == 'memory-faiss'", specifier = ">=1.7" },
     { name = "fastapi", marker = "extra == 'server'", specifier = ">=0.110" },
     { name = "faster-whisper", marker = "extra == 'speech'", specifier = ">=1.0" },
+    { name = "faster-whisper", marker = "extra == 'voice'", specifier = ">=1.0" },
+    { name = "faster-whisper", marker = "extra == 'voice-piper'", specifier = ">=1.0" },
+    { name = "faster-whisper", marker = "extra == 'voice-wake'", specifier = ">=1.0" },
     { name = "gepa", marker = "extra == 'learning-gepa'", specifier = ">=0.1" },
     { name = "google-api-python-client", marker = "extra == 'channel-gmail'", specifier = ">=2.0" },
     { name = "google-auth", marker = "extra == 'eval-sheets'", specifier = ">=2.0" },
@@ -5012,12 +5032,17 @@ requires-dist = [
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.25" },
     { name = "mlx-lm", marker = "sys_platform == 'darwin' and extra == 'inference-mlx'", specifier = ">=0.19" },
     { name = "numpy", marker = "extra == 'memory-faiss'", specifier = ">=1.24" },
+    { name = "numpy", marker = "extra == 'voice'", specifier = ">=1.24" },
+    { name = "numpy", marker = "extra == 'voice-piper'", specifier = ">=1.24" },
+    { name = "numpy", marker = "extra == 'voice-wake'", specifier = ">=1.24" },
     { name = "openai", specifier = ">=1.30" },
     { name = "openai", marker = "extra == 'inference-cloud'", specifier = ">=1.30" },
     { name = "openai", marker = "extra == 'media'", specifier = ">=1.30" },
     { name = "openhands-sdk", marker = "python_full_version >= '3.12' and extra == 'openhands'", specifier = ">=1.0" },
+    { name = "openwakeword", marker = "extra == 'voice-wake'", specifier = ">=0.6" },
     { name = "pdfplumber", marker = "extra == 'memory-pdf'", specifier = ">=0.10" },
     { name = "pdfplumber", marker = "extra == 'pdf'", specifier = ">=0.10" },
+    { name = "piper-tts", marker = "extra == 'voice-piper'", specifier = ">=1.2" },
     { name = "playwright", marker = "extra == 'browser'", specifier = ">=1.40" },
     { name = "praw", marker = "extra == 'channel-reddit'", specifier = ">=7.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0" },
@@ -5041,6 +5066,9 @@ requires-dist = [
     { name = "sentence-transformers", marker = "extra == 'memory-faiss'", specifier = ">=2.2" },
     { name = "slack-sdk", marker = "extra == 'channel-slack'", specifier = ">=3.27" },
     { name = "slixmpp", marker = "extra == 'channel-xmpp'", specifier = ">=1.8" },
+    { name = "sounddevice", marker = "extra == 'voice'", specifier = ">=0.4" },
+    { name = "sounddevice", marker = "extra == 'voice-piper'", specifier = ">=0.4" },
+    { name = "sounddevice", marker = "extra == 'voice-wake'", specifier = ">=0.4" },
     { name = "tavily-python", marker = "extra == 'tools-search'", specifier = ">=0.3" },
     { name = "textual", marker = "extra == 'dashboard'", specifier = ">=0.80" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0" },
@@ -5060,7 +5088,7 @@ requires-dist = [
     { name = "zeus-ml", extras = ["apple"], marker = "extra == 'energy-apple'" },
     { name = "zulip", marker = "extra == 'channel-zulip'", specifier = ">=0.9" },
 ]
-provides-extras = ["dev", "inference-mlx", "inference-vllm", "inference-cloud", "inference-google", "inference-litellm", "inference-gemma", "tools-search", "memory-faiss", "memory-colbert", "memory-pdf", "memory-bm25", "server", "openhands", "gpu-metrics", "energy-amd", "energy-apple", "energy-all", "orchestrator-training", "learning-dspy", "learning-gepa", "channel-telegram", "channel-discord", "channel-slack", "channel-line", "channel-viber", "channel-messenger", "channel-reddit", "channel-mastodon", "channel-xmpp", "channel-rocketchat", "channel-zulip", "channel-twitch", "channel-nostr", "channel-twilio", "channel-gmail", "channel-twitter", "browser", "media", "pdf", "scheduler", "security-signing", "sandbox-wasm", "sandbox-docker", "dashboard", "speech", "speech-deepgram", "eval-wandb", "eval-sheets", "docs"]
+provides-extras = ["dev", "inference-mlx", "inference-vllm", "inference-cloud", "inference-google", "inference-litellm", "inference-gemma", "tools-search", "memory-faiss", "memory-colbert", "memory-pdf", "memory-bm25", "server", "openhands", "gpu-metrics", "energy-amd", "energy-apple", "energy-all", "orchestrator-training", "learning-dspy", "learning-gepa", "channel-telegram", "channel-discord", "channel-slack", "channel-line", "channel-viber", "channel-messenger", "channel-reddit", "channel-mastodon", "channel-xmpp", "channel-rocketchat", "channel-zulip", "channel-twitch", "channel-nostr", "channel-twilio", "channel-gmail", "channel-twitter", "browser", "media", "pdf", "scheduler", "security-signing", "sandbox-wasm", "sandbox-docker", "dashboard", "speech", "speech-deepgram", "voice", "voice-wake", "voice-piper", "eval-wandb", "eval-sheets", "docs"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "maturin", specifier = ">=1.12.6" }]
@@ -5214,6 +5242,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ba/e6/40b59eda51ac47009fb47afcdf37c6938594a0bd7f3b9fadcbc6058248e3/opentelemetry_semantic_conventions_ai-0.4.13.tar.gz", hash = "sha256:94efa9fb4ffac18c45f54a3a338ffeb7eedb7e1bb4d147786e77202e159f0036", size = 5368, upload-time = "2025-08-22T10:14:17.387Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/35/b5/cf25da2218910f0d6cdf7f876a06bed118c4969eacaf60a887cbaef44f44/opentelemetry_semantic_conventions_ai-0.4.13-py3-none-any.whl", hash = "sha256:883a30a6bb5deaec0d646912b5f9f6dcbb9f6f72557b73d0f2560bf25d13e2d5", size = 6080, upload-time = "2025-08-22T10:14:16.477Z" },
+]
+
+[[package]]
+name = "openwakeword"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "onnxruntime" },
+    { name = "requests" },
+    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.17.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "tflite-runtime", marker = "sys_platform == 'linux'" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/9b/73b7d98b07f4e1f525ad39703e0c5f30ff61c3fa16c8bfe4d99eadc0567a/openwakeword-0.6.0.tar.gz", hash = "sha256:36858d90f1183e307485597a912a4e3c3384b14ea9923f83feaffae7c1565565", size = 70830, upload-time = "2024-02-11T20:56:17.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/33/dafd6822bebe463a9098951d06a0d88fb4f8c946ce087025bc4fa132e533/openwakeword-0.6.0-py3-none-any.whl", hash = "sha256:6f423a4e3ae9dd0e3cd12b50ff8abf69679f687b4ab349d7c82c021c0e2abc9d", size = 60690, upload-time = "2024-02-11T20:56:16.179Z" },
 ]
 
 [[package]]
@@ -5666,6 +5713,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/00/98/fc53ab36da80b88df0967896b6c4b4cd948a0dc5aa40a754266aa3ae48b3/pillow-12.1.1-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f975aa7ef9684ce7e2c18a3aa8f8e2106ce1e46b94ab713d156b2898811651d3", size = 5313850, upload-time = "2026-02-11T04:23:00.554Z" },
     { url = "https://files.pythonhosted.org/packages/30/02/00fa585abfd9fe9d73e5f6e554dc36cc2b842898cbfc46d70353dae227f8/pillow-12.1.1-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8089c852a56c2966cf18835db62d9b34fef7ba74c726ad943928d494fa7f4735", size = 5963343, upload-time = "2026-02-11T04:23:02.934Z" },
     { url = "https://files.pythonhosted.org/packages/f2/26/c56ce33ca856e358d27fda9676c055395abddb82c35ac0f593877ed4562e/pillow-12.1.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:cb9bb857b2d057c6dfc72ac5f3b44836924ba15721882ef103cecb40d002d80e", size = 7029880, upload-time = "2026-02-11T04:23:04.783Z" },
+]
+
+[[package]]
+name = "piper-tts"
+version = "1.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "onnxruntime" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/2f/df92a56383bbfb7a3a35ff539ba4081932bef0daf920ec089ab7269e1493/piper_tts-1.4.1.tar.gz", hash = "sha256:bf0640db9fe512392f0cf570d445f76b3894b29fbab6f81be42b784fd8f0afe0", size = 4364811, upload-time = "2026-02-05T09:58:25.233Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/1c/e9a6695e19aa5c80b3ac4f70dd432fe3dcf99519458ad149f73af5b0fa44/piper_tts-1.4.1-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:76467df3abe0a0dd8d53e4e7d769ceb1669796e7188954182257be4cf79ddae0", size = 13822406, upload-time = "2026-02-05T09:58:13.246Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/56/633c64944a9ae13d5183989de1519e5eb30e5e6b668942d97ca03b04c53a/piper_tts-1.4.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:a99d93a2eb2805aa7059996069f8448c86ce7704200ec0bf9f9099f035494dc7", size = 13830418, upload-time = "2026-02-05T09:58:15.561Z" },
+    { url = "https://files.pythonhosted.org/packages/df/95/c4c4163cf0f636eec0ccb3adc63c70fb74334ff28e41e176f0ca0415496e/piper_tts-1.4.1-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3dbc990b4e28c680a44e26dc7a880b3e1068e06ffc1deecc8690929895ffb005", size = 13841987, upload-time = "2026-02-05T09:58:18.259Z" },
+    { url = "https://files.pythonhosted.org/packages/39/42/b44ae16ef80d86173518aafe2a493a826b46f9fe4fba1b82cd575117d5ac/piper_tts-1.4.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5aa533364c15248d2932bcc362eb0740de7cd28dc34233de8df2ee3c6f2adf00", size = 13841873, upload-time = "2026-02-05T09:58:20.428Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/d9/bc628449230681cf49af5e289974a076b22e98ecd017108ef0e679be4e00/piper_tts-1.4.1-cp39-abi3-win_amd64.whl", hash = "sha256:058c025f2a929180d034ed8c333f6b9dd286178703be2133efbafba7f4db13ff", size = 13831941, upload-time = "2026-02-05T09:58:22.562Z" },
 ]
 
 [[package]]
@@ -8248,6 +8311,22 @@ wheels = [
 ]
 
 [[package]]
+name = "sounddevice"
+version = "0.5.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2a/f9/2592608737553638fca98e21e54bfec40bf577bb98a61b2770c912aab25e/sounddevice-0.5.5.tar.gz", hash = "sha256:22487b65198cb5bf2208755105b524f78ad173e5ab6b445bdab1c989f6698df3", size = 143191, upload-time = "2026-01-23T18:36:43.529Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/0a/478e441fd049002cf308520c0d62dd8333e7c6cc8d997f0dda07b9fbcc46/sounddevice-0.5.5-py3-none-any.whl", hash = "sha256:30ff99f6c107f49d25ad16a45cacd8d91c25a1bcdd3e81a206b921a3a6405b1f", size = 32807, upload-time = "2026-01-23T18:36:35.649Z" },
+    { url = "https://files.pythonhosted.org/packages/56/f9/c037c35f6d0b6bc3bc7bfb314f1d6f1f9a341328ef47cd63fc4f850a7b27/sounddevice-0.5.5-py3-none-macosx_10_6_x86_64.macosx_10_6_universal2.whl", hash = "sha256:05eb9fd6c54c38d67741441c19164c0dae8ce80453af2d8c4ad2e7823d15b722", size = 108557, upload-time = "2026-01-23T18:36:37.41Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a1/d19dd9889cd4bce2e233c4fac007cd8daaf5b9fe6e6a5d432cf17be0b807/sounddevice-0.5.5-py3-none-win32.whl", hash = "sha256:1234cc9b4c9df97b6cbe748146ae0ec64dd7d6e44739e8e42eaa5b595313a103", size = 317765, upload-time = "2026-01-23T18:36:39.047Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/0e/002ed7c4c1c2ab69031f78989d3b789fee3a7fba9e586eb2b81688bf4961/sounddevice-0.5.5-py3-none-win_amd64.whl", hash = "sha256:cfc6b2c49fb7f555591c78cb8ecf48d6a637fd5b6e1db5fec6ed9365d64b3519", size = 365324, upload-time = "2026-01-23T18:36:40.496Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/39/a61d4b83a7746b70d23d9173be688c0c6bfc7173772344b7442c2c155497/sounddevice-0.5.5-py3-none-win_arm64.whl", hash = "sha256:3861901ddd8230d2e0e8ae62ac320cdd4c688d81df89da036dcb812f757bb3e6", size = 317115, upload-time = "2026-01-23T18:36:42.235Z" },
+]
+
+[[package]]
 name = "sqlalchemy"
 version = "2.0.48"
 source = { registry = "https://pypi.org/simple" }
@@ -8401,6 +8480,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f7/08/1e1f705825359590ddfaeda57653bd518c4ff7a96bb2c3239ba1b6fc4c51/textual-8.0.0.tar.gz", hash = "sha256:ce48f83a3d686c0fac0e80bf9136e1f8851c653aa6a4502e43293a151df18809", size = 1595895, upload-time = "2026-02-16T17:12:14.215Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d3/be/e191c2a15da20530fde03564564e3e4b4220eb9d687d4014957e5c6a5e85/textual-8.0.0-py3-none-any.whl", hash = "sha256:8908f4ebe93a6b4f77ca7262197784a52162bc88b05f4ecf50ac93a92d49bb8f", size = 718904, upload-time = "2026-02-16T17:12:11.962Z" },
+]
+
+[[package]]
+name = "tflite-runtime"
+version = "2.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", marker = "sys_platform == 'linux'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/1f/aade0d066bacbe697946ae21f0467a702d81adb939bb64515e9abebae9ed/tflite_runtime-2.14.0-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:bb11df4283e281cd609c621ac9470ad0cb5674408593272d7593a2c6bde8a808", size = 2413436, upload-time = "2023-10-03T21:15:38.025Z" },
+    { url = "https://files.pythonhosted.org/packages/04/dd/a701667be92bb884644eeec91ebbde57e197d27d9a79241169b6ce15e1ad/tflite_runtime-2.14.0-cp310-cp310-manylinux_2_34_aarch64.whl", hash = "sha256:d38c6885f5e9673c11a61ccec5cad7c032ab97340718d26b17794137f398b780", size = 2324943, upload-time = "2023-10-03T21:15:40.253Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/33/ad39ee3706a67139dde4624e66a2dd65604cc800dbb861f719f7cb1f1edc/tflite_runtime-2.14.0-cp310-cp310-manylinux_2_34_armv7l.whl", hash = "sha256:7fe33f763263d1ff2733a09945a7547ab063d8bc311fd2a1be8144d850016ad3", size = 1818760, upload-time = "2023-10-03T21:15:42.321Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/a6/02d68cb62cd221589a0ff055073251d883936237c9c990e34a1d7cecd06f/tflite_runtime-2.14.0-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:195ab752e7e57329a68e54dd3dd5439fad888b9bff1be0f0dc042a3237a90e4d", size = 2414486, upload-time = "2023-10-03T21:15:44.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/e9/5fc0435129c23c17551fcfadc82bd0d5482276213dfbc641f07b4420cb6d/tflite_runtime-2.14.0-cp311-cp311-manylinux_2_34_aarch64.whl", hash = "sha256:ce9fa5d770a9725c746dcbf6f59f3178233b3759f09982e8b2db8d2234c333b0", size = 2325913, upload-time = "2023-10-03T21:15:46.348Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/76/e246c39d92929655bac8878d76406d6fb0293c678237e55621e7ece4a269/tflite_runtime-2.14.0-cp311-cp311-manylinux_2_34_armv7l.whl", hash = "sha256:c4e66a74165b18089c86788400af19fa551768ac782d231a9beae2f6434f7949", size = 1820588, upload-time = "2023-10-03T21:15:48.399Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds a fully modular voice assistant to Jarvis with the following components:
- Wake word detection via openwakeword (fallback: energy-based)
- Microphone VAD listening loop using sounddevice
- Speech-to-text via faster-whisper (local, int8)
- Text-to-speech via Piper TTS (fallback: macOS say, then silent)
- Response filtering to trim markdown/filler for spoken delivery
- State machine: standby -> wake -> listening -> thinking -> speaking -> standby
- Interrupt handling: wake word during TTS cancels playback
- jarvis voice CLI command with configurable model, engine, TTS backend
- New pyproject.toml extras: voice, voice-wake, voice-piper

## What does this PR do?

<!-- Brief description of the change and its motivation -->

## How was this tested?

<!-- Describe tests added or manual testing performed -->

## Checklist

- [ ] Tests pass (`uv run pytest tests/ -v`)
- [ ] Linter passes (`uv run ruff check src/ tests/`)
- [ ] Formatter passes (`uv run ruff format --check src/ tests/`)
- [ ] New/changed public API has docstrings
- [ ] Follows registry pattern (if adding new component)
- [ ] Documentation updated (if applicable)
