### PR TITLE
feat(cockpit): add Jarvis personal runtime dashboard

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useCallback, useRef } from 'react';
 import { Routes, Route } from 'react-router';
+import { useLocation } from 'react-router';
 import { Layout } from './components/Layout';
 import { ChatPage } from './pages/ChatPage';
 import { DashboardPage } from './pages/DashboardPage';
@@ -8,6 +9,7 @@ import { GetStartedPage } from './pages/GetStartedPage';
 import { AgentsPage } from './pages/AgentsPage';
 import { DataSourcesPage } from './pages/DataSourcesPage';
 import { LogsPage } from './pages/LogsPage';
+import { JarvisPersonalPage } from './pages/JarvisPersonalPage';
 import { CommandPalette } from './components/CommandPalette';
 import { SetupScreen } from './components/SetupScreen';
 import { Toaster } from './components/ui/sonner';
@@ -16,6 +18,8 @@ import { fetchModels, fetchServerInfo, fetchSavings, submitSavings, isTauri } fr
 import { OptInModal } from './components/OptInModal';
 
 export default function App() {
+  const location = useLocation();
+  const isPersonalCockpit = location.pathname === '/jarvis-personal';
   const [setupDone, setSetupDone] = useState(!isTauri());
   const handleSetupReady = useCallback(() => setSetupDone(true), []);
   const setModels = useAppStore((s) => s.setModels);
@@ -36,6 +40,8 @@ export default function App() {
   const setOptInModalOpen = useAppStore((s) => s.setOptInModalOpen);
   const markOptInModalSeen = useAppStore((s) => s.markOptInModalSeen);
   const savings = useAppStore((s) => s.savings);
+  const modelsLoadedRef = useRef(false);
+  const serverInfoLoadedRef = useRef(false);
 
   // Apply theme class to <html>
   useEffect(() => {
@@ -56,22 +62,27 @@ export default function App() {
 
   // Fetch models on mount
   useEffect(() => {
+    if (isPersonalCockpit || modelsLoadedRef.current) return;
     fetchModels()
       .then((m) => {
+        modelsLoadedRef.current = true;
         setModels(m);
         if (!selectedModel && m.length > 0) setSelectedModel(m[0].id);
       })
       .catch(() => setModels([]))
       .finally(() => setModelsLoading(false));
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [isPersonalCockpit]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Fetch server info
   useEffect(() => {
+    if (isPersonalCockpit || serverInfoLoadedRef.current) return;
+    serverInfoLoadedRef.current = true;
     fetchServerInfo().then(setServerInfo).catch(() => {});
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [isPersonalCockpit]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Poll savings and optionally share to Supabase
   useEffect(() => {
+    if (isPersonalCockpit) return;
     const refresh = () =>
       fetchSavings()
         .then((data) => {
@@ -106,7 +117,7 @@ export default function App() {
     refresh();
     const interval = setInterval(refresh, 30000);
     return () => clearInterval(interval);
-  }, [optInEnabled, optInDisplayName, optInAnonId]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [isPersonalCockpit, optInEnabled, optInDisplayName, optInAnonId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Show opt-in modal on first visit
   useEffect(() => {
@@ -173,6 +184,7 @@ export default function App() {
         <Route element={<Layout />}>
           <Route index element={<ChatPage />} />
           <Route path="dashboard" element={<DashboardPage />} />
+          <Route path="jarvis-personal" element={<JarvisPersonalPage />} />
           <Route path="settings" element={<SettingsPage />} />
           <Route path="get-started" element={<GetStartedPage />} />
           <Route path="data-sources" element={<DataSourcesPage />} />

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Outlet, useNavigate } from 'react-router';
+import { Outlet, useLocation, useNavigate } from 'react-router';
 import { Sidebar } from './Sidebar/Sidebar';
 import { SystemPulse } from './SystemPulse';
 import { useAppStore } from '../lib/store';
@@ -8,10 +8,15 @@ import { checkHealth } from '../lib/api';
 export function Layout() {
   const sidebarOpen = useAppStore((s) => s.sidebarOpen);
   const [apiReachable, setApiReachable] = useState<boolean | null>(null);
+  const location = useLocation();
+  const isPersonalCockpit = location.pathname === '/jarvis-personal';
 
   useEffect(() => {
     const check = () => checkHealth().then(setApiReachable);
     check();
+    if (isPersonalCockpit) {
+      return;
+    }
     const interval = setInterval(check, 30000);
     const onFocus = () => check();
     window.addEventListener('focus', onFocus);
@@ -19,7 +24,7 @@ export function Layout() {
       clearInterval(interval);
       window.removeEventListener('focus', onFocus);
     };
-  }, []);
+  }, [isPersonalCockpit]);
 
   const navigate = useNavigate();
 

--- a/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.tsx
@@ -17,6 +17,7 @@ import {
   Loader2,
   ScrollText,
   Database,
+  RadioTower,
 } from 'lucide-react';
 import { ConversationList } from './ConversationList';
 import { useAppStore } from '../../lib/store';
@@ -53,6 +54,7 @@ export function Sidebar() {
 
   const navItems = [
     { path: '/', icon: MessageSquare, label: 'Chat' },
+    { path: '/jarvis-personal', icon: RadioTower, label: 'Jarvis Personal' },
     { path: '/dashboard', icon: BarChart3, label: 'Dashboard' },
     { path: '/data-sources', icon: Database, label: 'Data Sources' },
     { path: '/agents', icon: Bot, label: 'Agents' },

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { ModelInfo, SavingsData, ServerInfo } from '../types';
+import type { ModelInfo, PersonalCockpitSnapshot, SavingsData, ServerInfo } from '../types';
 
 // ---------------------------------------------------------------------------
 // Supabase config — safe to embed (RLS protects writes)
@@ -219,6 +219,12 @@ export async function fetchTelemetry(): Promise<unknown> {
   }
   const res = await fetch(`${getBase()}/v1/telemetry/stats`);
   if (!res.ok) throw new Error(`Failed: ${res.status}`);
+  return res.json();
+}
+
+export async function fetchPersonalCockpit(): Promise<PersonalCockpitSnapshot> {
+  const res = await fetch(`${getBase()}/v1/personal-cockpit`);
+  if (!res.ok) throw new Error(`Failed to fetch personal cockpit: ${res.status}`);
   return res.json();
 }
 

--- a/frontend/src/pages/JarvisPersonalPage.tsx
+++ b/frontend/src/pages/JarvisPersonalPage.tsx
@@ -1,0 +1,1302 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  AlertTriangle,
+  CheckCircle2,
+  ChevronDown,
+  Copy,
+  Clock3,
+  Loader2,
+  Mail,
+  Mic,
+  MoveRight,
+  Radio,
+  RefreshCw,
+  ShieldCheck,
+  Sparkles,
+  Waves,
+} from 'lucide-react';
+import { toast } from 'sonner';
+import { fetchPersonalCockpit } from '../lib/api';
+import type { PersonalCockpitRecord, PersonalCockpitSnapshot } from '../types';
+
+function fmtDate(value?: string) {
+  if (!value) return 'n/a';
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return value;
+  return d.toLocaleString();
+}
+
+function fmtAgo(seconds?: number | null) {
+  if (seconds == null) return 'n/a';
+  if (seconds < 60) return `${seconds}s`;
+  if (seconds < 3600) return `${Math.floor(seconds / 60)} min`;
+  return `${Math.floor(seconds / 3600)} h`;
+}
+
+function toneFromText(value: string) {
+  const text = value.toLowerCase();
+  if (text.includes('ok') || text.includes('active') || text.includes('recent') || text.includes('executed')) {
+    return {
+      color: 'var(--color-success)',
+      bg: 'color-mix(in srgb, var(--color-success) 12%, transparent)',
+      border: 'color-mix(in srgb, var(--color-success) 30%, transparent)',
+    };
+  }
+  if (
+    text.includes('pending') ||
+    text.includes('pause') ||
+    text.includes('warning') ||
+    text.includes('idle') ||
+    text.includes('info')
+  ) {
+    return {
+      color: 'var(--color-warning)',
+      bg: 'color-mix(in srgb, var(--color-warning) 12%, transparent)',
+      border: 'color-mix(in srgb, var(--color-warning) 30%, transparent)',
+    };
+  }
+  return {
+    color: 'var(--color-error)',
+    bg: 'color-mix(in srgb, var(--color-error) 12%, transparent)',
+    border: 'color-mix(in srgb, var(--color-error) 30%, transparent)',
+  };
+}
+
+function Badge({ value }: { value: string }) {
+  const tone = toneFromText(value);
+  return (
+    <span
+      className="px-2.5 py-1 rounded-full text-xs font-medium"
+      style={{ color: tone.color, background: tone.bg, border: `1px solid ${tone.border}` }}
+    >
+      {value}
+    </span>
+  );
+}
+
+function Section({
+  title,
+  subtitle,
+  icon: Icon,
+  action,
+  id,
+  children,
+}: {
+  title: string;
+  subtitle?: string;
+  icon: typeof Mic;
+  action?: React.ReactNode;
+  id?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section id={id} className="hud-panel p-5 scroll-mt-6">
+      <div className="hud-panel-head flex items-start gap-3 mb-5">
+        <div
+          className="w-8 h-8 rounded-xl flex items-center justify-center shrink-0"
+          style={{
+            background: 'color-mix(in srgb, var(--color-accent) 10%, transparent)',
+            border: '1px solid color-mix(in srgb, var(--color-accent) 22%, transparent)',
+          }}
+        >
+          <Icon size={15} style={{ color: 'var(--color-accent)' }} />
+        </div>
+        <div className="min-w-0">
+          <h2 className="text-sm font-semibold tracking-[0.14em] uppercase" style={{ color: 'var(--color-text)' }}>
+            {title}
+          </h2>
+          {subtitle && (
+            <p className="text-sm mt-1" style={{ color: 'var(--color-text-secondary)' }}>
+              {subtitle}
+            </p>
+          )}
+        </div>
+        {action && <div className="ml-auto">{action}</div>}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function SummaryCard({
+  title,
+  value,
+  note,
+  badge,
+  accent = 'var(--color-accent)',
+}: {
+  title: string;
+  value: React.ReactNode;
+  note?: React.ReactNode;
+  badge?: React.ReactNode;
+  accent?: string;
+}) {
+  return (
+    <div
+      className="hud-panel p-4"
+      style={{
+        background: `linear-gradient(180deg, color-mix(in srgb, ${accent} 8%, var(--color-surface)), var(--color-surface))`,
+      }}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="text-[11px] uppercase tracking-[0.16em]" style={{ color: 'var(--color-text-tertiary)' }}>
+          {title}
+        </div>
+        {badge}
+      </div>
+      <div className="mt-3 text-2xl font-semibold leading-tight" style={{ color: 'var(--color-text)' }}>
+        {value}
+      </div>
+      {note && (
+        <div className="mt-2 text-sm" style={{ color: 'var(--color-text-secondary)' }}>
+          {note}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MessageCard({
+  title,
+  icon: Icon,
+  content,
+  compact = false,
+}: {
+  title: string;
+  icon: typeof Mic;
+  content: string;
+  compact?: boolean;
+}) {
+  return (
+    <Section title={title} icon={Icon}>
+      <div
+        className={`rounded-2xl px-4 py-4 ${compact ? 'min-h-[112px]' : 'min-h-[148px]'}`}
+        style={{
+          background: 'var(--color-bg-secondary)',
+          border: '1px solid var(--color-border)',
+          color: 'var(--color-text)',
+        }}
+      >
+        <ExpandableText text={content} emptyLabel="Aucun contenu récent." maxChars={260} />
+      </div>
+    </Section>
+  );
+}
+
+function AttentionCard({
+  title,
+  detail,
+  level,
+}: {
+  title: string;
+  detail: string;
+  level: 'warning' | 'info' | 'ok';
+}) {
+  const tone =
+    level === 'ok'
+      ? toneFromText('ok')
+      : level === 'info'
+      ? toneFromText('warning')
+      : toneFromText('error');
+
+  return (
+    <div
+      className="rounded-2xl px-4 py-4"
+      style={{
+        background: tone.bg,
+        border: `1px solid ${tone.border}`,
+      }}
+    >
+      <div className="text-sm font-semibold" style={{ color: tone.color }}>
+        {title}
+      </div>
+      <div className="text-sm mt-2" style={{ color: 'var(--color-text)' }}>
+        {detail}
+      </div>
+    </div>
+  );
+}
+
+function GuidanceCard({
+  title,
+  detail,
+  hint,
+}: {
+  title: string;
+  detail: string;
+  hint?: string;
+}) {
+  return (
+    <div
+      className="rounded-2xl px-4 py-4"
+      style={{
+        background: 'var(--color-bg-secondary)',
+        border: '1px solid var(--color-border)',
+      }}
+    >
+      <div className="text-xs uppercase tracking-[0.15em]" style={{ color: 'var(--color-text-tertiary)' }}>
+        {title}
+      </div>
+      <div className="text-sm font-medium mt-2" style={{ color: 'var(--color-text)' }}>
+        {detail}
+      </div>
+      {hint && (
+        <div className="text-sm mt-2" style={{ color: 'var(--color-text-secondary)' }}>
+          {hint}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function InfoChip({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div
+      className="rounded-full px-3 py-1.5 text-xs"
+      style={{
+        background: 'var(--color-bg-secondary)',
+        border: '1px solid var(--color-border)',
+        color: 'var(--color-text-secondary)',
+      }}
+    >
+      <span style={{ color: 'var(--color-text-tertiary)' }}>{label}:</span>{' '}
+      <span style={{ color: 'var(--color-text)' }}>{value}</span>
+    </div>
+  );
+}
+
+function MetricRow({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="flex items-start justify-between gap-4 py-2.5" style={{ borderBottom: '1px solid var(--color-border-subtle)' }}>
+      <div className="text-xs uppercase tracking-[0.14em]" style={{ color: 'var(--color-text-tertiary)' }}>
+        {label}
+      </div>
+      <div className="text-sm text-right max-w-[70%]" style={{ color: 'var(--color-text)' }}>
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function ExpandableText({
+  text,
+  emptyLabel,
+  maxChars = 220,
+}: {
+  text: string;
+  emptyLabel: string;
+  maxChars?: number;
+}) {
+  if (!text) {
+    return <div className="text-sm" style={{ color: 'var(--color-text-tertiary)' }}>{emptyLabel}</div>;
+  }
+  if (text.length <= maxChars) {
+    return (
+      <div className="text-sm whitespace-pre-wrap" style={{ color: 'var(--color-text)' }}>
+        {text}
+      </div>
+    );
+  }
+  return (
+    <details className="group">
+      <summary className="list-none cursor-pointer">
+        <div className="text-sm whitespace-pre-wrap" style={{ color: 'var(--color-text)' }}>
+          {text.slice(0, maxChars).trim()}…
+        </div>
+        <div className="text-xs mt-2" style={{ color: 'var(--color-accent)' }}>
+          Voir tout
+        </div>
+      </summary>
+      <div className="text-sm whitespace-pre-wrap mt-3" style={{ color: 'var(--color-text)' }}>
+        {text}
+      </div>
+    </details>
+  );
+}
+
+function CompactRecord({
+  record,
+  labels,
+}: {
+  record?: PersonalCockpitRecord | null;
+  labels: Array<{ key: string; label: string }>;
+}) {
+  if (!record) {
+    return <div className="text-sm" style={{ color: 'var(--color-text-tertiary)' }}>Aucun état disponible.</div>;
+  }
+
+  return (
+    <div className="space-y-1">
+      {labels.map(({ key, label }) => {
+        const value = record[key];
+        if (value == null || value === '') return null;
+        return <MetricRow key={key} label={label} value={String(value)} />;
+      })}
+    </div>
+  );
+}
+
+function PendingValidationCard({
+  pending,
+}: {
+  pending?: PersonalCockpitRecord | null;
+}) {
+  if (!pending) {
+    return (
+      <div
+        className="rounded-2xl px-4 py-4"
+        style={{
+          background: 'color-mix(in srgb, var(--color-success) 10%, transparent)',
+          border: '1px solid color-mix(in srgb, var(--color-success) 24%, transparent)',
+        }}
+      >
+        <div className="flex items-center gap-2">
+          <CheckCircle2 size={16} style={{ color: 'var(--color-success)' }} />
+          <div className="font-semibold" style={{ color: 'var(--color-text)' }}>
+            Aucune validation en attente
+          </div>
+        </div>
+        <div className="text-sm mt-2" style={{ color: 'var(--color-text-secondary)' }}>
+          Ruth n’a rien à confirmer vocalement au moment du snapshot.
+        </div>
+      </div>
+    );
+  }
+
+  const action = String(pending.action || 'Action réelle en attente');
+  const executable = String(pending.executable || 'n/a');
+  const requestedAt = String(pending.requested_at || '');
+
+  return (
+    <div
+      className="rounded-2xl px-4 py-4"
+      style={{
+        background: 'color-mix(in srgb, var(--color-warning) 12%, transparent)',
+        border: '1px solid color-mix(in srgb, var(--color-warning) 30%, transparent)',
+      }}
+    >
+      <div className="flex items-center gap-2">
+        <AlertTriangle size={16} style={{ color: 'var(--color-warning)' }} />
+        <div className="font-semibold" style={{ color: 'var(--color-text)' }}>
+          Validation attendue maintenant
+        </div>
+      </div>
+      <div className="text-base font-medium mt-3" style={{ color: 'var(--color-text)' }}>
+        {action}
+      </div>
+      <div className="text-sm mt-2" style={{ color: 'var(--color-text-secondary)' }}>
+        Jarvis attend un `oui/non` explicite avant toute exécution réelle.
+      </div>
+      <div className="flex flex-wrap gap-2 mt-4">
+        <InfoChip label="Executable" value={executable} />
+        <InfoChip label="Demandée" value={fmtDate(requestedAt)} />
+      </div>
+    </div>
+  );
+}
+
+function MailList({
+  title,
+  items,
+}: {
+  title: string;
+  items: Array<Record<string, unknown>>;
+}) {
+  if (items.length === 0) return null;
+  return (
+    <div className="space-y-2">
+      <div className="text-xs uppercase tracking-[0.14em]" style={{ color: 'var(--color-text-tertiary)' }}>
+        {title}
+      </div>
+      {items.slice(0, 4).map((item, index) => (
+        <div key={`${String(item.message_id || item.subject || index)}`} className="rounded-xl px-3 py-3" style={{ background: 'var(--color-bg-secondary)' }}>
+          <div className="text-sm font-medium" style={{ color: 'var(--color-text)' }}>
+            {String(item.subject || 'Sans sujet')}
+          </div>
+          <div className="text-xs mt-1" style={{ color: 'var(--color-text-secondary)' }}>
+            {String(item.sender || '')}
+          </div>
+          <div className="text-xs mt-2" style={{ color: 'var(--color-text-tertiary)' }}>
+            {String(item.source_folder || '')} → {String(item.target_folder || '')}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function OperationResultCard({
+  title,
+  summary,
+  status,
+  chips,
+  children,
+}: {
+  title: string;
+  summary: string;
+  status: string;
+  chips: Array<{ label: string; value: React.ReactNode }>;
+  children?: React.ReactNode;
+}) {
+  return (
+    <div
+      className="rounded-2xl px-4 py-4"
+      style={{
+        background: 'var(--color-bg-secondary)',
+        border: '1px solid var(--color-border)',
+      }}
+    >
+      <div className="flex items-center gap-3">
+        <div className="text-sm font-semibold" style={{ color: 'var(--color-text)' }}>
+          {title}
+        </div>
+        <Badge value={status} />
+      </div>
+      <div className="text-sm mt-3" style={{ color: 'var(--color-text)' }}>
+        {summary}
+      </div>
+      <div className="flex flex-wrap gap-2 mt-4">
+        {chips.map((chip) => (
+          <InfoChip key={chip.label} label={chip.label} value={chip.value} />
+        ))}
+      </div>
+      {children && <div className="mt-4">{children}</div>}
+    </div>
+  );
+}
+
+function ActionSummary({
+  title,
+  subtitle,
+  record,
+  labels,
+  compact = false,
+}: {
+  title: string;
+  subtitle: string;
+  record?: PersonalCockpitRecord | null;
+  labels: Array<{ key: string; label: string }>;
+  compact?: boolean;
+}) {
+  const items = Array.isArray(record?.items) ? (record?.items as Array<Record<string, unknown>>) : [];
+  const results = Array.isArray(record?.results) ? (record?.results as Array<Record<string, unknown>>) : [];
+
+  return (
+    <Section title={title} subtitle={subtitle} icon={Mail}>
+      <CompactRecord record={record} labels={labels} />
+      {!compact && (
+        <div className="mt-4">
+          <MailList title="Messages" items={items.length ? items : results} />
+        </div>
+      )}
+    </Section>
+  );
+}
+
+function ContinuityCard({
+  heading,
+  summary,
+  isLatest = false,
+}: {
+  heading: string;
+  summary: string;
+  isLatest?: boolean;
+}) {
+  return (
+    <div
+      className="rounded-2xl px-4 py-4"
+      style={{
+        background: isLatest ? 'color-mix(in srgb, var(--color-accent) 7%, var(--color-bg-secondary))' : 'var(--color-bg-secondary)',
+        border: isLatest
+          ? '1px solid color-mix(in srgb, var(--color-accent) 24%, transparent)'
+          : '1px solid var(--color-border)',
+      }}
+    >
+      <div className="flex items-center gap-2">
+        {isLatest && <Badge value="à reprendre" />}
+        <div className="text-sm font-semibold" style={{ color: 'var(--color-text)' }}>
+          {heading}
+        </div>
+      </div>
+      <div className="text-sm mt-3" style={{ color: 'var(--color-text-secondary)' }}>
+        {summary || '—'}
+      </div>
+    </div>
+  );
+}
+
+function SecondaryDetails({
+  title,
+  subtitle,
+  children,
+  defaultOpen = false,
+  id,
+}: {
+  title: string;
+  subtitle?: string;
+  children: React.ReactNode;
+  defaultOpen?: boolean;
+  id?: string;
+}) {
+  return (
+    <details
+      id={id}
+      className="hud-panel px-5 py-4 group"
+      open={defaultOpen}
+    >
+      <summary className="list-none cursor-pointer flex items-center gap-3">
+        <div className="min-w-0">
+          <div className="text-sm font-semibold" style={{ color: 'var(--color-text)' }}>
+            {title}
+          </div>
+          {subtitle && (
+            <div className="text-sm mt-1" style={{ color: 'var(--color-text-secondary)' }}>
+              {subtitle}
+            </div>
+          )}
+        </div>
+        <ChevronDown
+          size={16}
+          className="ml-auto transition-transform group-open:rotate-180"
+          style={{ color: 'var(--color-text-tertiary)' }}
+        />
+      </summary>
+      <div className="mt-4 pt-4" style={{ borderTop: '1px solid var(--color-border-subtle)' }}>
+        {children}
+      </div>
+    </details>
+  );
+}
+
+function MiniAttentionRow({
+  items,
+}: {
+  items: Array<{ title: string; detail: string; level: 'warning' | 'info' | 'ok' }>;
+}) {
+  return (
+    <div className="grid grid-cols-1 xl:grid-cols-3 gap-2.5">
+      {items.map((item) => {
+        const tone =
+          item.level === 'ok'
+            ? toneFromText('ok')
+            : item.level === 'info'
+            ? toneFromText('warning')
+            : toneFromText('error');
+        return (
+          <div
+            key={item.title}
+            className="rounded-xl px-3.5 py-3"
+            style={{
+              background: tone.bg,
+              border: `1px solid ${tone.border}`,
+            }}
+          >
+            <div className="text-xs uppercase tracking-[0.14em]" style={{ color: tone.color }}>
+              {item.title}
+            </div>
+            <div className="text-sm mt-1.5" style={{ color: 'var(--color-text)' }}>
+              {item.detail}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function ActionButton({
+  label,
+  icon: Icon,
+  onClick,
+  disabled = false,
+}: {
+  label: string;
+  icon: typeof RefreshCw;
+  onClick: () => void;
+  disabled?: boolean;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      className="inline-flex items-center gap-2 px-3 py-2 rounded-full text-sm cursor-pointer disabled:cursor-not-allowed"
+      style={{
+        background: disabled ? 'var(--color-bg-tertiary)' : 'var(--color-bg-secondary)',
+        border: '1px solid var(--color-border)',
+        color: disabled ? 'var(--color-text-tertiary)' : 'var(--color-text)',
+        opacity: disabled ? 0.7 : 1,
+      }}
+    >
+      <Icon size={14} />
+      {label}
+    </button>
+  );
+}
+
+export function JarvisPersonalPage() {
+  const [data, setData] = useState<PersonalCockpitSnapshot | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const next = await fetchPersonalCockpit();
+      setData(next);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Cockpit indisponible');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const scrollToId = useCallback((id: string) => {
+    const node = document.getElementById(id);
+    if (!node) return;
+    const details = node.tagName.toLowerCase() === 'details' ? (node as HTMLDetailsElement) : null;
+    if (details) details.open = true;
+    node.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }, []);
+
+  const copyText = useCallback(async (value: string, successLabel: string) => {
+    try {
+      await navigator.clipboard.writeText(value);
+      toast.success(successLabel);
+    } catch {
+      toast.error('Impossible de copier cette information');
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+    let timer: number | null = null;
+
+    const schedule = () => {
+      if (timer != null) window.clearTimeout(timer);
+      if (document.visibilityState !== 'visible') return;
+      timer = window.setTimeout(() => {
+        refresh();
+        schedule();
+      }, 12000);
+    };
+
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        refresh();
+      }
+      schedule();
+    };
+
+    schedule();
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    return () => {
+      if (timer != null) window.clearTimeout(timer);
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+    };
+  }, [refresh]);
+
+  const derived = useMemo(() => {
+    if (!data) {
+      return {
+        attentionCards: [] as Array<{ title: string; detail: string; level: 'warning' | 'info' | 'ok' }>,
+        connectorSummary: '',
+        continuityLead: '',
+        latestOperationalSummary: '',
+        nextMove: {
+          title: '',
+          detail: '',
+          actionLabel: '',
+          targetId: '',
+        },
+      };
+    }
+
+    const attentionCards: Array<{ title: string; detail: string; level: 'warning' | 'info' | 'ok' }> = [];
+
+    if (data.pending_validation) {
+      attentionCards.push({
+        title: 'Validation en attente',
+        detail: String(data.pending_validation.action || 'Une action réelle attend une validation.'),
+        level: 'warning',
+      });
+    } else {
+      attentionCards.push({
+        title: 'Aucune validation bloquante',
+        detail: 'Aucune action réelle n’attend une confirmation vocale maintenant.',
+        level: 'ok',
+      });
+    }
+
+    if (data.alerts.length > 0) {
+      const first = data.alerts[0];
+      attentionCards.push({
+        title: first.title,
+        detail: first.detail,
+        level: first.level === 'warning' ? 'warning' : first.level === 'info' ? 'info' : 'warning',
+      });
+    } else {
+      attentionCards.push({
+        title: 'Alerte récente',
+        detail: 'Aucune alerte notable sur les dernières traces du cockpit.',
+        level: 'ok',
+      });
+    }
+
+    const lastDynamicSummary =
+      String(data.yahoo_dynamic_result?.voice_summary || data.yahoo_dynamic_result?.action || '').trim() ||
+      'Pas de résultat Yahoo dynamique récent.';
+    attentionCards.push({
+      title: 'Dernier mouvement Yahoo',
+      detail: lastDynamicSummary,
+      level: 'info',
+    });
+
+    const connectorSummary = data.connectors
+      .map((connector) => `${connector.name}: ${connector.status}`)
+      .join(' · ');
+
+    const continuityLead = data.continuity[0]?.summary || 'Aucun extrait de continuité récent.';
+    const latestOperationalSummary =
+      String(
+        data.yahoo_dynamic_result?.voice_summary ||
+          data.yahoo_targeted_move?.voice_summary ||
+          data.last_live_brief?.voice_summary ||
+          '',
+      ).trim() || 'Aucun résultat opérationnel récent.';
+
+    let nextMove = {
+      title: 'Rafraîchir ou relire l’état',
+      detail: 'Le cockpit ne voit pas de blocage immédiat. Le geste le plus utile est de vérifier le dernier résultat ou la continuité récente.',
+      actionLabel: 'Aller au dernier résultat',
+      targetId: 'yahoo-result',
+    };
+
+    if (data.pending_validation) {
+      nextMove = {
+        title: 'Traiter la validation en attente',
+        detail: 'Le prochain geste sûr est de relire exactement l’action en attente, puis de décider si Ruth veut répondre vocalement oui ou non.',
+        actionLabel: 'Ouvrir la validation',
+        targetId: 'pending-validation',
+      };
+    } else if (data.continuity.length > 0) {
+      nextMove = {
+        title: 'Reprendre le prochain contexte utile',
+        detail: 'Aucun blocage immédiat n’est en attente. Le geste le plus utile est de relire l’artefact de continuité le plus récent avant de reprendre.',
+        actionLabel: 'Ouvrir la continuité',
+        targetId: 'continuity-details',
+      };
+    } else if (latestOperationalSummary) {
+      nextMove = {
+        title: 'Relire le dernier résultat confirmé',
+        detail: 'Le geste le plus sûr est de repartir du dernier résultat opérationnel réellement observé par le cockpit.',
+        actionLabel: 'Ouvrir le résultat',
+        targetId: 'yahoo-result',
+      };
+    }
+
+    return { attentionCards, connectorSummary, continuityLead, latestOperationalSummary, nextMove };
+  }, [data]);
+
+  if (loading) {
+    return (
+      <div className="flex-1 flex items-center justify-center">
+        <div className="hud-panel px-6 py-5 flex items-center gap-3">
+          <Loader2 size={18} className="animate-spin" style={{ color: 'var(--color-accent)' }} />
+          <span style={{ color: 'var(--color-text)' }}>Chargement du cockpit Jarvis personnel…</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div className="flex-1 overflow-y-auto px-6 py-10">
+        <div className="max-w-5xl mx-auto">
+          <Section title="Cockpit indisponible" icon={AlertTriangle}>
+            <div className="text-sm" style={{ color: 'var(--color-error)' }}>
+              {error || 'Impossible de charger les données du cockpit.'}
+            </div>
+          </Section>
+        </div>
+      </div>
+    );
+  }
+
+  const general = data.general_state;
+  const liveSummary = data.last_live_brief;
+  const targeted = data.yahoo_targeted_move;
+  const candidate = data.yahoo_dynamic_candidate;
+  const finalBatch = data.yahoo_dynamic_result;
+  const handoffPath = data.file_health.session_handoffs?.path || '';
+  const latestYahooSummary = String(finalBatch?.voice_summary || targeted?.voice_summary || '').trim();
+
+  return (
+    <div className="flex-1 overflow-y-auto px-6 py-8">
+      <div className="max-w-7xl mx-auto space-y-4">
+        <header
+          className="hud-panel p-6"
+          style={{
+            background:
+              'linear-gradient(135deg, color-mix(in srgb, var(--color-accent) 10%, var(--color-surface)) 0%, var(--color-surface) 48%, color-mix(in srgb, var(--color-accent-purple) 8%, var(--color-surface)) 100%)',
+          }}
+        >
+          <div className="flex flex-col xl:flex-row xl:items-end gap-4">
+            <div className="min-w-0">
+              <div className="flex items-center gap-2 mb-2">
+                <span className="hud-heartbeat" />
+                <span className="hud-label uppercase tracking-[0.22em]">Jarvis Personal Cockpit</span>
+              </div>
+              <h1 className="text-3xl md:text-4xl font-semibold leading-tight" style={{ color: 'var(--color-text)' }}>
+                Cockpit personnel Ruth
+              </h1>
+              <p className="text-sm md:text-base mt-3 max-w-3xl" style={{ color: 'var(--color-text-secondary)' }}>
+                Vue locale séparée d’Obsidian, centrée sur l’état Jarvis, la voix, les validations en attente et les mouvements Yahoo réellement suivis.
+              </p>
+            </div>
+
+            <div className="xl:ml-auto flex flex-col sm:flex-row sm:items-center gap-3">
+              <div
+                className="rounded-2xl px-4 py-3"
+                style={{ background: 'var(--color-bg-secondary)', border: '1px solid var(--color-border)' }}
+              >
+                <div className="text-[11px] uppercase tracking-[0.16em]" style={{ color: 'var(--color-text-tertiary)' }}>
+                  Dernier snapshot
+                </div>
+                <div className="text-sm hud-mono mt-1" style={{ color: 'var(--color-text)' }}>
+                  {fmtDate(data.meta.generated_at)}
+                </div>
+              </div>
+              <button
+                onClick={refresh}
+                className="inline-flex items-center justify-center gap-2 px-4 py-3 rounded-2xl cursor-pointer"
+                style={{
+                  background: 'var(--color-bg-secondary)',
+                  border: '1px solid var(--color-border)',
+                  color: 'var(--color-text)',
+                }}
+              >
+                <RefreshCw size={15} />
+                Rafraîchir
+              </button>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-3 mt-5">
+            <SummaryCard
+              title="Jarvis"
+              value={general.live_status === 'recently_active' ? 'Actif récemment' : general.live_status}
+              note={general.status}
+              badge={<Badge value={general.live_status || 'idle'} />}
+            />
+            <SummaryCard
+              title="Voix"
+              value={data.voice_live.wake_word || 'Jarvis'}
+              note={`${data.voice_live.stt} · ${data.voice_live.tts}`}
+              badge={<Badge value={data.voice_live.vad || 'n/a'} />}
+              accent="var(--color-accent-purple)"
+            />
+            <SummaryCard
+              title="Validation"
+              value={data.pending_validation ? 'En attente' : 'Rien à valider'}
+              note={
+                data.pending_validation
+                  ? String(data.pending_validation.action || 'Action réelle en attente')
+                  : 'Aucune action réelle bloquée'
+              }
+              badge={<Badge value={data.pending_validation ? 'pending' : 'ok'} />}
+              accent={data.pending_validation ? 'var(--color-warning)' : 'var(--color-success)'}
+            />
+            <SummaryCard
+              title="Dernière activité"
+              value={fmtAgo(general.age_seconds)}
+              note={`Mémoire courte : ${general.turn_count} tours`}
+              badge={<Clock3 size={15} style={{ color: 'var(--color-text-tertiary)' }} />}
+              accent="var(--color-accent-amber)"
+            />
+          </div>
+
+          <div className="grid grid-cols-1 xl:grid-cols-[1.15fr_1fr] gap-3 mt-5">
+            <GuidanceCard
+              title={derived.nextMove.title}
+              detail={derived.nextMove.detail}
+              hint="Ce cadrage reste descriptif : aucune action réelle n’est lancée depuis ce panneau."
+            />
+            <div
+              className="rounded-2xl px-4 py-4"
+              style={{
+                background: 'color-mix(in srgb, var(--color-accent) 8%, var(--color-surface))',
+                border: '1px solid color-mix(in srgb, var(--color-accent) 22%, transparent)',
+              }}
+            >
+              <div className="text-xs uppercase tracking-[0.15em]" style={{ color: 'var(--color-text-tertiary)' }}>
+                Actions disponibles
+              </div>
+              <div className="flex flex-wrap gap-2 mt-3">
+                <ActionButton
+                  label={derived.nextMove.actionLabel}
+                  icon={MoveRight}
+                  onClick={() => scrollToId(derived.nextMove.targetId)}
+                  disabled={!derived.nextMove.targetId}
+                />
+                <ActionButton label="Rafraîchir l’état" icon={RefreshCw} onClick={refresh} />
+                <ActionButton label="Aller à la validation" icon={AlertTriangle} onClick={() => scrollToId('pending-validation')} />
+                <ActionButton label="Aller au résultat" icon={Mail} onClick={() => scrollToId('yahoo-result')} />
+                <ActionButton label="Aller à la continuité" icon={Clock3} onClick={() => scrollToId('continuity-details')} />
+                <ActionButton
+                  label="Copier le chemin du handoff"
+                  icon={Copy}
+                  onClick={() => copyText(handoffPath, 'Chemin du handoff copié')}
+                  disabled={!handoffPath}
+                />
+                <ActionButton
+                  label="Copier le résumé Yahoo"
+                  icon={Copy}
+                  onClick={() => copyText(latestYahooSummary, 'Résumé Yahoo copié')}
+                  disabled={!latestYahooSummary}
+                />
+              </div>
+            </div>
+          </div>
+        </header>
+
+        <Section
+          id="attention-now"
+          title="Ce Qui Compte Maintenant"
+          subtitle="Le signal prioritaire, avant les détails."
+          icon={Sparkles}
+        >
+          <MiniAttentionRow items={derived.attentionCards} />
+        </Section>
+
+        <Section
+          title="Derniers Échanges Vocaux"
+          subtitle="Ce que Ruth vient de dire, puis la dernière réponse utile de Jarvis."
+          icon={Mic}
+        >
+          <div className="grid grid-cols-1 xl:grid-cols-2 gap-3">
+            <div>
+              <div className="text-xs uppercase tracking-[0.14em] mb-2" style={{ color: 'var(--color-text-tertiary)' }}>
+                Dernière transcription
+              </div>
+              <div
+                className="rounded-2xl px-4 py-4 min-h-[112px]"
+                style={{ background: 'var(--color-bg-secondary)', border: '1px solid var(--color-border)' }}
+              >
+                <ExpandableText text={data.latest_transcription} emptyLabel="Aucune transcription récente." maxChars={220} />
+              </div>
+            </div>
+            <div>
+              <div className="text-xs uppercase tracking-[0.14em] mb-2" style={{ color: 'var(--color-text-tertiary)' }}>
+                Dernière réponse Jarvis
+              </div>
+              <div
+                className="rounded-2xl px-4 py-4 min-h-[112px]"
+                style={{ background: 'var(--color-bg-secondary)', border: '1px solid var(--color-border)' }}
+              >
+                <ExpandableText text={data.latest_response} emptyLabel="Aucune réponse récente." maxChars={220} />
+              </div>
+            </div>
+          </div>
+        </Section>
+
+        <div className="grid grid-cols-1 xl:grid-cols-2 gap-3">
+          <Section
+            id="pending-validation"
+            title="Validation et état voix"
+            subtitle="Le centre de décision immédiat."
+            icon={ShieldCheck}
+          >
+            <div className="mb-4">
+              <PendingValidationCard pending={data.pending_validation} />
+            </div>
+
+            <div className="space-y-1">
+              <MetricRow label="Mode voix" value={<Badge value={general.status || 'unknown'} />} />
+              <MetricRow label="Voix live" value={<Badge value={general.live_status || 'idle'} />} />
+              <MetricRow label="Wake word" value={data.voice_live.wake_word || 'n/a'} />
+              <MetricRow label="Chaîne voix" value={`${data.voice_live.stt || 'n/a'} → ${data.voice_live.tts || 'n/a'}`} />
+            </div>
+          </Section>
+
+          <Section
+            id="alerts-section"
+            title="Alertes récentes"
+            subtitle="Incidents, validations ou signaux faibles à traiter."
+            icon={AlertTriangle}
+          >
+            <div className="space-y-3">
+              {data.alerts.length === 0 && (
+                <div className="rounded-2xl px-4 py-4" style={{ background: 'var(--color-bg-secondary)' }}>
+                  <div className="text-sm" style={{ color: 'var(--color-text-secondary)' }}>
+                    Aucune alerte récente remontée par le cockpit.
+                  </div>
+                </div>
+              )}
+              {data.alerts.map((alert, index) => (
+                <div key={`${alert.title}-${index}`} className="rounded-2xl px-4 py-4" style={{ background: 'var(--color-bg-secondary)' }}>
+                  <div className="flex items-center gap-2">
+                    <Badge value={alert.level} />
+                    <div className="text-sm font-semibold" style={{ color: 'var(--color-text)' }}>
+                      {alert.title}
+                    </div>
+                  </div>
+                  <div className="text-sm mt-2" style={{ color: 'var(--color-text-secondary)' }}>
+                    {alert.detail}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </Section>
+        </div>
+
+        <div className="grid grid-cols-1 xl:grid-cols-[1.25fr_0.75fr] gap-3">
+          <Section
+            id="yahoo-result"
+            title="Dernier résultat opérationnel"
+            subtitle="Ce qui vient réellement de se produire ou de rester en place."
+            icon={Mail}
+          >
+            <OperationResultCard
+              title="Synthèse opérationnelle"
+              summary={derived.latestOperationalSummary}
+              status={finalBatch ? 'yahoo dynamique' : targeted ? 'yahoo ciblé' : 'brief live'}
+              chips={[
+                {
+                  label: 'Messages demandés',
+                  value: String(finalBatch?.messages_requested ?? targeted?.messages_requested ?? 'n/a'),
+                },
+                {
+                  label: 'Déplacés maintenant',
+                  value: String(finalBatch?.messages_moved_now ?? targeted?.messages_moved_now ?? 'n/a'),
+                },
+                {
+                  label: 'Déjà en cible',
+                  value: String(finalBatch?.messages_already_in_target ?? targeted?.messages_already_in_target ?? 'n/a'),
+                },
+              ]}
+            >
+              <div className="grid grid-cols-1 gap-3">
+                <details className="rounded-xl px-3 py-3" style={{ background: 'var(--color-surface)', border: '1px solid var(--color-border)' }}>
+                  <summary className="cursor-pointer text-sm font-medium" style={{ color: 'var(--color-text)' }}>
+                    Voir le résultat Yahoo dynamique
+                  </summary>
+                  <div className="mt-3">
+                    <CompactRecord
+                      record={finalBatch}
+                      labels={[
+                        { key: 'action', label: 'action' },
+                        { key: 'voice_summary', label: 'résumé' },
+                        { key: 'messages_requested', label: 'messages demandés' },
+                        { key: 'messages_moved_now', label: 'déplacés maintenant' },
+                        { key: 'messages_already_in_target', label: 'déjà dans la cible' },
+                      ]}
+                    />
+                    <div className="mt-4">
+                      <MailList
+                        title="Messages concernés"
+                        items={Array.isArray(finalBatch?.results) ? (finalBatch?.results as Array<Record<string, unknown>>) : []}
+                      />
+                    </div>
+                  </div>
+                </details>
+
+                <details className="rounded-xl px-3 py-3" style={{ background: 'var(--color-surface)', border: '1px solid var(--color-border)' }}>
+                  <summary className="cursor-pointer text-sm font-medium" style={{ color: 'var(--color-text)' }}>
+                    Voir le résultat Yahoo ciblé
+                  </summary>
+                  <div className="mt-3">
+                    <CompactRecord
+                      record={targeted}
+                      labels={[
+                        { key: 'action', label: 'action' },
+                        { key: 'voice_summary', label: 'résumé' },
+                        { key: 'messages_requested', label: 'messages demandés' },
+                        { key: 'messages_moved_now', label: 'déplacés maintenant' },
+                        { key: 'messages_already_in_target', label: 'déjà dans la cible' },
+                      ]}
+                    />
+                  </div>
+                </details>
+              </div>
+            </OperationResultCard>
+          </Section>
+
+          <ActionSummary
+            title="Dernier brief live"
+            subtitle="Contexte multi-source le plus récent."
+            record={liveSummary}
+            labels={[
+              { key: 'action', label: 'action' },
+              { key: 'voice_summary', label: 'résumé' },
+              { key: 'generated_at', label: 'généré' },
+            ]}
+            compact
+          />
+        </div>
+
+        <div className="grid grid-cols-1 xl:grid-cols-2 gap-3">
+          <Section
+            title="Historique court de session"
+            subtitle="Les derniers échanges utiles sans bruit inutile."
+            icon={Mic}
+          >
+            <div className="space-y-3">
+              {data.session_history.length === 0 && (
+                <div className="text-sm" style={{ color: 'var(--color-text-tertiary)' }}>
+                  Aucun historique de session disponible.
+                </div>
+              )}
+              {data.session_history.map((entry, index) => (
+                <div key={`${entry.timestamp}-${index}`} className="rounded-2xl px-4 py-4" style={{ background: 'var(--color-bg-secondary)' }}>
+                  <div className="flex items-center justify-between gap-3">
+                    <div className="text-xs uppercase tracking-[0.14em]" style={{ color: 'var(--color-text-tertiary)' }}>
+                      {entry.intent || 'intent inconnu'}
+                    </div>
+                    <div className="text-xs hud-mono" style={{ color: 'var(--color-text-tertiary)' }}>
+                      {fmtDate(entry.timestamp)}
+                    </div>
+                  </div>
+                  <div className="text-sm mt-3" style={{ color: 'var(--color-text)' }}>
+                    <strong>Ruth :</strong> {entry.user || '—'}
+                  </div>
+                  <div className="text-sm mt-2" style={{ color: 'var(--color-text-secondary)' }}>
+                    <strong>Jarvis :</strong> {entry.assistant || '—'}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </Section>
+
+          <Section
+            title="Vue connecteurs"
+            subtitle="Résumé rapide avant les détails techniques."
+            icon={ShieldCheck}
+          >
+            <div
+              className="rounded-2xl px-4 py-4 mb-4"
+              style={{ background: 'var(--color-bg-secondary)', border: '1px solid var(--color-border)' }}
+            >
+              <div className="text-xs uppercase tracking-[0.15em]" style={{ color: 'var(--color-text-tertiary)' }}>
+                Résumé
+              </div>
+              <div className="text-sm mt-2" style={{ color: 'var(--color-text)' }}>
+                {derived.connectorSummary}
+              </div>
+            </div>
+            <div className="space-y-3">
+              {data.connectors.map((connector) => (
+                <div key={connector.name} className="rounded-2xl px-4 py-4" style={{ background: 'var(--color-bg-secondary)' }}>
+                  <div className="flex items-center justify-between gap-3">
+                    <div className="font-semibold" style={{ color: 'var(--color-text)' }}>
+                      {connector.name}
+                    </div>
+                    <Badge value={connector.status || 'unknown'} />
+                  </div>
+                  <div className="text-xs mt-2" style={{ color: 'var(--color-text-secondary)' }}>
+                    Mis à jour : {fmtDate(connector.updated_at)}
+                  </div>
+                  <div className="flex flex-wrap gap-2 mt-3">
+                    {Object.entries(connector.services || {}).map(([name, value]) => (
+                      <span
+                        key={name}
+                        className="px-2.5 py-1 rounded-full text-xs"
+                        style={{
+                          background: 'var(--color-surface)',
+                          border: '1px solid var(--color-border)',
+                          color: 'var(--color-text-secondary)',
+                        }}
+                      >
+                        {name}: {value}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </Section>
+        </div>
+
+        <div className="grid grid-cols-1 xl:grid-cols-3 gap-3">
+          <SecondaryDetails
+            title="Yahoo dynamique candidat"
+            subtitle="Le batch préparé avant exécution reste visible mais secondaire."
+          >
+            <CompactRecord
+              record={candidate}
+              labels={[
+                { key: 'action', label: 'action' },
+                { key: 'source_name', label: 'source revue' },
+                { key: 'batch_size', label: 'taille' },
+                { key: 'batch_revision', label: 'révision' },
+                { key: 'voice_summary', label: 'résumé' },
+              ]}
+            />
+            <div className="mt-4">
+              <MailList
+                title="Messages candidats"
+                items={Array.isArray(candidate?.items) ? (candidate?.items as Array<Record<string, unknown>>) : []}
+              />
+            </div>
+          </SecondaryDetails>
+
+          <SecondaryDetails
+            id="continuity-details"
+            title="Continuité récente"
+            subtitle={derived.continuityLead}
+            defaultOpen
+          >
+            {data.continuity.length > 0 && (
+              <div className="space-y-3">
+                <ContinuityCard
+                  heading={data.continuity[0].heading}
+                  summary={data.continuity[0].summary}
+                  isLatest
+                />
+                {data.continuity.length > 1 && (
+                  <details className="rounded-xl px-3 py-3" style={{ background: 'var(--color-surface)', border: '1px solid var(--color-border)' }}>
+                    <summary className="cursor-pointer text-sm font-medium" style={{ color: 'var(--color-text)' }}>
+                      Voir les autres extraits de continuité
+                    </summary>
+                    <div className="space-y-3 mt-3">
+                      {data.continuity.slice(1).map((entry, index) => (
+                        <ContinuityCard
+                          key={`${entry.heading}-${index + 1}`}
+                          heading={entry.heading}
+                          summary={entry.summary}
+                        />
+                      ))}
+                    </div>
+                  </details>
+                )}
+              </div>
+            )}
+          </SecondaryDetails>
+
+          <SecondaryDetails
+            title="Santé des fichiers runtime"
+            subtitle="Détails techniques utiles, mais hors du premier regard."
+          >
+            <div className="space-y-2">
+              {Object.entries(data.file_health).map(([name, file]) => (
+                <div key={name} className="rounded-xl px-3 py-3" style={{ background: 'var(--color-bg-secondary)' }}>
+                  <div className="flex items-center justify-between gap-3">
+                    <div className="text-sm font-medium" style={{ color: 'var(--color-text)' }}>
+                      {name}
+                    </div>
+                    <Badge value={file.exists ? 'ok' : 'missing'} />
+                  </div>
+                  <div className="text-xs mt-2 break-all" style={{ color: 'var(--color-text-secondary)' }}>
+                    {file.path}
+                  </div>
+                  <div className="text-xs mt-1" style={{ color: 'var(--color-text-tertiary)' }}>
+                    Modifié : {fmtDate(file.modified_at)}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </SecondaryDetails>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -133,6 +133,77 @@ export interface ServerInfo {
   engine: string;
 }
 
+export interface PersonalCockpitRecord {
+  [key: string]: unknown;
+}
+
+export interface PersonalCockpitFileHealth {
+  exists: boolean;
+  path: string;
+  modified_at: string;
+}
+
+export interface PersonalCockpitSnapshot {
+  meta: {
+    generated_at: string;
+    personal_root: string;
+    voice_runtime: string;
+  };
+  general_state: {
+    status: string;
+    live_status: string;
+    paused: boolean;
+    active_until: string;
+    updated_at: string;
+    age_seconds: number | null;
+    turn_count: number;
+    last_transcription: string;
+    last_response: string;
+    pending_validation?: PersonalCockpitRecord | null;
+    last_validated_action?: PersonalCockpitRecord | null;
+  };
+  voice_live: {
+    config_status: string;
+    wake_word: string;
+    vad: string;
+    stt: string;
+    tts: string;
+    commands: string[];
+    last_updated_at: string;
+  };
+  latest_transcription: string;
+  latest_response: string;
+  pending_validation?: PersonalCockpitRecord | null;
+  last_live_brief?: PersonalCockpitRecord | null;
+  yahoo_targeted_move?: PersonalCockpitRecord | null;
+  yahoo_dynamic_candidate?: PersonalCockpitRecord | null;
+  yahoo_dynamic_result?: PersonalCockpitRecord | null;
+  session_history: Array<{
+    timestamp: string;
+    intent: string;
+    user: string;
+    assistant: string;
+  }>;
+  recent_actions: Array<Record<string, unknown>>;
+  connectors: Array<{
+    name: string;
+    status: string;
+    services: Record<string, string>;
+    updated_at: string;
+    details: PersonalCockpitRecord;
+  }>;
+  alerts: Array<{
+    level: string;
+    title: string;
+    detail: string;
+  }>;
+  continuity: Array<{
+    heading: string;
+    summary: string;
+  }>;
+  file_health: Record<string, PersonalCockpitFileHealth>;
+}
+
 // --- Log Types ---
 
 export interface LogEntry {

--- a/scripts/oauth_all.py
+++ b/scripts/oauth_all.py
@@ -111,7 +111,7 @@ def do_google() -> None:
     print("\n=== Google OAuth (Drive, Calendar, Contacts, Gmail, Tasks) ===")
     scopes = [
         "openid", "email", "profile",
-        "https://www.googleapis.com/auth/drive.readonly",
+        "https://www.googleapis.com/auth/drive",
         "https://www.googleapis.com/auth/calendar.readonly",
         "https://www.googleapis.com/auth/contacts.readonly",
         "https://www.googleapis.com/auth/gmail.readonly",

--- a/src/openjarvis/connectors/gdrive.py
+++ b/src/openjarvis/connectors/gdrive.py
@@ -31,7 +31,7 @@ from openjarvis.tools._stubs import ToolSpec
 # ---------------------------------------------------------------------------
 
 _GDRIVE_API_BASE = "https://www.googleapis.com/drive/v3"
-_GDRIVE_SCOPE = "https://www.googleapis.com/auth/drive.readonly"
+_GDRIVE_SCOPE = "https://www.googleapis.com/auth/drive"
 _DEFAULT_CREDENTIALS_PATH = str(DEFAULT_CONFIG_DIR / "connectors" / "gdrive.json")
 
 # Map from Google Workspace MIME types to export MIME types
@@ -161,7 +161,7 @@ class GDriveConnector(BaseConnector):
         delete_tokens(self._credentials_path)
 
     def auth_url(self) -> str:
-        """Return a Google OAuth consent URL requesting ``drive.readonly`` scope."""
+        """Return a Google OAuth consent URL requesting ``drive`` scope."""
         tokens = load_tokens(self._credentials_path)
         client_id = ""
         if tokens:

--- a/src/openjarvis/connectors/oauth.py
+++ b/src/openjarvis/connectors/oauth.py
@@ -57,7 +57,7 @@ GOOGLE_ALL_SCOPES: List[str] = [
     "openid",
     "email",
     "profile",
-    "https://www.googleapis.com/auth/drive.readonly",
+    "https://www.googleapis.com/auth/drive",
     "https://www.googleapis.com/auth/calendar.readonly",
     "https://www.googleapis.com/auth/contacts.readonly",
     "https://www.googleapis.com/auth/gmail.readonly",

--- a/src/openjarvis/server/app.py
+++ b/src/openjarvis/server/app.py
@@ -15,6 +15,7 @@ from openjarvis.server.comparison import comparison_router
 from openjarvis.server.connectors_router import create_connectors_router
 from openjarvis.server.dashboard import dashboard_router
 from openjarvis.server.digest_routes import create_digest_router
+from openjarvis.server.personal_cockpit import router as personal_cockpit_router
 from openjarvis.server.routes import router
 from openjarvis.server.upload_router import router as upload_router
 
@@ -226,6 +227,7 @@ def create_app(
     app.include_router(router)
     app.include_router(dashboard_router)
     app.include_router(comparison_router)
+    app.include_router(personal_cockpit_router)
     app.include_router(create_connectors_router())
     app.include_router(create_digest_router())
     app.include_router(upload_router)

--- a/src/openjarvis/server/personal_cockpit.py
+++ b/src/openjarvis/server/personal_cockpit.py
@@ -1,0 +1,288 @@
+"""Personal Jarvis cockpit routes backed by jarvis-personal runtime files."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections import deque
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter
+
+try:
+    import tomllib
+except ImportError:  # pragma: no cover
+    tomllib = None
+
+router = APIRouter(prefix="/v1/personal-cockpit", tags=["personal-cockpit"])
+
+PERSONAL_ROOT = Path.home() / ".openjarvis" / "jarvis-personal"
+VOICE_DIR = PERSONAL_ROOT / "runtime" / "voice"
+WORKING_DIR = PERSONAL_ROOT / "memory" / "working"
+INTEGRATIONS_DIR = PERSONAL_ROOT / "integrations"
+
+STATE_PATH = VOICE_DIR / "v4_state.json"
+SESSIONS_PATH = VOICE_DIR / "v4_sessions.jsonl"
+ACTIONS_PATH = VOICE_DIR / "v4_action_queue.jsonl"
+LIVE_BRIEF_PATH = VOICE_DIR / "voice_live_brief_latest.json"
+TARGETED_MOVE_PATH = VOICE_DIR / "yahoo_voice_targeted_move_latest.json"
+DYNAMIC_CANDIDATE_PATH = VOICE_DIR / "yahoo_voice_dynamic_move_candidate_latest.json"
+DYNAMIC_RESULT_PATH = VOICE_DIR / "yahoo_voice_dynamic_move_latest.json"
+HANDOFFS_PATH = WORKING_DIR / "session_handoffs.md"
+VOICE_CONFIG_PATH = INTEGRATIONS_DIR / "voice.toml"
+
+
+def _load_json(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+
+
+def _load_jsonl_tail(path: Path, limit: int) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    rows: deque[dict[str, Any]] = deque(maxlen=limit)
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rows.append(json.loads(line))
+                except Exception:
+                    continue
+    except Exception:
+        return []
+    return list(rows)
+
+
+def _load_toml(path: Path) -> dict[str, Any]:
+    if not path.exists() or tomllib is None:
+        return {}
+    try:
+        with path.open("rb") as handle:
+            return tomllib.load(handle)
+    except Exception:
+        return {}
+
+
+def _parse_iso(raw: str | None) -> datetime | None:
+    if not raw:
+        return None
+    try:
+        return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except Exception:
+        return None
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _relative_seconds(raw: str | None) -> int | None:
+    dt = _parse_iso(raw)
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return max(0, int((_utcnow() - dt.astimezone(timezone.utc)).total_seconds()))
+
+
+def _tail_handoffs(limit: int = 4) -> list[dict[str, str]]:
+    if not HANDOFFS_PATH.exists():
+        return []
+    try:
+        text = HANDOFFS_PATH.read_text(encoding="utf-8")
+    except Exception:
+        return []
+    chunks = re.split(r"^##\s+", text, flags=re.M)
+    items: list[dict[str, str]] = []
+    for chunk in chunks[1:]:
+        lines = [line.rstrip() for line in chunk.strip().splitlines() if line.strip()]
+        if not lines:
+            continue
+        heading = lines[0]
+        bullets = [line for line in lines[1:] if line.startswith("- ")]
+        items.append(
+            {
+                "heading": heading,
+                "summary": " ".join(bullets[:3]).replace("- ", "").strip(),
+            }
+        )
+    return items[-limit:]
+
+
+def _connector_entry(name: str, payload: dict[str, Any] | None) -> dict[str, Any]:
+    payload = payload or {}
+    services = payload.get("services", {})
+    primary = next((str(v) for v in services.values() if v), payload.get("status", "unknown"))
+    return {
+        "name": name,
+        "status": primary,
+        "services": services,
+        "updated_at": payload.get("updated_at", ""),
+        "details": payload,
+    }
+
+
+def _state_summary(state: dict[str, Any] | None, voice_cfg: dict[str, Any]) -> dict[str, Any]:
+    state = state or {}
+    turns = state.get("turns", [])
+    last_turn = turns[-1] if turns else {}
+    updated_at = state.get("updated_at", "")
+    age_seconds = _relative_seconds(updated_at)
+    active_until = state.get("active_until", "")
+    active_dt = _parse_iso(active_until)
+    active_now = bool(active_dt and (active_dt > datetime.now(active_dt.tzinfo)))
+    paused = bool(state.get("paused", False))
+    live_status = "paused" if paused else "active_window" if active_now else "idle"
+    if age_seconds is not None and age_seconds <= 90 and not paused:
+        live_status = "recently_active"
+    return {
+        "status": voice_cfg.get("voice_v4", {}).get("status", ""),
+        "live_status": live_status,
+        "paused": paused,
+        "active_until": active_until,
+        "updated_at": updated_at,
+        "age_seconds": age_seconds,
+        "turn_count": len(turns),
+        "last_transcription": last_turn.get("user", ""),
+        "last_response": state.get("last_answer", "") or last_turn.get("assistant", ""),
+        "pending_validation": state.get("pending_validation"),
+        "last_validated_action": state.get("last_validated_action"),
+    }
+
+
+def _recent_alerts(
+    state: dict[str, Any] | None,
+    actions: list[dict[str, Any]],
+    required_files: dict[str, Path],
+) -> list[dict[str, str]]:
+    alerts: list[dict[str, str]] = []
+    state = state or {}
+    pending = state.get("pending_validation")
+    if pending:
+        alerts.append(
+            {
+                "level": "warning",
+                "title": "Validation en attente",
+                "detail": pending.get("action", "Une action réelle attend une validation vocale."),
+            }
+        )
+    for label, path in required_files.items():
+        if not path.exists():
+            alerts.append(
+                {
+                    "level": "error",
+                    "title": f"Fichier manquant : {label}",
+                    "detail": str(path),
+                }
+            )
+    for action in reversed(actions[-8:]):
+        kind = action.get("kind", "")
+        if kind in {"cancelled_action", "cancelled_dynamic_batch"}:
+            alerts.append(
+                {
+                    "level": "info",
+                    "title": "Action annulée",
+                    "detail": action.get("action", kind),
+                }
+            )
+        if kind == "validated_action" and action.get("execution_status") == "validated_but_not_executed_in_generic_voice_layer":
+            alerts.append(
+                {
+                    "level": "warning",
+                    "title": "Validation sans exécution générique",
+                    "detail": action.get("action", ""),
+                }
+            )
+    return alerts[:8]
+
+
+@router.get("")
+async def personal_cockpit_snapshot():
+    """Return a local cockpit snapshot sourced from jarvis-personal runtime."""
+    voice_cfg = _load_toml(VOICE_CONFIG_PATH)
+    state = _load_json(STATE_PATH)
+    sessions = _load_jsonl_tail(SESSIONS_PATH, 12)
+    actions = _load_jsonl_tail(ACTIONS_PATH, 12)
+    live_brief = _load_json(LIVE_BRIEF_PATH)
+    targeted_move = _load_json(TARGETED_MOVE_PATH)
+    dynamic_candidate = _load_json(DYNAMIC_CANDIDATE_PATH)
+    dynamic_result = _load_json(DYNAMIC_RESULT_PATH)
+    handoffs = _tail_handoffs(limit=5)
+
+    connectors = [
+        _connector_entry("Yahoo", _load_json(INTEGRATIONS_DIR / "yahoo" / "status.json")),
+        _connector_entry("Google", _load_json(INTEGRATIONS_DIR / "google" / "status.json")),
+        _connector_entry("Graphify", _load_json(INTEGRATIONS_DIR / "graphify" / "status.json")),
+    ]
+
+    required_files = {
+        "v4_state": STATE_PATH,
+        "v4_sessions": SESSIONS_PATH,
+        "v4_actions": ACTIONS_PATH,
+    }
+
+    history = [
+        {
+            "timestamp": item.get("timestamp", ""),
+            "intent": item.get("intent", ""),
+            "user": item.get("user", ""),
+            "assistant": item.get("assistant", ""),
+        }
+        for item in sessions[-8:]
+    ]
+
+    return {
+        "meta": {
+            "generated_at": datetime.now().isoformat(timespec="seconds"),
+            "personal_root": str(PERSONAL_ROOT),
+            "voice_runtime": str(VOICE_DIR),
+        },
+        "general_state": _state_summary(state, voice_cfg),
+        "voice_live": {
+            "config_status": voice_cfg.get("voice_v4", {}).get("status", ""),
+            "wake_word": voice_cfg.get("voice_v4", {}).get("wake_word", ""),
+            "vad": voice_cfg.get("voice_v4", {}).get("vad", ""),
+            "stt": voice_cfg.get("voice_v4", {}).get("stt", ""),
+            "tts": voice_cfg.get("voice_v4", {}).get("tts", ""),
+            "commands": voice_cfg.get("voice_v4", {}).get("commands", []),
+            "last_updated_at": (state or {}).get("updated_at", ""),
+        },
+        "latest_transcription": (state or {}).get("turns", [{}])[-1].get("user", "") if (state or {}).get("turns") else "",
+        "latest_response": (state or {}).get("last_answer", ""),
+        "pending_validation": (state or {}).get("pending_validation"),
+        "last_live_brief": live_brief,
+        "yahoo_targeted_move": targeted_move,
+        "yahoo_dynamic_candidate": dynamic_candidate,
+        "yahoo_dynamic_result": dynamic_result,
+        "session_history": history,
+        "recent_actions": actions[-8:],
+        "connectors": connectors,
+        "alerts": _recent_alerts(state, actions, required_files),
+        "continuity": handoffs,
+        "file_health": {
+            label: {
+                "exists": path.exists(),
+                "path": str(path),
+                "modified_at": datetime.fromtimestamp(path.stat().st_mtime).isoformat(timespec="seconds") if path.exists() else "",
+            }
+            for label, path in {
+                "v4_state": STATE_PATH,
+                "v4_sessions": SESSIONS_PATH,
+                "v4_action_queue": ACTIONS_PATH,
+                "voice_live_brief": LIVE_BRIEF_PATH,
+                "yahoo_targeted_move": TARGETED_MOVE_PATH,
+                "yahoo_dynamic_candidate": DYNAMIC_CANDIDATE_PATH,
+                "yahoo_dynamic_result": DYNAMIC_RESULT_PATH,
+                "session_handoffs": HANDOFFS_PATH,
+            }.items()
+        },
+    }


### PR DESCRIPTION
## What does this PR do?
- add a dedicated Jarvis Personal runtime cockpit
- add a backend snapshot endpoint for `jarvis-personal` runtime files
- add a dedicated React page at `/jarvis-personal`
- gate generic frontend polling to reduce background noise on the personal cockpit
- improve readability and calmness of the cockpit without redesigning the overall OpenJarvis app

## How was this tested?
- frontend build validated successfully with `npm run build`

## Notes
- no broad architecture rewrite
- no websocket migration
- personal cockpit stays local, runtime-driven, and focused on operational clarity

## Checklist
- [x] frontend build passes
- [x] no backend rewrite
- [x] no fake controls added
- [x] changes limited to the personal cockpit scope