### PR TITLE
perf: replace agents polling with WebSocket, fix workbox prod mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ MagicMock/
 
 # Second Repos
 Inline/
+
+# Local git worktrees
+.worktrees/

--- a/frontend/src/lib/useAgentEvents.ts
+++ b/frontend/src/lib/useAgentEvents.ts
@@ -1,0 +1,90 @@
+import { useEffect, useRef } from 'react';
+import { getBase } from './api';
+
+export interface AgentEvent {
+  type: string;
+  timestamp: number;
+  data: Record<string, unknown>;
+}
+
+function buildWsUrl(agentId?: string): string {
+  const base = getBase();
+  let origin: string;
+  if (base) {
+    origin = base.replace(/^http/, 'ws');
+  } else {
+    const loc = window.location;
+    origin = `${loc.protocol === 'https:' ? 'wss:' : 'ws:'}//${loc.host}`;
+  }
+  const path = '/v1/agents/events';
+  return agentId
+    ? `${origin}${path}?agent_id=${encodeURIComponent(agentId)}`
+    : `${origin}${path}`;
+}
+
+/**
+ * Subscribe to agent events over WebSocket.
+ * Auto-reconnects with backoff when the socket drops.
+ */
+export function useAgentEvents(
+  agentId: string | undefined,
+  onEvent: (event: AgentEvent) => void,
+  eventTypes?: readonly string[],
+): void {
+  const onEventRef = useRef(onEvent);
+  onEventRef.current = onEvent;
+  const typesRef = useRef(eventTypes);
+  typesRef.current = eventTypes;
+
+  useEffect(() => {
+    if (!agentId) return;
+    let ws: WebSocket | null = null;
+    let closed = false;
+    let retry = 0;
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const connect = () => {
+      if (closed) return;
+      try {
+        ws = new WebSocket(buildWsUrl(agentId));
+      } catch {
+        schedule();
+        return;
+      }
+      ws.onopen = () => {
+        retry = 0;
+      };
+      ws.onmessage = (msg) => {
+        try {
+          const payload = JSON.parse(msg.data) as AgentEvent;
+          const allowed = typesRef.current;
+          if (allowed && !allowed.includes(payload.type)) return;
+          onEventRef.current(payload);
+        } catch {
+          // ignore malformed payload
+        }
+      };
+      ws.onclose = () => {
+        if (!closed) schedule();
+      };
+      ws.onerror = () => {
+        ws?.close();
+      };
+    };
+
+    const schedule = () => {
+      if (closed) return;
+      const delay = Math.min(30000, 1000 * 2 ** Math.min(retry, 5));
+      retry += 1;
+      reconnectTimer = setTimeout(connect, delay);
+    };
+
+    connect();
+
+    return () => {
+      closed = true;
+      if (reconnectTimer) clearTimeout(reconnectTimer);
+      ws?.close();
+    };
+  }, [agentId]);
+}

--- a/frontend/src/pages/AgentsPage.tsx
+++ b/frontend/src/pages/AgentsPage.tsx
@@ -32,6 +32,7 @@ import {
   sendblueHealth,
 } from '../lib/api';
 import type { AgentTask, ChannelBinding, AgentTemplate, AgentMessage, ManagedAgent, LearningLogEntry, AgentTrace, ToolInfo } from '../lib/api';
