### PR TITLE
fix: recommend Qwen3.5 MoE models instead of Qwen3 dense

### DIFF
--- a/src/openjarvis/core/config.py
+++ b/src/openjarvis/core/config.py
@@ -240,17 +240,19 @@ def _available_memory_gb(hw: HardwareInfo) -> float:
 
 # Explicit tier table: (max_ram_gb, model_id).
 # Walked in order — first tier where available_gb <= max_ram is chosen.
+# Uses Qwen3.5 MoE models — better quality per GB than dense models since
+# only a fraction of parameters are active per token.
 _MODEL_TIERS = [
-    (8, "qwen3:1.7b"),
-    (16, "qwen3:4b"),
-    (32, "qwen3:8b"),
-    (64, "qwen3:14b"),
+    (8, "qwen3.5:2b"),
+    (16, "qwen3.5:4b"),
+    (32, "qwen3.5:9b"),
+    (64, "qwen3.5:27b"),
 ]
-_MODEL_TIER_FALLBACK = "qwen3:14b"
+_MODEL_TIER_FALLBACK = "qwen3.5:27b"
 
 
 def recommend_model(hw: HardwareInfo, engine: str) -> str:
-    """Suggest a Qwen3 dense model that fits the detected hardware.
+    """Suggest the best Qwen3.5 model that fits the detected hardware.
 
     Uses an explicit tier table mapping available memory to model size.
     Falls back to scanning the full catalog if the tiered model is not
@@ -276,12 +278,12 @@ def recommend_model(hw: HardwareInfo, engine: str) -> str:
     if spec and engine in spec.supported_engines:
         return model_id
 
-    # Fallback: scan all Qwen3 dense models for engine compatibility
+    # Fallback: scan all Qwen3.5 models for engine compatibility
     candidates = [
         s
         for s in BUILTIN_MODELS
         if s.provider == "alibaba"
-        and s.model_id.startswith("qwen3:")
+        and s.model_id.startswith("qwen3.5:")
         and engine in s.supported_engines
     ]
     candidates.sort(key=lambda s: s.parameter_count_b, reverse=True)

--- a/tests/core/test_recommend_model.py
+++ b/tests/core/test_recommend_model.py
@@ -6,87 +6,85 @@ from openjarvis.core.config import GpuInfo, HardwareInfo, recommend_model
 
 
 class TestRecommendModelTiers:
-    """Tier-based model recommendation (Qwen3 dense)."""
+    """Tier-based model recommendation (Qwen3.5 MoE)."""
 
-    def test_8gb_ram_picks_qwen3_1_7b(self) -> None:
+    def test_8gb_ram_picks_qwen35_2b(self) -> None:
         hw = HardwareInfo(platform="linux", ram_gb=8.0, gpu=None)
         result = recommend_model(hw, "llamacpp")
-        # available = (8 - 4) * 0.8 = 3.2 GB → ≤8 tier → qwen3:1.7b
-        assert result == "qwen3:1.7b"
+        # available = (8 - 4) * 0.8 = 3.2 GB → ≤8 tier → qwen3.5:2b
+        assert result == "qwen3.5:2b"
 
-    def test_16gb_ram_picks_qwen3_4b(self) -> None:
+    def test_16gb_ram_picks_qwen35_4b(self) -> None:
         hw = HardwareInfo(platform="linux", ram_gb=16.0, gpu=None)
         result = recommend_model(hw, "llamacpp")
-        # available = (16 - 4) * 0.8 = 9.6 GB → ≤16 tier → qwen3:4b
-        assert result == "qwen3:4b"
+        # available = (16 - 4) * 0.8 = 9.6 GB → ≤16 tier → qwen3.5:4b
+        assert result == "qwen3.5:4b"
 
-    def test_32gb_ram_picks_qwen3_8b(self) -> None:
+    def test_32gb_ram_picks_qwen35_9b(self) -> None:
         hw = HardwareInfo(platform="linux", ram_gb=32.0, gpu=None)
         result = recommend_model(hw, "llamacpp")
-        # available = (32 - 4) * 0.8 = 22.4 GB → ≤32 tier → qwen3:8b
-        assert result == "qwen3:8b"
+        # available = (32 - 4) * 0.8 = 22.4 GB → ≤32 tier → qwen3.5:9b
+        assert result == "qwen3.5:9b"
 
