### PR TITLE
test: add live marker, CI coverage gate, rust bridge boundary tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,20 @@ jobs:
         run: uv run maturin develop --manifest-path rust/crates/openjarvis-python/Cargo.toml
 
       - name: Run tests
-        run: uv run pytest tests/ -v --tb=short -m "not live and not cloud"
+        run: |
+          uv run pytest tests/ -v --tb=short -m "not live and not cloud" \
+            --cov=openjarvis \
+            --cov-report=term-missing \
+            --cov-report=xml \
+            --cov-fail-under=60
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml
+          path: coverage.xml
+          if-no-files-found: warn
 
   rust:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ MagicMock/
 
 # Second Repos
 Inline/
+
+# Local git worktrees
+.worktrees/

--- a/rust/crates/openjarvis-learning/src/icl_updater.rs
+++ b/rust/crates/openjarvis-learning/src/icl_updater.rs
@@ -141,7 +141,7 @@ impl ICLUpdaterPolicy {
             }
         }
 
-        skills.sort_by(|a, b| b.occurrences.cmp(&a.occurrences));
+        skills.sort_by_key(|s| std::cmp::Reverse(s.occurrences));
         self.discovered_skills = skills;
         &self.discovered_skills
     }

--- a/rust/crates/openjarvis-learning/src/training_data.rs
+++ b/rust/crates/openjarvis-learning/src/training_data.rs
@@ -219,7 +219,7 @@ impl TrainingDataMiner {
                 }
             }
             let mut ranked: Vec<_> = tool_freq.into_iter().collect();
-            ranked.sort_by(|a, b| b.1.cmp(&a.1));
+            ranked.sort_by_key(|r| std::cmp::Reverse(r.1));
             let best_tools: Vec<String> = ranked.into_iter().map(|(name, _)| name).collect();
 
             let all_scores: Vec<f64> = agent_scores.values().flat_map(|v| v.iter().copied()).collect();

--- a/rust/crates/openjarvis-workflow/src/lib.rs
+++ b/rust/crates/openjarvis-workflow/src/lib.rs
@@ -136,13 +136,10 @@ impl WorkflowGraph {
                 continue;
             }
             if let Some(&vi) = self.node_index.get(&edge.target) {
-                match color[vi] {
+                let c = color[vi];
+                match c {
                     1 => return true,
-                    0 => {
-                        if self.dfs_has_cycle(vi, color) {
-                            return true;
-                        }
-                    }
+                    0 if self.dfs_has_cycle(vi, color) => return true,
                     _ => {}
                 }
             }

--- a/tests/connectors/test_live_smoke.py
+++ b/tests/connectors/test_live_smoke.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import tempfile
 from pathlib import Path
 
+import pytest
+
 from openjarvis.connectors.obsidian import ObsidianConnector
 from openjarvis.connectors.pipeline import IngestionPipeline
 from openjarvis.connectors.store import KnowledgeStore
@@ -19,6 +21,7 @@ from openjarvis.tools.knowledge_search import KnowledgeSearchTool
 DOCS_DIR = Path(__file__).resolve().parents[2] / "docs"
 
 
+@pytest.mark.live
 def test_live_obsidian_full_pipeline() -> None:
     """Smoke test: index real .md files, then search them."""
     assert DOCS_DIR.is_dir(), f"Docs dir not found: {DOCS_DIR}"

--- a/tests/core/test_rust_bridge.py
+++ b/tests/core/test_rust_bridge.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 
 class TestGetRustModule:
     """Test get_rust_module() returns the Rust extension module."""
@@ -125,6 +127,122 @@ class TestRetrievalResultsFromJson:
         ]
         results = retrieval_results_from_json(json.dumps(data))
         assert results[0].metadata == {"nested": True}
