### PR TITLE
feat(evals): per-config max_turns + Phase 2 vLLM settings docs

### DIFF
--- a/src/openjarvis/evals/backends/jarvis_agent.py
+++ b/src/openjarvis/evals/backends/jarvis_agent.py
@@ -25,6 +25,7 @@ class JarvisAgentBackend(InferenceBackend):
         telemetry: bool = False,
         gpu_metrics: bool = False,
         model: Optional[str] = None,
+        max_turns: Optional[int] = None,
     ) -> None:
         from openjarvis.system import SystemBuilder
 
@@ -45,6 +46,12 @@ class JarvisAgentBackend(InferenceBackend):
         # creates a GpuMonitor when building the InstrumentedEngine.
         if gpu_metrics:
             builder._config.telemetry.gpu_metrics = True
+        # Override the agent's per-run turn budget. JarvisConfig.agent.max_turns
+        # defaults to 10, which is too low for thinking/reasoning models on
+        # multi-step agentic benchmarks (Trinity-Large hit the cap on 25/50
+        # GAIA tasks before this was configurable per-eval).
+        if max_turns is not None:
+            builder._config.agent.max_turns = max_turns
         self._system = builder.telemetry(telemetry).traces(True).build()
 
     def generate(

--- a/src/openjarvis/evals/cli.py
+++ b/src/openjarvis/evals/cli.py
@@ -165,6 +165,7 @@ def _build_backend(
     telemetry: bool = False,
     gpu_metrics: bool = False,
     model: Optional[str] = None,
+    max_turns: Optional[int] = None,
 ):
     """Construct the appropriate backend."""
     if backend_name == "jarvis-agent":
@@ -177,6 +178,7 @@ def _build_backend(
             telemetry=telemetry,
             gpu_metrics=gpu_metrics,
             model=model,
+            max_turns=max_turns,
         )
     else:
         from openjarvis.evals.backends.jarvis_direct import JarvisDirectBackend
@@ -651,6 +653,7 @@ def _run_single(config, console: Optional[Console] = None) -> object:
         telemetry=getattr(config, "telemetry", False),
         gpu_metrics=getattr(config, "gpu_metrics", False),
         model=config.model,
+        max_turns=getattr(config, "max_turns", None),
     )
     dataset = _build_dataset(config.benchmark)
     # Inject engine config for benchmarks that run their own simulation

--- a/src/openjarvis/evals/configs/gaia-qwen-2b.toml
+++ b/src/openjarvis/evals/configs/gaia-qwen-2b.toml
@@ -14,7 +14,7 @@ max_tokens = 4096
 engine = "cloud"
 
 [run]
-max_workers = 1
+max_workers = 8
 output_dir = "results/neurips-2026/baselines/qwen-2b/gaia/"
 seed = 42
 

--- a/src/openjarvis/evals/configs/gaia-trinity-large.toml
+++ b/src/openjarvis/evals/configs/gaia-trinity-large.toml
@@ -14,6 +14,10 @@ max_tokens = 4096
 
 [run]
 max_workers = 16
+# Trinity-Large is a "thinking" model — needs more turns to reach an answer.
+# Without this override the agent hits the default max_turns=10 cap on
+# ~50% of GAIA tasks before producing a final answer.
+max_turns = 50
 output_dir = "results/neurips-2026/baselines/gaia-trinity-large/"
 seed = 42
 

--- a/src/openjarvis/evals/configs/liveresearch-qwen-2b.toml
+++ b/src/openjarvis/evals/configs/liveresearch-qwen-2b.toml
@@ -14,7 +14,7 @@ max_tokens = 4096
 engine = "cloud"
 
 [run]
-max_workers = 1
+max_workers = 8
 output_dir = "results/neurips-2026/baselines/qwen-2b/liveresearch/"
 seed = 42
 

--- a/src/openjarvis/evals/configs/liveresearch-trinity-large.toml
+++ b/src/openjarvis/evals/configs/liveresearch-trinity-large.toml
@@ -14,6 +14,10 @@ max_tokens = 4096
 
 [run]
 max_workers = 16
+# Trinity-Large is a "thinking" model — needs more turns to reach an answer.
+# Without this override the agent hits the default max_turns=10 cap on
+# ~78% of LiveResearchBench tasks before producing a final answer.
+max_turns = 50
 output_dir = "results/neurips-2026/baselines/liveresearch-trinity-large/"
 seed = 42
 

--- a/src/openjarvis/evals/configs/taubench-telecom-qwen2b.toml
+++ b/src/openjarvis/evals/configs/taubench-telecom-qwen2b.toml
@@ -13,7 +13,7 @@ temperature = 0.0
 engine = "cloud"
 
 [run]
-max_workers = 1
+max_workers = 8
 output_dir = "results/neurips-2026/baselines/qwen-2b/taubench-telecom/"
 seed = 42
 

--- a/src/openjarvis/evals/core/config.py
+++ b/src/openjarvis/evals/core/config.py
@@ -133,6 +133,9 @@ def load_eval_config(path: str | Path) -> EvalSuiteConfig:
         sheets_spreadsheet_id=run_raw.get("sheets_spreadsheet_id", ""),
         sheets_worksheet=run_raw.get("sheets_worksheet", "Results"),
         sheets_credentials_path=run_raw.get("sheets_credentials_path", ""),
