### PR TITLE
docs: align quickstart model with CPU-friendly recommendation (qwen3.…

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,13 +69,13 @@ uv run jarvis init
 # 2. Start Ollama and pull a model
 curl -fsSL https://ollama.com/install.sh | sh
 ollama serve &
-ollama pull qwen3:8b
+ollama pull qwen3.5:4b   # CPU-friendly default; use qwen3.5:9b or larger if you have a GPU
 
 # 3. Ask a question
 uv run jarvis ask "What is the capital of France?"
 ```
 
-`jarvis init` auto-detects your hardware and recommends the best engine. Run `uv run jarvis doctor` at any time to diagnose issues.
+`jarvis init` auto-detects your hardware and recommends the best engine and model size. Run `uv run jarvis doctor` at any time to diagnose issues.
 
 ## Starter Configs
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -14,7 +14,7 @@ OpenJarvis is a modular AI assistant framework. Here's what developers build wit
 === "Chat with Any Model"
 
     ```bash
-    jarvis ask "Explain quantum entanglement" -m qwen3:8b
+    jarvis ask "Explain quantum entanglement" -m qwen3.5:4b   # use qwen3.5:9b or larger on GPU
     ```
 
 === "Agent + Tools"


### PR DESCRIPTION
…5:4b)

Reported via twitter (issue #269): the macOS install guide and other docs recommend a 4B model on CPU but the README and quickstart pull / ask a much larger model (qwen3:8b) — confusing and slow for first-time CPU-only users.

Switch the README quickstart and the docs/getting-started/quickstart.md 'Chat with Any Model' tile to qwen3.5:4b, with an inline note that GPU users can scale up to qwen3.5:9b or larger. This matches the existing chat-simple preset and the macOS guide's CPU recommendation.

Closes #269

## What does this PR do?

<!-- Brief description of the change and its motivation -->

## How was this tested?

<!-- Describe tests added or manual testing performed -->

## Checklist

- [ ] Tests pass (`uv run pytest tests/ -v`)
- [ ] Linter passes (`uv run ruff check src/ tests/`)
- [ ] Formatter passes (`uv run ruff format --check src/ tests/`)
- [ ] New/changed public API has docstrings
- [ ] Follows registry pattern (if adding new component)
- [ ] Documentation updated (if applicable)
