### PR TITLE
Close KnowledgeStore connections in connectors_router endpoints

### DIFF
--- a/src/openjarvis/connectors/store.py
+++ b/src/openjarvis/connectors/store.py
@@ -132,6 +132,12 @@ class KnowledgeStore(MemoryBackend):
         self._conn.row_factory = sqlite3.Row
         self._setup()
 
+    def __enter__(self) -> "KnowledgeStore":
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self.close()
+
     # ------------------------------------------------------------------
     # Internal setup
     # ------------------------------------------------------------------

--- a/src/openjarvis/server/connectors_router.py
+++ b/src/openjarvis/server/connectors_router.py
@@ -108,12 +108,12 @@ def create_connectors_router():
         try:
             from openjarvis.connectors.store import KnowledgeStore
 
-            store = KnowledgeStore()
-            rows = store._conn.execute(
-                "SELECT COUNT(*) FROM knowledge_chunks WHERE source = ?",
-                (connector_id,),
-            ).fetchone()
-            chunks = rows[0] if rows else 0
+            with KnowledgeStore() as store:
+                rows = store._conn.execute(
+                    "SELECT COUNT(*) FROM knowledge_chunks WHERE source = ?",
+                    (connector_id,),
+                ).fetchone()
+                chunks = rows[0] if rows else 0
         except Exception:
             pass
 
@@ -260,10 +260,10 @@ def create_connectors_router():
                     from openjarvis.connectors.store import KnowledgeStore
                     from openjarvis.connectors.sync_engine import SyncEngine
 
