### PR TITLE
fix: add check_same_thread=False to all SQLite connections

### DIFF
--- a/src/openjarvis/learning/optimize/store.py
+++ b/src/openjarvis/learning/optimize/store.py
@@ -92,7 +92,7 @@ class OptimizationStore:
 
     def __init__(self, db_path: Union[str, Path]) -> None:
         self._db_path = str(db_path)
-        self._conn = sqlite3.connect(self._db_path)
+        self._conn = sqlite3.connect(self._db_path, check_same_thread=False)
         self._conn.execute("PRAGMA journal_mode=WAL")
         self._conn.execute(_CREATE_RUNS)
         self._conn.execute(_CREATE_TRIALS)

--- a/src/openjarvis/security/audit.py
+++ b/src/openjarvis/security/audit.py
@@ -39,7 +39,7 @@ class AuditLogger:
         from openjarvis.security.file_utils import secure_create
 
         secure_create(self._db_path)
-        self._conn = sqlite3.connect(str(self._db_path))
+        self._conn = sqlite3.connect(str(self._db_path), check_same_thread=False)
         self._conn.execute(
             """
             CREATE TABLE IF NOT EXISTS security_events (

--- a/src/openjarvis/telemetry/aggregator.py
+++ b/src/openjarvis/telemetry/aggregator.py
@@ -89,7 +89,7 @@ class TelemetryAggregator:
 
     def __init__(self, db_path: str | Path) -> None:
         self._db_path = str(db_path)
-        self._conn = sqlite3.connect(self._db_path)
+        self._conn = sqlite3.connect(self._db_path, check_same_thread=False)
         self._conn.row_factory = sqlite3.Row
 
     @staticmethod

--- a/src/openjarvis/tools/storage/knowledge_graph.py
+++ b/src/openjarvis/tools/storage/knowledge_graph.py
@@ -60,7 +60,7 @@ class KnowledgeGraphMemory:
     ) -> None:
         self._db_path = Path(db_path)
         self._db_path.parent.mkdir(parents=True, exist_ok=True)
-        self._conn = sqlite3.connect(str(self._db_path))
+        self._conn = sqlite3.connect(str(self._db_path), check_same_thread=False)
         self._create_tables()
 
     def _create_tables(self) -> None:


### PR DESCRIPTION
## Summary
Four SQLite connections missing check_same_thread=False cause thread errors during eval runs.

### Fixed files
- learning/optimize/store.py (OptimizationStore)
- security/audit.py (AuditLogger)
- telemetry/aggregator.py (TelemetryAggregator)
- tools/storage/knowledge_graph.py (KnowledgeGraphMemory)

All use WAL mode, making cross-thread access safe. All other SQLite stores in the codebase already had this flag.

### Impact
Fixes silent task failures in LiveCodeBench, LiveResearchBench, and GAIA eval runs where ThreadPoolExecutor worker threads access SQLite objects created in the main thread.