+        max_turns=(
+            int(run_raw["max_turns"]) if "max_turns" in run_raw else None
+        ),
     )
 
     # Parse [[models]]
@@ -293,6 +296,7 @@ def expand_suite(suite: EvalSuiteConfig) -> List[RunConfig]:
                     sheets_spreadsheet_id=suite.run.sheets_spreadsheet_id,
                     sheets_worksheet=suite.run.sheets_worksheet,
                     sheets_credentials_path=suite.run.sheets_credentials_path,
+                    max_turns=suite.run.max_turns,
                 )
             )
 

--- a/src/openjarvis/evals/core/types.py
+++ b/src/openjarvis/evals/core/types.py
@@ -84,6 +84,11 @@ class RunConfig:
     system_prompt: str = ""
     episode_mode: bool = False
     dataset_subset: Optional[str] = None
+    # Override the agent harness's max_turns budget. Default None means use
+    # the JarvisConfig.agent.max_turns value (typically 10). Set higher when
+    # running thinking/reasoning models that consume turns on intermediate
+    # reasoning before producing tool calls.
+    max_turns: Optional[int] = None
 
 
 @dataclass(slots=True)
@@ -202,6 +207,10 @@ class ExecutionConfig:
     sheets_spreadsheet_id: str = ""
     sheets_worksheet: str = "Results"
     sheets_credentials_path: str = ""
+    # Override the agent harness's per-run max_turns budget. None falls back
+    # to JarvisConfig.agent.max_turns (default 10). Bump to 30-50 for
+    # thinking/reasoning models on agentic benchmarks (GAIA, LiveResearch).
+    max_turns: Optional[int] = None
 
 
 @dataclass(slots=True)


### PR DESCRIPTION
## Summary

- **Per-config `max_turns`**: Add `[run] max_turns` field to eval TOML configs, plumbed through `JarvisAgentBackend` to `JarvisConfig.agent.max_turns`. Defaults to `None` (inherits the JarvisConfig default of 10) so existing configs are unaffected.
- **`docs/development/eval-vllm-settings.md`**: New page documenting the per-model-family vLLM startup flags discovered while running Phase 2 — including the Trinity-Large `--reasoning-parser deepseek_r1` empty-content bug, the Qwen tool parser pitfall, and reference vLLM commands for each model family.
- **Config updates**: Bump max_workers=1→8 on the three Qwen 2B Phase 2 configs (gaia, lr, taubench-telecom). Add `max_turns = 50` to `gaia-trinity-large.toml` and `liveresearch-trinity-large.toml` using the new field.

## Why

While running Phase 2 baselines we discovered three non-obvious issues that silently produce wrong scores rather than crashing. Each one cost a 20-60 point swing on its respective benchmark:

| Issue | Impact (Trinity-Large) |
|---|---|
| `--reasoning-parser deepseek_r1` routes entire output to `reasoning_content`, leaving `content=""` | GAIA 12% → **42%** |
| `agent.max_turns=10` default too low for thinking models (cap hit on 78% of LR tasks) | LiveResearchBench 12% → **72%** |
| Wrong `--tool-call-parser` for Qwen series (`hermes` instead of `qwen3_coder`) | Qwen-2B GAIA 0% → **6%** |

The first issue is documented (you serve without the parser). The second is the source-code change in this PR — without it, the only workaround is a runtime `OPENJARVIS_CONFIG` TOML hack with `[agent] max_turns = 50`. The third is documented.

## Files changed (10)

**Source (4):**
- `src/openjarvis/evals/core/types.py` — add `max_turns: Optional[int] = None` to both `RunConfig` and `ExecutionConfig`
- `src/openjarvis/evals/core/config.py` — parse `[run] max_turns` from TOML, propagate suite→RunConfig
- `src/openjarvis/evals/backends/jarvis_agent.py` — accept `max_turns`, set `builder._config.agent.max_turns` before `.build()`
- `src/openjarvis/evals/cli.py` — pass `config.max_turns` through `_build_backend`

**Configs (5):**
- `gaia-qwen-2b.toml`, `liveresearch-qwen-2b.toml`, `taubench-telecom-qwen2b.toml` — `max_workers = 1 → 8`
- `gaia-trinity-large.toml`, `liveresearch-trinity-large.toml` — add `max_turns = 50` (uses the new field)

**Docs (1):**
- `docs/development/eval-vllm-settings.md` — new page

## Test plan

- [x] 119/119 evaluation framework tests pass locally (`tests/evals/`)
- [x] `load_eval_config()` correctly parses `max_turns = 50` (Trinity configs) and `None` (existing Qwen-27B configs) — verified with a sanity import
- [x] Empirically validated end-to-end on H100 cluster: Trinity-Large GAIA 12% → 42% and LR 12% → 72% with `max_turns=50` and the deepseek_r1 parser removed
- [x] Backwards compat: any config without `[run] max_turns` continues to use `JarvisConfig.agent.max_turns` (default 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)