+import { useAgentEvents } from '../lib/useAgentEvents';
 import {
   Plus,
   Bot,
@@ -1332,9 +1333,20 @@ function InteractTab({ agentId, agentStatus }: { agentId: string; agentStatus: s
 
   useEffect(() => {
     loadData();
-    const interval = setInterval(loadData, 2000);
+    // Fallback slow poll — WS is primary, this catches missed events / dropped sockets
+    const interval = setInterval(loadData, 30000);
     return () => clearInterval(interval);
   }, [loadData]);
+
+  // Event-driven refresh — fires when the server reports agent activity
+  useAgentEvents(agentId, loadData, [
+    'agent_tick_start',
+    'agent_tick_end',
+    'agent_tick_error',
+    'agent_message_received',
+    'tool_call_end',
+    'inference_end',
+  ]);
 
   useEffect(() => { setLiveStatus(agentStatus); }, [agentStatus]);
 
@@ -2854,9 +2866,19 @@ function LogsTab({ agentId }: { agentId: string }) {
 
   useEffect(() => {
     loadData();
-    const interval = setInterval(loadData, 5000);
+    // Fallback slow poll — WS is primary, this catches missed events
+    const interval = setInterval(loadData, 30000);
     return () => clearInterval(interval);
   }, [loadData]);
+
+  // Event-driven refresh — trace/learning entries are created by tick + tool events
+  useAgentEvents(agentId, loadData, [
+    'agent_tick_end',
+    'agent_tick_error',
+    'tool_call_end',
+    'inference_end',
+    'agent_learning_completed',
+  ]);
 
   // Merge traces and learning entries into a unified timeline
   type TimelineEntry =

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -30,7 +30,6 @@ export default defineConfig({
       workbox: {
         globPatterns: ['**/*.{js,css,html,ico,png,svg}'],
         navigateFallbackDenylist: [/^\/v1\//, /^\/health/, /^\/dashboard/],
-        mode: 'development',
       },
     }),
   ],

--- a/rust/crates/openjarvis-learning/src/icl_updater.rs
+++ b/rust/crates/openjarvis-learning/src/icl_updater.rs
@@ -141,7 +141,7 @@ impl ICLUpdaterPolicy {
             }
         }
 
-        skills.sort_by(|a, b| b.occurrences.cmp(&a.occurrences));
+        skills.sort_by_key(|s| std::cmp::Reverse(s.occurrences));
         self.discovered_skills = skills;
         &self.discovered_skills
     }

--- a/rust/crates/openjarvis-learning/src/training_data.rs
+++ b/rust/crates/openjarvis-learning/src/training_data.rs
@@ -219,7 +219,7 @@ impl TrainingDataMiner {
                 }
             }
             let mut ranked: Vec<_> = tool_freq.into_iter().collect();
-            ranked.sort_by(|a, b| b.1.cmp(&a.1));
+            ranked.sort_by_key(|r| std::cmp::Reverse(r.1));
             let best_tools: Vec<String> = ranked.into_iter().map(|(name, _)| name).collect();
 
             let all_scores: Vec<f64> = agent_scores.values().flat_map(|v| v.iter().copied()).collect();

--- a/rust/crates/openjarvis-workflow/src/lib.rs
+++ b/rust/crates/openjarvis-workflow/src/lib.rs
@@ -136,13 +136,10 @@ impl WorkflowGraph {
                 continue;
             }
             if let Some(&vi) = self.node_index.get(&edge.target) {
-                match color[vi] {
+                let c = color[vi];
+                match c {
                     1 => return true,
-                    0 => {
-                        if self.dfs_has_cycle(vi, color) {
-                            return true;
-                        }
-                    }
+                    0 if self.dfs_has_cycle(vi, color) => return true,
                     _ => {}
                 }
             }


### PR DESCRIPTION
Fixes #227 (partial — see scope note below).

## Summary
- **InteractTab (2s) and LogsTab (5s) polls → WebSocket-driven refresh** against the existing but unused `/v1/agents/events` endpoint, with a 30s fallback poll for resilience if the socket drops.
- **New `useAgentEvents` hook** (`frontend/src/lib/useAgentEvents.ts`) — subscribes to `/v1/agents/events?agent_id=X`, filters by event type, auto-reconnects with exponential backoff.
- **Workbox prod caching re-enabled** — removed `workbox.mode: 'development'` from `vite.config.ts`, which was silently disabling the Service Worker in production builds.

## Net effect
Idle `/agents/:id` goes from ~42 req/min (2s + 5s polls) down to ~2 req/min (30s fallbacks), with the WS pushing updates in real time.

## Scope notes
- **Lazy-loading `AgentsPage`** — intentionally skipped. The issue flagged the 3,589-line file as bundle bloat, but this is a Tauri desktop app served from localhost, so code-splitting a single route is low-value. Left as-is.
- **Connectors 10s poll** (`AgentsPage.tsx:1605`) — left in place. Server WS doesn't emit events for OAuth connector completions, so no WS path exists.
- **Error-toast 30s poll** (`AgentsPage.tsx:3122`) — left in place. Already low frequency; refactoring wasn't worth the churn.

## Test plan
- [x] `npm run build` succeeds in `frontend/`
- [x] Navigate to `/agents`, open an agent detail view → verify messages and status update live without the old 2s flicker
- [x] Check DevTools Network tab → InteractTab should show a WS connection to `/v1/agents/events?agent_id=...` and one HTTP fetch per ~30s (not every 2s)
- [ ] Kill the WS mid-session (e.g. stop the server briefly) → fallback poll keeps the tab functional; WS reconnects when server returns
- [ ] Production build: verify Service Worker is registered and caching `.js`/`.css` assets (was broken by `mode: 'development'`)