### PR TITLE
fix(cloud-router): prevent local HF org models from being misrouted to OpenRouter

### DIFF
--- a/src/openjarvis/server/cloud_router.py
+++ b/src/openjarvis/server/cloud_router.py
@@ -28,6 +28,14 @@ _ANTHROPIC_PREFIXES = ("claude-",)
 _GOOGLE_PREFIXES = ("gemini-",)
 _MINIMAX_PREFIXES = ("MiniMax-",)
 
+# HuggingFace orgs that host local-only quantised models — never route to cloud.
+_LOCAL_HF_ORGS = (
+    "mlx-community/",
+    "bartowski/",
+    "unsloth/",
+    "lmstudio-community/",
+)
+
 
 def _load_keys() -> dict[str, str]:
     """Read cloud-keys.env from disk every call so live updates are picked up."""
@@ -64,6 +72,8 @@ def get_provider(model: str) -> str | None:
         return "google"
     if any(model.startswith(p) for p in _MINIMAX_PREFIXES):
         return "minimax"
+    if any(model.startswith(org) for org in _LOCAL_HF_ORGS):
+        return None  # local model, never route to cloud
     if "/" in model:  # openrouter format: "meta-llama/llama-3-8b"
         return "openrouter"
     return None


### PR DESCRIPTION
## Summary

`get_provider()` routes any model name containing `/` to OpenRouter (line 67 of `cloud_router.py`). This silently sends locally-served HuggingFace org models — such as `mlx-community/Qwen3.5-27B-4bit-DWQ`, `bartowski/`, `unsloth/`, `lmstudio-community/` — to the cloud instead of the local inference server.

- Adds a `_LOCAL_HF_ORGS` module-level allowlist of known local-only HF org prefixes
- Returns `None` early for these before the OpenRouter `/` check
- No behaviour change for genuine OpenRouter models

## Test plan

- [ ] Model `mlx-community/Qwen3.5-27B-4bit-DWQ` resolves to `None` (local) not OpenRouter
- [ ] Model `meta-llama/llama-3-8b` still resolves to OpenRouter as expected
- [ ] Existing cloud router tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)