### PR TITLE
fix(config): drop [security] enabled=false from reference config so s…

### DIFF
--- a/configs/openjarvis/config.toml
+++ b/configs/openjarvis/config.toml
@@ -109,6 +109,3 @@ db_path = "~/.openjarvis/traces.db"
 host = "0.0.0.0"
 port = 8000
 agent = "native_openhands"
-
-[security]
-enabled = false                           # Disable for eval (no PII scanning overhead)


### PR DESCRIPTION
…ecurity middleware ships on by default

configs/openjarvis/config.toml is the file users copy as their starting configuration. It explicitly set [security] enabled = false (with a comment about eval performance) — meaning users who follow the quickstart unknowingly run with GuardrailsEngine, InjectionScanner, CapabilityPolicy, and rate limiting all disabled.

The SecurityConfig.enabled default in code is True, so removing the override here lets every install ship with security on. Eval workflows that genuinely need it disabled can opt out via their own config.

Closes #224

## What does this PR do?

<!-- Brief description of the change and its motivation -->

## How was this tested?

<!-- Describe tests added or manual testing performed -->

## Checklist

- [ ] Tests pass (`uv run pytest tests/ -v`)
- [ ] Linter passes (`uv run ruff check src/ tests/`)
- [ ] Formatter passes (`uv run ruff format --check src/ tests/`)
- [ ] New/changed public API has docstrings
- [ ] Follows registry pattern (if adding new component)
- [ ] Documentation updated (if applicable)
