### PR TITLE
Security: Panic on malformed hex input in signature verification (DoS risk)

### DIFF
--- a/rust/crates/openjarvis-python/src/skills.rs
+++ b/rust/crates/openjarvis-python/src/skills.rs
@@ -48,10 +48,18 @@ impl PySkillManifest {
     }
 
     fn verify_signature(&self, public_key_hex: &str) -> bool {
-        let key_bytes: Vec<u8> = (0..public_key_hex.len())
-            .step_by(2)
-            .filter_map(|i| u8::from_str_radix(&public_key_hex[i..i + 2], 16).ok())
-            .collect();
+        if public_key_hex.len() % 2 != 0 {
+            return false;
+        }
+
+        let mut key_bytes = Vec::with_capacity(public_key_hex.len() / 2);
+        for i in (0..public_key_hex.len()).step_by(2) {
+            match u8::from_str_radix(&public_key_hex[i..i + 2], 16) {
+                Ok(byte) => key_bytes.push(byte),
+                Err(_) => return false,
+            }
+        }
+
         openjarvis_skills::verify_signature(&self.inner, &key_bytes)
     }
 }


### PR DESCRIPTION
## Summary

Security: Panic on malformed hex input in signature verification (DoS risk)

## Problem

**Severity**: `High` | **File**: `rust/crates/openjarvis-python/src/skills.rs:L45`

`verify_signature` slices `public_key_hex[i..i + 2]` without validating that the input length is even. An odd-length or otherwise malformed string can trigger an out-of-bounds panic, which may crash the process (or at minimum terminate the request path), creating a denial-of-service vector if this method is reachable from untrusted input.

## Solution

Validate input before slicing (e.g., reject non-hex chars and require even length). Prefer a safe decoder like `hex::decode(public_key_hex)` and return `false` or a `PyResult` error on decode failure instead of panicking.

## Changes

- `rust/crates/openjarvis-python/src/skills.rs` (modified)