### PR TITLE
fix(server): replace CORS wildcard fallback with closed localhost list

### DIFF
--- a/src/openjarvis/server/app.py
+++ b/src/openjarvis/server/app.py
@@ -181,7 +181,15 @@ def create_app(
 
     from fastapi.middleware.cors import CORSMiddleware
 
-    _origins = cors_origins if cors_origins is not None else ["*"]
+    _origins = (
+        cors_origins
+        if cors_origins is not None
+        else [
+            "http://localhost:5173",
+            "http://127.0.0.1:5173",
+            "tauri://localhost",
+        ]
+    )
     app.add_middleware(
         CORSMiddleware,
         allow_origins=_origins,


### PR DESCRIPTION
server/app.py defaulted to allow_origins=["*"] combined with allow_credentials=True when cors_origins was not passed. That combination is invalid per the CORS spec — browsers reject it — and when used loosely it signals that any cross-origin request with credentials is allowed, exposing session cookies and auth headers.

The reference config at configs/openjarvis/config.toml binds to 0.0.0.0 without setting cors_origins, so this fallback fired in every default deployment.

Default to a closed list (Vite dev origin + Tauri webview) instead of the wildcard. Users who actually need a custom origin already pass it via cors_origins.

Closes #222

## What does this PR do?

<!-- Brief description of the change and its motivation -->

## How was this tested?

<!-- Describe tests added or manual testing performed -->

## Checklist

- [ ] Tests pass (`uv run pytest tests/ -v`)
- [ ] Linter passes (`uv run ruff check src/ tests/`)
- [ ] Formatter passes (`uv run ruff format --check src/ tests/`)
- [ ] New/changed public API has docstrings
- [ ] Follows registry pattern (if adding new component)
- [ ] Documentation updated (if applicable)
