### PR TITLE
adding TTS for morning digest

### DIFF
--- a/src/openjarvis/agents/morning_digest.py
+++ b/src/openjarvis/agents/morning_digest.py
@@ -202,6 +202,7 @@ class MorningDigestAgent(ToolUsingAgent):
         tts_text = re.sub(r"\*{1,2}([^*]+)\*{1,2}", r"\1", tts_text)
         tts_text = tts_text.strip()
 
+        output_dir = str(Path.home() / ".openjarvis" / "digests")
         tts_call = ToolCall(
             id="digest-tts-1",
             name="text_to_speech",
@@ -211,6 +212,7 @@ class MorningDigestAgent(ToolUsingAgent):
                     "voice_id": self._voice_id,
                     "backend": self._tts_backend,
                     "speed": self._voice_speed,
+                    "output_dir": output_dir,
                 }
             ),
         )

--- a/src/openjarvis/cli/digest_cmd.py
+++ b/src/openjarvis/cli/digest_cmd.py
@@ -184,10 +184,36 @@ def digest(
             from openjarvis.sdk import Jarvis
 
             with Jarvis() as j:
-                result = j.ask("Generate my morning digest", agent="morning_digest")
-                console.print(Markdown(result))
+                j.ask("Generate my morning digest", agent="morning_digest")
         except Exception as exc:
             console.print(f"[red]Failed to generate digest: {exc}[/red]")
+            store.close()
+            return
+
+        # Reload the freshly-generated digest from the store and play audio
+        store.close()
+        store = DigestStore(db_path=db_path) if db_path else DigestStore()
+        artifact = store.get_latest()
+        if artifact is None:
+            console.print("[red]Digest was not saved.[/red]")
+            store.close()
+            return
+
+        audio_path = str(artifact.audio_path)
+        console.print(f"[dim]Audio path: '{audio_path}'[/dim]")
+        has_audio = bool(audio_path) and artifact.audio_path.exists()
+        console.print(f"[dim]Audio available: {has_audio}[/dim]")
+        if has_audio:
+            audio_thread = threading.Thread(
+                target=_play_audio, args=(audio_path,), daemon=True
+            )
+            audio_thread.start()
+            console.print("[dim]Playing audio...[/dim]")
+        else:
+            console.print("[yellow]Audio unavailable — TTS failed.[/yellow]")
+            console.print("[yellow]Check OPENAI_API_KEY is set.[/yellow]")
+
+        console.print(Markdown(artifact.text))
         store.close()
         return
 

--- a/src/openjarvis/tools/text_to_speech.py
+++ b/src/openjarvis/tools/text_to_speech.py
@@ -59,6 +59,8 @@ class TextToSpeechTool(BaseTool):
         text = params.get("text", "")
         voice_id = params.get("voice_id", "")
         backend_key = params.get("backend", "cartesia")
+        _ALIASES = {"openai": "openai_tts"}
+        backend_key = _ALIASES.get(backend_key, backend_key)
         output_dir = params.get("output_dir", "")
         speed = float(params.get("speed", 1.0))
 


### PR DESCRIPTION
## What does this PR do?

adding TTS for morning digest using openai ; 

## How was this tested?

i ram the morning digest using `jarvis digest --fresh` and i added these logs to : 

```
Generating fresh digest...
Audio path: '~/.openjarvis/digests/digest.mp3'
Audio available: True
Playing audio...
```

## Checklist

- [ ] Tests pass (`uv run pytest tests/ -v`)
- [x] Linter passes (`uv run ruff check src/ tests/`) 
- [x] Formatter passes (`uv run ruff format --check src/ tests/`)
- [ ] New/changed public API has docstrings
- [ ] Follows registry pattern (if adding new component)
- [ ] Documentation updated (if applicable)
