### PR TITLE
fix(memory): default context_min_score to 0.0 so FTS5 BM25 results ar…

### DIFF
--- a/src/openjarvis/core/config.py
+++ b/src/openjarvis/core/config.py
@@ -764,7 +764,7 @@ class StorageConfig:
     default_backend: str = "sqlite"
     db_path: str = str(DEFAULT_CONFIG_DIR / "memory.db")
     context_top_k: int = 5
-    context_min_score: float = 0.1
+    context_min_score: float = 0.0
     context_max_tokens: int = 2048
     chunk_size: int = 512
     chunk_overlap: int = 64

--- a/src/openjarvis/tools/storage/context.py
+++ b/src/openjarvis/tools/storage/context.py
@@ -16,7 +16,7 @@ class ContextConfig:
 
     enabled: bool = True
     top_k: int = 5
-    min_score: float = 0.1
+    min_score: float = 0.0
     max_context_tokens: int = 2048
 
 


### PR DESCRIPTION
…en't dropped on small corpora

SQLite FTS5 BM25 scores collapse toward zero on small corpora — when every indexed document contains the query term, IDF approaches zero so scores return ~1e-6. The default context_min_score = 0.1 silently filters out every result before injection, so memory is stored but never reaches the model on a fresh install.

Lowering both defaults to 0.0 lets retrieved context flow through; users who want strict filtering can still set [memory] context_min_score in config.toml.

Closes #262

## What does this PR do?

<!-- Brief description of the change and its motivation -->

## How was this tested?

<!-- Describe tests added or manual testing performed -->

## Checklist

- [ ] Tests pass (`uv run pytest tests/ -v`)
- [ ] Linter passes (`uv run ruff check src/ tests/`)
- [ ] Formatter passes (`uv run ruff format --check src/ tests/`)
- [ ] New/changed public API has docstrings
- [ ] Follows registry pattern (if adding new component)
- [ ] Documentation updated (if applicable)
