### PR TITLE
fix: correct import path for build_routing_context in executor

### DIFF
--- a/src/openjarvis/agents/executor.py
+++ b/src/openjarvis/agents/executor.py
@@ -261,7 +261,7 @@ class AgentExecutor:
         if router_policy_key and self._system:
             try:
                 from openjarvis.core.registry import RouterPolicyRegistry
-                from openjarvis.learning.routing.types import (
+                from openjarvis.learning.routing.router import (
                     build_routing_context,
                 )
 


### PR DESCRIPTION
## Summary

- `openjarvis.learning.routing.types` does not exist — it was an in-progress module that was consolidated into `openjarvis.learning.routing.router` before it was created
- The broken import lives inside a `try/except` block in `AgentExecutor`, so it fails silently: the router policy never activates and the executor always falls back to the configured model, ignoring any `router_policy` setting entirely
- One-line fix: change the import to `openjarvis.learning.routing.router` where `build_routing_context` is actually defined and exported

## Test plan

- [ ] Confirm `build_routing_context` is exported from `openjarvis.learning.routing.router`
- [ ] Set a `router_policy` in config and verify the executor now routes correctly instead of always falling back

🤖 Generated with [Claude Code](https://claude.ai/claude-code)