-    def test_64gb_ram_picks_qwen3_14b(self) -> None:
+    def test_64gb_ram_picks_qwen35_27b(self) -> None:
         hw = HardwareInfo(platform="linux", ram_gb=64.0, gpu=None)
         result = recommend_model(hw, "llamacpp")
-        # available = (64 - 4) * 0.8 = 48 GB → >32 → qwen3:14b
-        assert result == "qwen3:14b"
+        # available = (64 - 4) * 0.8 = 48 GB → >32 → qwen3.5:27b
+        assert result == "qwen3.5:27b"
 
 
 class TestRecommendModelGpu:
     """GPU-based model recommendation."""
 
-    def test_24gb_gpu_picks_qwen3_14b(self) -> None:
+    def test_24gb_gpu_picks_qwen35_9b(self) -> None:
         hw = HardwareInfo(
             platform="linux",
             ram_gb=64.0,
             gpu=GpuInfo(vendor="nvidia", name="RTX 4090", vram_gb=24.0, count=1),
         )
         result = recommend_model(hw, "ollama")
-        # available = 24 * 0.9 = 21.6 GB → ≤32 tier → qwen3:8b
-        # Actually 21.6 ≤ 32, so tier is qwen3:8b
-        assert result == "qwen3:8b"
+        # available = 24 * 0.9 = 21.6 GB → ≤32 tier → qwen3.5:9b
+        assert result == "qwen3.5:9b"
 
-    def test_8gb_gpu_picks_qwen3_1_7b(self) -> None:
+    def test_8gb_gpu_picks_qwen35_2b(self) -> None:
         hw = HardwareInfo(
             platform="linux",
             ram_gb=32.0,
             gpu=GpuInfo(vendor="nvidia", name="RTX 3070", vram_gb=8.0, count=1),
         )
         result = recommend_model(hw, "ollama")
-        # available = 8 * 0.9 = 7.2 GB → ≤8 tier → qwen3:1.7b
-        assert result == "qwen3:1.7b"
+        # available = 8 * 0.9 = 7.2 GB → ≤8 tier → qwen3.5:2b
+        assert result == "qwen3.5:2b"
 
-    def test_4gb_gpu_picks_qwen3_1_7b(self) -> None:
+    def test_4gb_gpu_picks_qwen35_2b(self) -> None:
         hw = HardwareInfo(
             platform="linux",
             ram_gb=16.0,
             gpu=GpuInfo(vendor="nvidia", name="GTX 1650", vram_gb=4.0, count=1),
         )
         result = recommend_model(hw, "ollama")
-        # available = 4 * 0.9 = 3.6 GB → ≤8 tier → qwen3:1.7b
-        assert result == "qwen3:1.7b"
+        # available = 4 * 0.9 = 3.6 GB → ≤8 tier → qwen3.5:2b
+        assert result == "qwen3.5:2b"
 
-    def test_multi_gpu_picks_qwen3_14b(self) -> None:
+    def test_multi_gpu_picks_qwen35_27b(self) -> None:
         hw = HardwareInfo(
             platform="linux",
             ram_gb=256.0,
             gpu=GpuInfo(vendor="nvidia", name="A100", vram_gb=80.0, count=2),
         )
         result = recommend_model(hw, "vllm")
-        # available = 80 * 2 * 0.9 = 144 GB → >64 → qwen3:14b (tier fallback)
-        assert result == "qwen3:14b"
+        # available = 80 * 2 * 0.9 = 144 GB → >64 → qwen3.5:27b (tier fallback)
+        assert result == "qwen3.5:27b"
 
-    def test_huge_vram_falls_back_to_scan(self) -> None:
+    def test_huge_vram_picks_largest_compatible(self) -> None:
         hw = HardwareInfo(
             platform="linux",
             ram_gb=512.0,
             gpu=GpuInfo(vendor="nvidia", name="H100", vram_gb=80.0, count=4),
         )
         result = recommend_model(hw, "vllm")
-        # available = 288 GB → tier gives qwen3:14b, but scan finds larger
-        # Tier fallback is qwen3:14b — it's valid for vllm
-        assert result == "qwen3:14b"
+        # available = 288 GB → tier fallback qwen3.5:27b, valid for vllm
+        assert result == "qwen3.5:27b"
 
 
 class TestRecommendModelEdgeCases:
