### PR TITLE
fix: pass github_token to Claude workflows to bypass OIDC

### DIFF
--- a/.github/workflows/claude-issues.yml
+++ b/.github/workflows/claude-issues.yml
@@ -38,6 +38,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             You are an automated issue fixer for the OpenJarvis repository. Follow these steps in order:
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -47,4 +47,5 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: ${{ steps.review.outputs.instructions }}


### PR DESCRIPTION
## Summary
- Adds `github_token: ${{ secrets.GITHUB_TOKEN }}` to both `claude-review.yml` and `claude-issues.yml`
- Without this, the action attempts OIDC token exchange which fails because the Anthropic GitHub App is not installed on the org
- Passing the token directly skips the OIDC flow entirely

Closes #182

## Test plan
- [ ] Open a PR and verify the Claude PR Review workflow runs without OIDC errors
- [ ] Label an issue with `bug` and verify the Claude Issue Fixer workflow triggers