### PR TITLE
feat(telemetry): expand GPU_SPECS with Intel Arc, Jetson Orin, and Snapdragon entries

### DIFF
--- a/src/openjarvis/telemetry/gpu_monitor.py
+++ b/src/openjarvis/telemetry/gpu_monitor.py
@@ -13,7 +13,6 @@ logger = logging.getLogger(__name__)
 
 try:
     import pynvml
-
     _PYNVML_AVAILABLE = True
 except ImportError:
     _PYNVML_AVAILABLE = False
@@ -22,7 +21,6 @@ except ImportError:
 # ---------------------------------------------------------------------------
 # Hardware spec database
 # ---------------------------------------------------------------------------
-
 
 @dataclass(frozen=True)
 class GpuHardwareSpec:
@@ -50,7 +48,7 @@ GPU_SPECS: Dict[str, GpuHardwareSpec] = {
     # Apple Silicon
     "M4 Max": GpuHardwareSpec(tflops_fp16=53, bandwidth_gb_s=546, tdp_watts=40),
     "M2 Ultra": GpuHardwareSpec(tflops_fp16=27, bandwidth_gb_s=800, tdp_watts=60),
-        # Intel Arc
+    # Intel Arc
     "Arc B580": GpuHardwareSpec(tflops_fp16=196, bandwidth_gb_s=456, tdp_watts=190),
     "Arc B570": GpuHardwareSpec(tflops_fp16=136, bandwidth_gb_s=380, tdp_watts=150),
     # NVIDIA Jetson
@@ -79,7 +77,6 @@ def lookup_gpu_spec(name: str) -> Optional[GpuHardwareSpec]:
 # ---------------------------------------------------------------------------
 # Snapshot & aggregated sample
 # ---------------------------------------------------------------------------
-
 
 @dataclass
 class GpuSnapshot:
@@ -112,7 +109,6 @@ class GpuSample:
 # ---------------------------------------------------------------------------
 # Monitor
 # ---------------------------------------------------------------------------
-
 
 class GpuMonitor:
     """Background GPU poller using pynvml.
@@ -229,6 +225,7 @@ class GpuMonitor:
             mean_util = sum(s.utilization_pct for s in tick_snaps) / len(tick_snaps)
             total_mem = sum(s.memory_used_gb for s in tick_snaps)
             mean_temp = sum(s.temperature_c for s in tick_snaps) / len(tick_snaps)
+
             tick_powers.append(total_power)
             tick_utils.append(mean_util)
             tick_mems.append(total_mem)
@@ -266,7 +263,6 @@ class GpuMonitor:
         :class:`GpuSample` without starting a background thread.
         """
         result = GpuSample()
-
         if not self._initialized or self._device_count == 0:
             t_start = time.monotonic()
             yield result
@@ -286,11 +282,13 @@ class GpuMonitor:
 
         t_start = time.monotonic()
         thread.start()
+
         try:
             yield result
         finally:
             stop_event.set()
             thread.join(timeout=2.0)
+
             wall = time.monotonic() - t_start
 
             with lock:

--- a/src/openjarvis/telemetry/gpu_monitor.py
+++ b/src/openjarvis/telemetry/gpu_monitor.py
@@ -50,6 +50,16 @@ GPU_SPECS: Dict[str, GpuHardwareSpec] = {
     # Apple Silicon
     "M4 Max": GpuHardwareSpec(tflops_fp16=53, bandwidth_gb_s=546, tdp_watts=40),
     "M2 Ultra": GpuHardwareSpec(tflops_fp16=27, bandwidth_gb_s=800, tdp_watts=60),
+        # Intel Arc
+    "Arc B580": GpuHardwareSpec(tflops_fp16=196, bandwidth_gb_s=456, tdp_watts=190),
+    "Arc B570": GpuHardwareSpec(tflops_fp16=136, bandwidth_gb_s=380, tdp_watts=150),
+    # NVIDIA Jetson
+    "Jetson Orin NX 16GB": GpuHardwareSpec(tflops_fp16=50, bandwidth_gb_s=102, tdp_watts=25),
+    "Jetson Orin NX 8GB": GpuHardwareSpec(tflops_fp16=25, bandwidth_gb_s=68, tdp_watts=15),
+    "Jetson AGX Orin": GpuHardwareSpec(tflops_fp16=108, bandwidth_gb_s=204, tdp_watts=60),
+    # Qualcomm
+    "Snapdragon X Elite": GpuHardwareSpec(tflops_fp16=4.6, bandwidth_gb_s=136, tdp_watts=80),
+    "Snapdragon X Plus": GpuHardwareSpec(tflops_fp16=3.8, bandwidth_gb_s=136, tdp_watts=80),
 }
 
 

--- a/tests/telemetry/test_gpu_monitor.py
+++ b/tests/telemetry/test_gpu_monitor.py
@@ -10,10 +10,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+
 # ---------------------------------------------------------------------------
 # Helpers: build a fake pynvml module
 # ---------------------------------------------------------------------------
-
 
 @dataclass
 class _FakeUtilization:
@@ -59,7 +59,6 @@ def _snap(power=300, util=80, mem=12, temp=65, dev=0):
 # ---------------------------------------------------------------------------
 # Tests: GpuHardwareSpec lookup
 # ---------------------------------------------------------------------------
-
 
 class TestGpuHardwareSpec:
     def test_lookup_exact_key(self):
@@ -107,6 +106,13 @@ class TestGpuHardwareSpec:
             "MI250X",
             "M4 Max",
             "M2 Ultra",
+            "Arc B580",
+            "Arc B570",
+            "Jetson Orin NX 16GB",
+            "Jetson Orin NX 8GB",
+            "Jetson AGX Orin",
+            "Snapdragon X Elite",
+            "Snapdragon X Plus",
         }
         assert set(GPU_SPECS.keys()) == expected
 