@@ -96,12 +94,11 @@ class TestRecommendModelEdgeCases:
         hw = HardwareInfo(platform="linux", ram_gb=0.0, gpu=None)
         assert recommend_model(hw, "ollama") == ""
 
-    def test_4gb_ram_picks_qwen3_1_7b(self) -> None:
+    def test_6gb_ram_picks_qwen35_2b(self) -> None:
         hw = HardwareInfo(platform="linux", ram_gb=6.0, gpu=None)
         result = recommend_model(hw, "llamacpp")
-        # available = (6 - 4) * 0.8 = 1.6 GB → ≤8 tier → qwen3:1.7b
-        # 1.7 * 0.5 * 1.1 = 0.935 → fits in 1.6
-        assert result == "qwen3:1.7b"
+        # available = (6 - 4) * 0.8 = 1.6 GB → ≤8 tier → qwen3.5:2b
+        assert result == "qwen3.5:2b"
 
     def test_very_low_ram_returns_empty(self) -> None:
         hw = HardwareInfo(platform="linux", ram_gb=4.0, gpu=None)
@@ -120,9 +117,8 @@ class TestRecommendModelMlx:
             gpu=GpuInfo(vendor="apple", name="Apple M1", vram_gb=8.0, count=1),
         )
         result = recommend_model(hw, "mlx")
-        # available = 8 * 0.9 = 7.2 GB → ≤8 tier → qwen3:1.7b
-        # But qwen3:1.7b supports mlx → good
-        assert result == "qwen3:1.7b"
+        # available = 8 * 0.9 = 7.2 GB → ≤8 tier → qwen3.5:2b
+        assert result == "qwen3.5:2b"
 
     def test_apple_silicon_16gb_mlx(self) -> None:
         hw = HardwareInfo(
@@ -131,8 +127,8 @@ class TestRecommendModelMlx:
             gpu=GpuInfo(vendor="apple", name="Apple M2", vram_gb=16.0, count=1),
         )
         result = recommend_model(hw, "mlx")
-        # available = 16 * 0.9 = 14.4 GB → ≤16 tier → qwen3:4b
-        assert result == "qwen3:4b"
+        # available = 16 * 0.9 = 14.4 GB → ≤16 tier → qwen3.5:4b
+        assert result == "qwen3.5:4b"
 
     def test_apple_silicon_32gb_mlx(self) -> None:
         hw = HardwareInfo(
@@ -141,8 +137,8 @@ class TestRecommendModelMlx:
             gpu=GpuInfo(vendor="apple", name="Apple M2 Pro", vram_gb=32.0, count=1),
         )
         result = recommend_model(hw, "mlx")
-        # available = 32 * 0.9 = 28.8 GB → ≤32 tier → qwen3:8b
-        assert result == "qwen3:8b"
+        # available = 32 * 0.9 = 28.8 GB → ≤32 tier → qwen3.5:9b
+        assert result == "qwen3.5:9b"
 
     def test_apple_silicon_64gb_mlx(self) -> None:
         hw = HardwareInfo(
@@ -151,6 +147,5 @@ class TestRecommendModelMlx:
             gpu=GpuInfo(vendor="apple", name="Apple M2 Max", vram_gb=64.0, count=1),
         )
         result = recommend_model(hw, "mlx")
-        # available = 64 * 0.9 = 57.6 GB → ≤64 tier → qwen3:14b
-        # qwen3:14b doesn't support mlx → fallback scan finds qwen3:8b
-        assert result == "qwen3:8b"
+        # available = 64 * 0.9 = 57.6 GB → ≤64 tier → qwen3.5:27b
+        assert result == "qwen3.5:27b"


### PR DESCRIPTION
## Summary
- Switches the `recommend_model()` tier table from Qwen3 dense to Qwen3.5 MoE models
- MoE models provide better quality per GB since only a fraction of parameters are active per token
- Updated tiers: ≤8GB → `qwen3.5:2b`, 8-16GB → `qwen3.5:4b`, 16-32GB → `qwen3.5:9b`, 32GB+ → `qwen3.5:27b`

Follow-up to #188

## Test plan
- [x] All 16 recommendation tests pass
- [x] Covers CPU-only, GPU, multi-GPU, MLX, and edge cases