### PR TITLE
fix(server): allow 'unsafe-inline' 'unsafe-eval' in CSP so dashboard …

### DIFF
--- a/src/openjarvis/server/middleware.py
+++ b/src/openjarvis/server/middleware.py
@@ -48,7 +48,9 @@ def create_security_middleware() -> Any:
             response.headers["Permissions-Policy"] = (
                 "camera=(), microphone=(), geolocation=()"
             )
-            response.headers["Content-Security-Policy"] = "default-src 'self'"
+            response.headers["Content-Security-Policy"] = (
+                "default-src 'self' 'unsafe-inline' 'unsafe-eval'"
+            )
             return response
 
     return SecurityHeadersMiddleware
@@ -62,5 +64,5 @@ SECURITY_HEADERS = {
     "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
     "Referrer-Policy": "strict-origin-when-cross-origin",
     "Permissions-Policy": "camera=(), microphone=(), geolocation=()",
-    "Content-Security-Policy": "default-src 'self'",
+    "Content-Security-Policy": "default-src 'self' 'unsafe-inline' 'unsafe-eval'",
 }


### PR DESCRIPTION
…renders after Rust module compiles

The dashboard at /dashboard renders blank once the Rust security module is compiled (uv run maturin develop ...). The middleware sets "Content-Security-Policy: default-src 'self'", which blocks the inline scripts and styles the dashboard HTML relies on.

Loosen the policy to allow 'unsafe-inline' and 'unsafe-eval' so the dashboard works once the security middleware is active. The same string is exported via SECURITY_HEADERS for tests, so update both call sites.

Closes #261

## What does this PR do?

<!-- Brief description of the change and its motivation -->

## How was this tested?

<!-- Describe tests added or manual testing performed -->

## Checklist

- [ ] Tests pass (`uv run pytest tests/ -v`)
- [ ] Linter passes (`uv run ruff check src/ tests/`)
- [ ] Formatter passes (`uv run ruff format --check src/ tests/`)
- [ ] New/changed public API has docstrings
- [ ] Follows registry pattern (if adding new component)
- [ ] Documentation updated (if applicable)
