### PR TITLE
fix: remove invalid trim() from take-assign workflow

### DIFF
--- a/.github/workflows/take-assign.yml
+++ b/.github/workflows/take-assign.yml
@@ -11,7 +11,7 @@ jobs:
   assign:
     if: >-
       !github.event.issue.pull_request
-      && contains(fromJSON('["take", "Take", "TAKE"]'), trim(github.event.comment.body))
+      && contains(fromJSON('["take", "Take", "TAKE"]'), github.event.comment.body)
     runs-on: ubuntu-latest
     steps:
       - name: Assign commenter


### PR DESCRIPTION
## Summary
- Removes `trim()` from the take-assign workflow conditional — it is not a valid GitHub Actions expression function
- The job was failing on every trigger before any steps could run

Closes #181

## Test plan
- [ ] Comment "take" on an issue and verify auto-assignment works