-                    store = KnowledgeStore()
-                    pipeline = IngestionPipeline(store)
-                    engine = SyncEngine(pipeline)
-                    engine.sync(instance)
+                    with KnowledgeStore() as store:
+                        pipeline = IngestionPipeline(store)
+                        engine = SyncEngine(pipeline)
+                        engine.sync(instance)
                     logger.info(
                         "Auto-ingested %s after connect",
                         connector_id,
@@ -479,10 +479,10 @@ def create_connectors_router():
                 from openjarvis.connectors.store import KnowledgeStore
                 from openjarvis.connectors.sync_engine import SyncEngine
 
-                store = KnowledgeStore()
-                pipeline = IngestionPipeline(store=store)
-                engine = SyncEngine(pipeline=pipeline)
-                engine.sync(inst)
+                with KnowledgeStore() as store:
+                    pipeline = IngestionPipeline(store=store)
+                    engine = SyncEngine(pipeline=pipeline)
+                    engine.sync(inst)
                 logger.info("Sync completed for %s", connector_id)
                 _sync_state[connector_id] = {"state": "complete", "error": None}
             except Exception as exc:

--- a/tests/connectors/test_store.py
+++ b/tests/connectors/test_store.py
@@ -333,3 +333,27 @@ def test_memory_retrieve_event_emitted(tmp_path: Path) -> None:
 
     types = [e.event_type for e in bus.history]
     assert EventType.MEMORY_RETRIEVE in types
+
+
+def test_context_manager_closes_connection(tmp_path: Path) -> None:
+    """Used as a context manager, KnowledgeStore closes its connection on exit."""
+    import sqlite3
+
+    with KnowledgeStore(db_path=tmp_path / "ctx.db") as ks:
+        _store(ks, content="inside with", source="test")
+
+    with pytest.raises(sqlite3.ProgrammingError):
+        ks._conn.execute("SELECT 1")
+
+
+def test_context_manager_closes_on_exception(tmp_path: Path) -> None:
+    """The connection is closed even when the with block raises."""
+    import sqlite3
+
+    ks = KnowledgeStore(db_path=tmp_path / "ctx_exc.db")
+    with pytest.raises(RuntimeError):
+        with ks:
+            raise RuntimeError("boom")
+
+    with pytest.raises(sqlite3.ProgrammingError):
+        ks._conn.execute("SELECT 1")

--- a/tests/server/test_connectors_router.py
+++ b/tests/server/test_connectors_router.py
@@ -19,7 +19,7 @@ def app():
 
     _app = FastAPI()
     router = create_connectors_router()
-    _app.include_router(router)
+    _app.include_router(router, prefix="/v1")
     return TestClient(_app)
 
 
@@ -92,30 +92,3 @@ def test_trigger_sync(app, tmp_path: Path) -> None:
     assert resp.status_code == 200
     data = resp.json()
     assert data["chunks_indexed"] >= 1
-
-
-def test_list_connectors_closes_store_connections(app, monkeypatch) -> None:
-    """GET /v1/connectors closes every KnowledgeStore it opens (regression)."""
-    from openjarvis.connectors import store as store_module
-
-    close_calls = 0
-    original_close = store_module.KnowledgeStore.close
-
-    def counted_close(self: store_module.KnowledgeStore) -> None:
-        nonlocal close_calls
-        close_calls += 1
-        original_close(self)
-
-    monkeypatch.setattr(store_module.KnowledgeStore, "close", counted_close)
-
-    resp = app.get("/v1/connectors")
-    assert resp.status_code == 200
-    num_connectors = len(resp.json()["connectors"])
-    assert num_connectors > 0
-
-    baseline = close_calls
-    polls = 3
-    for _ in range(polls):
-        assert app.get("/v1/connectors").status_code == 200
-
-    assert close_calls - baseline == polls * num_connectors

--- a/tests/server/test_connectors_router.py
+++ b/tests/server/test_connectors_router.py
@@ -19,7 +19,7 @@ def app():
 
     _app = FastAPI()
     router = create_connectors_router()
-    _app.include_router(router, prefix="/v1")
+    _app.include_router(router)
     return TestClient(_app)
 
 
@@ -92,3 +92,30 @@ def test_trigger_sync(app, tmp_path: Path) -> None:
     assert resp.status_code == 200
     data = resp.json()
     assert data["chunks_indexed"] >= 1
+
+
+def test_list_connectors_closes_store_connections(app, monkeypatch) -> None:
+    """GET /v1/connectors closes every KnowledgeStore it opens (regression)."""
+    from openjarvis.connectors import store as store_module
+
+    close_calls = 0
+    original_close = store_module.KnowledgeStore.close
+
+    def counted_close(self: store_module.KnowledgeStore) -> None:
+        nonlocal close_calls
+        close_calls += 1
+        original_close(self)
+
+    monkeypatch.setattr(store_module.KnowledgeStore, "close", counted_close)
+
+    resp = app.get("/v1/connectors")
+    assert resp.status_code == 200
+    num_connectors = len(resp.json()["connectors"])
+    assert num_connectors > 0
+
+    baseline = close_calls
+    polls = 3
+    for _ in range(polls):
+        assert app.get("/v1/connectors").status_code == 200
+
+    assert close_calls - baseline == polls * num_connectors


### PR DESCRIPTION
## What does this PR do?

This PR fixes a file descriptor leak in the connectors router. The backend was crashing with `OSError: [Errno 24] Too many open files` after roughly 100 polls from the web frontend, which on macOS is about a minute of normal use because Apple still ships a default per-process FD limit of 256. KnowledgeStore.__init__ opens a SQLite connection in its constructor. Three places in connectors_router.py create a KnowledgeStore and then just... let it fall out of scope without calling close.

The worst offender is _connector_summary(), which runs once per connector every time the frontend hits /v1/connectors. The frontend polls that endpoint, so you leak "connector count" file descriptors per poll. lsof on the dying backend: 222 of the 256 open files were knowledge.db and knowledge.db-wal handles, all coming from connectors_router.

The actual fix is pretty small:
- Add __enter__ and __exit__ to KnowledgeStore. The close() method already existed, nothing was calling it.
- Wrap the three leak sites in with KnowledgeStore() as store: so the connection actually gets released when the scope exits.

## How was this tested?

Two new tests in tests/connectors/test_store.py for the context manager protocol:
- `test_context_manager_closes_connection`: Opens a store inside a with, then verifies _conn.execute() raises sqlite3.ProgrammingError after the block exits.
- `test_context_manager_closes_on_exception`: Raises inside the "with" block and verifies the connection still got cleaned up properly.

Also reproduced the crash manually by running the full stack (mlx_lm.server + jarvis backend + frontend) and watching lsof -p <backend-pid> while clicking around.  After the patch, the counter stays flat under the same load.

## Checklist

- [x] Tests pass (uv run pytest tests/ -v)
- [x] Linter passes (uv run ruff check src/ tests/)
- [x] Formatter passes (uv run ruff format --check src/ tests/)
- [x] New/changed public API has docstrings
- [x] Follows registry pattern (if adding new component) (N/A)
- [x] Documentation updated (if applicable) (N/A)

## Note for reviewers

While I was in there I noticed tests/server/test_connectors_router.py has a broken fixture. The router declares prefix="/v1/connectors" internally (since commit 31eb2e43 in March), but the test fixture calls include_router(router, prefix="/v1"), which double-prefixes everything to /v1/v1/connectors. All 6 tests in that file would 404 if they actually ran.

BUT the fixture is wrapped in try: import fastapi; except: pytest.skip(), and CI only installs --extra dev, which doesn't pull in fastapi. Every test in that file silently skips on CI. It's been hidden for weeks. Even in commits happening now, I see:

========= 5405 passed, 108 skipped, 8 deselected in 157.44s (0:02:37) ==========

Lots of skipped tests. This should probably be fixed in another PR