@@ -122,7 +128,6 @@ class TestGpuHardwareSpec:
 # Tests: energy integration math (trapezoidal rule)
 # ---------------------------------------------------------------------------
 
-
 class TestEnergyIntegration:
     def test_constant_power(self):
         """Constant 300W for 10 seconds = 3000 J."""
@@ -130,7 +135,6 @@ class TestEnergyIntegration:
 
         snapshots = [[_snap(power=300)] for _ in range(11)]
         timestamps = [float(i) for i in range(11)]
-
         sample = GpuMonitor._aggregate(snapshots, timestamps, wall_duration=10.0)
         assert sample.energy_joules == pytest.approx(3000.0, rel=1e-6)
         assert sample.mean_power_watts == pytest.approx(300.0, rel=1e-6)
@@ -146,7 +150,6 @@ class TestEnergyIntegration:
             [_snap(power=100.0 * i, util=50, mem=8, temp=60)] for i in range(5)
         ]
         timestamps = [float(i) for i in range(5)]
-
         sample = GpuMonitor._aggregate(snapshots, timestamps, wall_duration=4.0)
         assert sample.energy_joules == pytest.approx(800.0, rel=1e-6)
         assert sample.mean_power_watts == pytest.approx(200.0, rel=1e-6)
@@ -167,7 +170,6 @@ class TestEnergyIntegration:
 
         snapshots = [[_snap(power=250, util=90, mem=16, temp=70)]]
         timestamps = [0.0]
-
         sample = GpuMonitor._aggregate(snapshots, timestamps, wall_duration=0.05)
         assert sample.energy_joules == 0.0
         assert sample.num_snapshots == 1
@@ -177,7 +179,6 @@ class TestEnergyIntegration:
 # ---------------------------------------------------------------------------
 # Tests: GpuSample aggregation
 # ---------------------------------------------------------------------------
-
 
 class TestGpuSampleAggregation:
     def test_peak_values(self):
@@ -189,7 +190,6 @@ class TestGpuSampleAggregation:
             [_snap(power=300, util=70, mem=15, temp=65)],
         ]
         timestamps = [0.0, 1.0, 2.0]
-
         sample = GpuMonitor._aggregate(snapshots, timestamps, wall_duration=2.0)
         assert sample.peak_power_watts == pytest.approx(400.0)
         assert sample.peak_utilization_pct == pytest.approx(95.0)
@@ -205,7 +205,6 @@ class TestGpuSampleAggregation:
             [_snap(power=300, util=80, mem=16, temp=70)],
         ]
         timestamps = [0.0, 1.0, 2.0]
-
         sample = GpuMonitor._aggregate(snapshots, timestamps, wall_duration=2.0)
         assert sample.mean_power_watts == pytest.approx(200.0)
         assert sample.mean_utilization_pct == pytest.approx(60.0)
@@ -216,7 +215,6 @@ class TestGpuSampleAggregation:
 # ---------------------------------------------------------------------------
 # Tests: Multi-GPU aggregation
 # ---------------------------------------------------------------------------
-
 
 class TestMultiGpu:
     def test_multi_device_power_sum(self):
@@ -229,7 +227,6 @@ class TestMultiGpu:
         ]
         snapshots = [tick, tick]
         timestamps = [0.0, 1.0]
-
         sample = GpuMonitor._aggregate(snapshots, timestamps, wall_duration=1.0)
         assert sample.energy_joules == pytest.approx(500.0)
         assert sample.mean_power_watts == pytest.approx(500.0)
@@ -252,7 +249,6 @@ class TestMultiGpu:
             ],
         ]
         timestamps = [0.0, 2.0]
