### PR TITLE
fix: inject default system prompt to ground locally-hosted models

### DIFF
--- a/src/openjarvis/agents/_stubs.py
+++ b/src/openjarvis/agents/_stubs.py
@@ -134,12 +134,26 @@ class BaseAgent(ABC):
         conversation messages, and finally the user input.
         """
         messages: list[Message] = []
+        # Check if the context already supplies a system message
+        _context_has_system = (
+            context
+            and context.conversation.messages
+            and any(m.role == Role.SYSTEM for m in context.conversation.messages)
+        )
+
         if self._prompt_builder is not None:
             effective_system_prompt = self._prompt_builder.build()
         elif system_prompt:
             effective_system_prompt = system_prompt
-        else:
+        elif _context_has_system:
             effective_system_prompt = None
+        else:
+            # Fall back to the config-level default (grounds local models)
+            try:
+                cfg = load_config()
+                effective_system_prompt = cfg.agent.default_system_prompt or None
+            except Exception:
+                effective_system_prompt = None
         if effective_system_prompt:
             messages.append(Message(role=Role.SYSTEM, content=effective_system_prompt))
         if context and context.conversation.messages:

--- a/src/openjarvis/core/config.py
+++ b/src/openjarvis/core/config.py
@@ -772,6 +772,11 @@ class AgentConfig:
     system_prompt: str = ""  # inline system prompt (takes precedence if set)
     system_prompt_path: str = ""  # path to system prompt file (.txt, .md)
     context_from_memory: bool = True  # inject relevant memory context into prompts
+    default_system_prompt: str = (
+        "You are a helpful AI assistant running locally on the user's own "
+        "hardware through OpenJarvis. You are not a cloud service. Respond "
+        "helpfully, concisely, and accurately."
+    )
 
     # Backward-compat property for old field name
     @property

--- a/tests/agents/test_base_agent.py
+++ b/tests/agents/test_base_agent.py
@@ -143,15 +143,17 @@ class TestEmitTurnEnd:
 
 
 class TestBuildMessages:
-    def test_basic(self):
+    def test_default_system_prompt_injected(self):
         engine = MagicMock()
         agent = _ConcreteAgent(engine, "m")
         messages = agent._build_messages("hello")
-        assert len(messages) == 1
-        assert messages[0].role == Role.USER
-        assert messages[0].content == "hello"
+        assert len(messages) == 2
+        assert messages[0].role == Role.SYSTEM
+        assert "local" in messages[0].content.lower()
+        assert messages[1].role == Role.USER
+        assert messages[1].content == "hello"
 
-    def test_with_system_prompt(self):
+    def test_explicit_system_prompt_overrides_default(self):
         engine = MagicMock()
         agent = _ConcreteAgent(engine, "m")
         messages = agent._build_messages("hello", system_prompt="Be helpful.")
@@ -159,6 +161,21 @@ class TestBuildMessages:
         assert messages[0].role == Role.SYSTEM
         assert messages[0].content == "Be helpful."
         assert messages[1].role == Role.USER
+
+    def test_empty_config_default_no_system_message(self, monkeypatch):
+        from openjarvis.core.config import JarvisConfig
+
+        empty_cfg = JarvisConfig()
+        empty_cfg.agent.default_system_prompt = ""
+        monkeypatch.setattr(
+            "openjarvis.agents._stubs.load_config", lambda: empty_cfg
+        )
+
+        engine = MagicMock()
+        agent = _ConcreteAgent(engine, "m")
+        messages = agent._build_messages("hello")
+        assert len(messages) == 1
+        assert messages[0].role == Role.USER
 
     def test_with_context(self):
         engine = MagicMock()
@@ -168,10 +185,10 @@ class TestBuildMessages:
         conv.add(Message(role=Role.ASSISTANT, content="reply"))
         ctx = AgentContext(conversation=conv)
         messages = agent._build_messages("new", ctx)
-        assert len(messages) == 3
-        assert messages[0].content == "prev"
-        assert messages[1].content == "reply"
-        assert messages[2].content == "new"
+        # default system prompt + 2 context + 1 user
+        assert messages[-1].content == "new"
+        assert messages[-2].content == "reply"
+        assert messages[-3].content == "prev"
 
     def test_with_system_prompt_and_context(self):
         engine = MagicMock()
@@ -186,6 +203,7 @@ class TestBuildMessages:
         )
         assert len(messages) == 3
         assert messages[0].role == Role.SYSTEM
+        assert messages[0].content == "System."
         assert messages[1].content == "prev"
         assert messages[2].content == "new"
 

--- a/tests/agents/test_simple.py
+++ b/tests/agents/test_simple.py
@@ -57,8 +57,10 @@ class TestSimpleAgent:
         agent.run("Hello")
         call_args = engine.generate.call_args
         messages = call_args[1].get("messages") or call_args[0][0]
-        assert len(messages) == 1
-        assert messages[0].role == Role.USER
+        # Default system prompt + user message
+        assert len(messages) == 2
+        assert messages[0].role == Role.SYSTEM
+        assert messages[1].role == Role.USER
 
     def test_custom_temperature(self):
         engine = _make_mock_engine()


### PR DESCRIPTION
## Summary
- Adds a `default_system_prompt` field to `AgentConfig` that tells the model it is running locally through OpenJarvis
- `BaseAgent._build_messages()` falls back to this prompt when no other system prompt is provided (prompt builder, explicit param, or context)
- Users can override or clear it in `config.toml` under `[agent]`
- Skips injection when the conversation context already contains a system message

Closes #164

## Test plan
- [x] Default system prompt injected when no other prompt is set
- [x] Explicit system prompt overrides the default
- [x] Context with existing system message skips default injection
- [x] Empty config default produces no system message
- [x] Full test suite — zero regressions