### PR TITLE
fix(evals): add tool_choice=auto + fix traces thread safety

### DIFF
--- a/src/openjarvis/evals/execution/taubench_env.py
+++ b/src/openjarvis/evals/execution/taubench_env.py
@@ -177,6 +177,7 @@ class JarvisHalfDuplexAgent:
             "temperature": self._temperature,
             "max_tokens": self._max_tokens,
             "tools": openai_tools,
+            "tool_choice": "auto",
         }
         # Disable thinking mode for local models (Qwen3.5 etc.)
         # to avoid <think> tags interfering with tool call parsing

--- a/src/openjarvis/system.py
+++ b/src/openjarvis/system.py
@@ -503,10 +503,15 @@ class SystemBuilder:
         # Resolve model
         model = self._resolve_model(config, engine)
 
-        # Compute telemetry_enabled once
+        # Compute telemetry_enabled and traces_enabled once
         telemetry_enabled = (
             self._telemetry if self._telemetry is not None else config.telemetry.enabled
         )
+        traces_enabled = (
+            self._traces if self._traces is not None else config.traces.enabled
+        )
+        # Apply traces flag to config so downstream code respects it
+        config.traces.enabled = traces_enabled
         gpu_monitor = None
         energy_monitor = None
         if telemetry_enabled and config.telemetry.gpu_metrics:


### PR DESCRIPTION
## Summary
Two fixes for eval accuracy and stability.

### 1. TauBench: add tool_choice=auto
tau2's native LLMAgent always passes tool_choice=auto when tools are provided. Our JarvisHalfDuplexAgent didn't, causing 10-14pp score drops for Qwen and GPT-5.4 which are sensitive to this signal.

### 2. SystemBuilder: fix traces flag
builder.traces(False) was a no-op — the flag was stored but never applied to config.traces.enabled. This left SQLite trace connections active, which crash when accessed from ThreadPoolExecutor worker threads in GAIA evals.

## Test plan
- [x] 79 tests passing
- [ ] Re-run TauBench to verify score improvement
- [ ] Re-run GAIA with local models to verify SQLite fix