### PR TITLE
fix(connectors): prevent Apple Music connector from launching Music.app

### DIFF
--- a/src/openjarvis/connectors/apple_music.py
+++ b/src/openjarvis/connectors/apple_music.py
@@ -26,9 +26,18 @@ logger = logging.getLogger(__name__)
 # AppleScript helpers
 # ---------------------------------------------------------------------------
 
-_LIBRARY_CHECK_SCRIPT = 'tell application "Music" to get name of playlist "Library"'
+_LIBRARY_CHECK_SCRIPT = """
+if application "Music" is running then
+    tell application "Music" to get name of playlist "Library"
+else
+    error "Music is not running"
+end if
+"""
 
 _TRACKS_SCRIPT = """
+if not (application "Music" is running) then
+    error "Music is not running"
+end if
 tell application "Music"
     set output to ""
     set allTracks to every track of playlist "Library"


### PR DESCRIPTION
## Problem

On macOS, opening the OpenJarvis web app causes Music.app to launch automatically — even if the user has never configured or used the Apple Music connector. Closing the app doesn't help: it relaunches within minutes. The behaviour persists whether or not the user has the web app in focus.

This is disorienting because there is no visible link between OpenJarvis and Music.app. Users have no reason to suspect their local web app is responsible.

## Root cause

AppleScript's `tell application "X"` directive is an implicit launch command — macOS will start the named application if it is not already running. Both scripts in `apple_music.py` used this pattern unconditionally:

```applescript
tell application "Music" to get name of playlist "Library"  -- is_connected()
tell application "Music" ...                                 -- sync()
```

`is_connected()` is called on every connector status poll: once on frontend load, and repeatedly by the background `SyncScheduler`. Because `apple_music` is registered by default, this ran for every macOS user regardless of whether they use Apple Music.

## Fix

Wrap both AppleScript blocks with an `application "Music" is running` guard. If Music is not open, the script exits with a non-zero code, `_run_osascript` returns `None`, and `is_connected()` returns `False` — without touching Music.app.

```applescript
if application "Music" is running then
    tell application "Music" to get name of playlist "Library"
else
    error "Music is not running"
end if
```

The connector now behaves correctly in both states: returns `connected = true` when Music is open, `connected = false` when it is not, and never launches it unsolicited.

## Test plan

- [ ] Start OpenJarvis with Music.app closed — confirm it does not launch
- [ ] Open the web app data sources panel — confirm Apple Music shows as disconnected, Music.app stays closed
- [ ] Open Music.app manually, reload — confirm Apple Music shows as connected
- [ ] Run `uv run pytest tests/connectors/test_apple_music.py -v`