+
+
+class TestConverterInvalidInputs:
+    """Boundary behavior: malformed JSON and missing/unexpected fields."""
+
+    def test_scan_result_malformed_json_raises(self):
+        from openjarvis._rust_bridge import scan_result_from_json
+
+        with pytest.raises(json.JSONDecodeError):
+            scan_result_from_json("{not json")
+
+    def test_scan_result_missing_findings_key_is_clean(self):
+        from openjarvis._rust_bridge import scan_result_from_json
+
+        result = scan_result_from_json("{}")
+        assert result.clean
+        assert result.findings == []
+
+    def test_scan_result_unknown_threat_level_raises(self):
+        from openjarvis._rust_bridge import scan_result_from_json
+
+        data = {
+            "findings": [
+                {
+                    "pattern_name": "x",
+                    "matched_text": "y",
+                    "threat_level": "not-a-level",
+                    "start": 0,
+                    "end": 1,
+                    "description": "",
+                },
+            ],
+        }
+        with pytest.raises(ValueError):
+            scan_result_from_json(json.dumps(data))
+
+    def test_scan_result_finding_missing_fields_uses_defaults(self):
+        from openjarvis._rust_bridge import scan_result_from_json
+
+        result = scan_result_from_json('{"findings": [{}]}')
+        assert not result.clean
+        finding = result.findings[0]
+        assert finding.pattern_name == ""
+        assert finding.matched_text == ""
+        assert finding.threat_level.value == "low"
+        assert finding.start == 0
+        assert finding.end == 0
+
+    def test_injection_result_malformed_json_raises(self):
+        from openjarvis._rust_bridge import injection_result_from_json
+
+        with pytest.raises(json.JSONDecodeError):
+            injection_result_from_json("")
+
+    def test_injection_result_unknown_top_level_threat_defaults_to_low(self):
+        from openjarvis._rust_bridge import injection_result_from_json
+
+        data = {
+            "is_clean": True,
+            "findings": [],
+            "threat_level": "bogus",
+        }
+        result = injection_result_from_json(json.dumps(data))
+        assert result.threat_level.value == "low"
+
+    def test_injection_result_missing_keys_uses_defaults(self):
+        from openjarvis._rust_bridge import injection_result_from_json
+
+        result = injection_result_from_json("{}")
+        assert result.is_clean is True
+        assert result.findings == []
+        assert result.threat_level.value == "low"
+
+    def test_retrieval_results_malformed_json_raises(self):
+        from openjarvis._rust_bridge import retrieval_results_from_json
+
+        with pytest.raises(json.JSONDecodeError):
+            retrieval_results_from_json("not-json")
+
+    def test_retrieval_results_metadata_invalid_json_string_falls_back_to_empty(self):
+        from openjarvis._rust_bridge import retrieval_results_from_json
+
+        data = [
+            {
+                "content": "c",
+                "score": 0.1,
+                "source": "s",
+                "metadata": "{not valid json",
+            },
+        ]
+        results = retrieval_results_from_json(json.dumps(data))
+        assert results[0].metadata == {}
+
+    def test_retrieval_results_missing_fields_uses_defaults(self):
+        from openjarvis._rust_bridge import retrieval_results_from_json
+
+        results = retrieval_results_from_json("[{}]")
+        assert len(results) == 1
+        assert results[0].content == ""
+        assert results[0].score == 0.0
+        assert results[0].source == ""
+        assert results[0].metadata == {}
+
+    def test_retrieval_results_score_string_coerced_to_float(self):
+        from openjarvis._rust_bridge import retrieval_results_from_json
+
+        data = [{"content": "x", "score": "2.5", "source": "", "metadata": {}}]
+        results = retrieval_results_from_json(json.dumps(data))
+        assert results[0].score == 2.5
+
+    def test_retrieval_results_non_iterable_top_level_raises(self):
+        from openjarvis._rust_bridge import retrieval_results_from_json
+
+        # Top-level must be a list; a bare number has no iteration.
+        with pytest.raises(TypeError):
+            retrieval_results_from_json("42")
 
 
 class TestRustBackedModules:


### PR DESCRIPTION
Closes #223.

## Summary
- Mark `test_live_obsidian_full_pipeline` with `@pytest.mark.live` so the CI filter `-m "not live and not cloud"` deselects it.
- Run pytest under coverage in CI: `--cov=openjarvis`, term-missing + xml reports, `--cov-fail-under=60` (current baseline measured at ~63%), and upload `coverage.xml` as an artifact.
- Add 12 boundary tests for the rust bridge JSON converters (`scan_result_from_json`, `injection_result_from_json`, `retrieval_results_from_json`) covering malformed JSON, missing keys, unknown threat levels, metadata decode failure, score coercion, and non-list top-level inputs.

## Notes / deviations from issue
- Issue suggested `--cov=src/openjarvis`; coverage takes module names not paths, so this PR uses `--cov=openjarvis`.
- Skipped `codecov/codecov-action@v4` because it would need a `CODECOV_TOKEN` secret to be configured — artifact upload gives visibility without new repo config. Easy to add later.
- Out of scope but worth flagging: `tests/server/test_agent_manager_routes.py` and `tests/server/test_connectors_router.py` have ~13 tests already failing on `main` due to stale fixtures. Those need a separate fix before the new coverage gate is useful in CI.

## Test plan
- [x] `pytest tests/core/test_rust_bridge.py` — 23 passed (11 existing + 12 new)
- [x] `pytest tests/connectors/test_live_smoke.py -m "not live and not cloud" --collect-only` — 1 deselected (confirms marker works)
- [x] Full suite with coverage locally — 5832 passed, baseline coverage 63%
- [ ] CI run against this PR