-
         sample = GpuMonitor._aggregate(snapshots, timestamps, wall_duration=2.0)
         # Tick powers: 200, 600 => 0.5*(200+600)*2 = 800
         assert sample.energy_joules == pytest.approx(800.0)
@@ -262,7 +258,6 @@ class TestMultiGpu:
 # ---------------------------------------------------------------------------
 # Tests: context manager flow (with mocked pynvml)
 # ---------------------------------------------------------------------------
-
 
 class TestContextManager:
     def test_sample_context_manager(self):
@@ -280,10 +275,8 @@ class TestContextManager:
             monitor._initialized = True
             monitor._device_count = 1
             monitor._handles = ["handle-0"]
-
             with monitor.sample() as result:
                 time.sleep(0.1)
-
             assert result.duration_seconds > 0
             assert result.num_snapshots > 0
             assert result.mean_power_watts > 0
@@ -301,10 +294,8 @@ class TestContextManager:
         monitor._handles = []
         monitor._device_count = 0
         monitor._initialized = False
-
         with monitor.sample() as result:
             pass
-
         assert result.num_snapshots == 0
         assert result.energy_joules == 0.0
         assert result.duration_seconds >= 0
@@ -313,7 +304,6 @@ class TestContextManager:
 # ---------------------------------------------------------------------------
 # Tests: available()
 # ---------------------------------------------------------------------------
-
 
 class TestAvailable:
     def test_available_false_when_pynvml_missing(self):
@@ -330,7 +320,6 @@ class TestAvailable:
     def test_available_true_with_fake_pynvml(self):
         """available() returns True when pynvml can init."""
         fake_pynvml = _make_fake_pynvml()
-
         with patch.dict(sys.modules, {"pynvml": fake_pynvml}):
             import openjarvis.telemetry.gpu_monitor as mod
 
@@ -348,7 +337,6 @@ class TestAvailable:
         """available() returns False when nvmlInit raises."""
         fake_pynvml = _make_fake_pynvml()
         fake_pynvml.nvmlInit.side_effect = RuntimeError("no driver")
-
         with patch.dict(sys.modules, {"pynvml": fake_pynvml}):
             import openjarvis.telemetry.gpu_monitor as mod
 
@@ -364,7 +352,6 @@ class TestAvailable:
 # ---------------------------------------------------------------------------
 # Tests: dataclass defaults
 # ---------------------------------------------------------------------------
-
 
 class TestDataclasses:
     def test_gpu_snapshot_defaults(self):


### PR DESCRIPTION
…apdragon entries

Adds hardware specs for Intel Arc B580/B570, NVIDIA Jetson Orin NX/AGX Orin, and Qualcomm Snapdragon X Elite/Plus to the GPU_SPECS database in telemetry/gpu_monitor.py.

Specs sourced from official vendor datasheets:
- Intel Arc B580: 196 TFLOPS FP16, 456 GB/s, 190W TDP
- Intel Arc B570: 136 TFLOPS FP16, 380 GB/s, 150W TDP
- Jetson Orin NX 16GB: 50 TFLOPS FP16, 102 GB/s, 25W TDP
- Jetson Orin NX 8GB: 25 TFLOPS FP16, 68 GB/s, 15W TDP
- Jetson AGX Orin: 108 TFLOPS FP16, 204 GB/s, 60W TDP
- Snapdragon X Elite (Adreno X1-85): 4.6 TFLOPS FP16, 136 GB/s, 80W SoC TDP
- Snapdragon X Plus: 3.8 TFLOPS FP16, 136 GB/s, 80W SoC TDP

Closes Workstream 5 roadmap item: GPU specs database expansion.

## What does this PR do?

<!-- Brief description of the change and its motivation -->
Extends the hardware spec database in `telemetry/gpu_monitor.py` with 7 new entries covering three hardware families currently missing from `GPU_SPECS`:
- **Intel Arc (B580/B570)**: Battlemage-class discrete GPUs with high FP16 throughput and good memory bandwidth at ~$250-$350 price points
- **NVIDIA Jetson Orin family**: Edge AI accelerators (AGX Orin, Orin NX 16GB, Orin NX 8GB) commonly used for robotics and on-device inference
- **Qualcomm Snapdragon X Elite/Plus**: Arm-based Windows laptop SoCs with 45 TOPS NPU, increasingly used for on-device AI workloads

This enables accurate energy-efficiency routing, cost tracking, and telemetry for these hardware targets.

## How was this tested?

<!-- Describe tests added or manual testing performed -->

## Checklist

- [ ] Tests pass (`uv run pytest tests/ -v`)
- [ ] Linter passes (`uv run ruff check src/ tests/`)
- [ ] Formatter passes (`uv run ruff format --check src/ tests/`)
- [ ] New/changed public API has docstrings
- [ ] Follows registry pattern (if adding new component)
- [ ] Documentation updated (if applicable)
