### PR TITLE
distillation: promote REVIEW ops to AUTO

### DIFF
--- a/src/openjarvis/learning/distillation/plan/planner.py
+++ b/src/openjarvis/learning/distillation/plan/planner.py
@@ -65,7 +65,7 @@ Each edit object must have ALL of these fields:
 - payload (object matching the schema above for the chosen op)
 - rationale (string explaining why)
 - expected_improvement (cluster id this addresses)
-- risk_tier ("auto" for safe changes, "review" for prompts)
+- risk_tier ("auto" for all v1 ops; the planner overwrites this deterministically)
 - references (list of trace ids that justify this edit)
 
 Respond with ONLY a JSON object: {{"edits": [...]}}

--- a/src/openjarvis/learning/distillation/plan/risk_tier.py
+++ b/src/openjarvis/learning/distillation/plan/risk_tier.py
@@ -22,12 +22,12 @@ TIER_TABLE: dict[EditOp, EditRiskTier] = {
     # Intelligence — safe, reversible
     EditOp.SET_MODEL_FOR_QUERY_CLASS: EditRiskTier.AUTO,
     EditOp.SET_MODEL_PARAM: EditRiskTier.AUTO,
-    # Agent — params are safe, prompts and class need review
-    EditOp.PATCH_SYSTEM_PROMPT: EditRiskTier.REVIEW,
-    EditOp.REPLACE_SYSTEM_PROMPT: EditRiskTier.REVIEW,
-    EditOp.SET_AGENT_CLASS: EditRiskTier.REVIEW,
+    # Agent
+    EditOp.PATCH_SYSTEM_PROMPT: EditRiskTier.AUTO,
+    EditOp.REPLACE_SYSTEM_PROMPT: EditRiskTier.AUTO,
+    EditOp.SET_AGENT_CLASS: EditRiskTier.AUTO,
     EditOp.SET_AGENT_PARAM: EditRiskTier.AUTO,
-    EditOp.EDIT_FEW_SHOT_EXEMPLARS: EditRiskTier.REVIEW,
+    EditOp.EDIT_FEW_SHOT_EXEMPLARS: EditRiskTier.AUTO,
     # Tools — all safe, reversible
     EditOp.ADD_TOOL_TO_AGENT: EditRiskTier.AUTO,
     EditOp.REMOVE_TOOL_FROM_AGENT: EditRiskTier.AUTO,

--- a/tests/learning/distillation/test_risk_tier.py
+++ b/tests/learning/distillation/test_risk_tier.py
@@ -45,24 +45,24 @@ class TestAssignTier:
 
         assert assign_tier(EditOp.SET_AGENT_PARAM) == EditRiskTier.AUTO
 
-    def test_prompt_ops_are_review(self) -> None:
+    def test_prompt_ops_are_auto(self) -> None:
         from openjarvis.learning.distillation.models import EditOp, EditRiskTier
         from openjarvis.learning.distillation.plan.risk_tier import assign_tier
 
-        assert assign_tier(EditOp.PATCH_SYSTEM_PROMPT) == EditRiskTier.REVIEW
-        assert assign_tier(EditOp.REPLACE_SYSTEM_PROMPT) == EditRiskTier.REVIEW
+        assert assign_tier(EditOp.PATCH_SYSTEM_PROMPT) == EditRiskTier.AUTO
+        assert assign_tier(EditOp.REPLACE_SYSTEM_PROMPT) == EditRiskTier.AUTO
 
-    def test_agent_class_is_review(self) -> None:
+    def test_agent_class_is_auto(self) -> None:
         from openjarvis.learning.distillation.models import EditOp, EditRiskTier
         from openjarvis.learning.distillation.plan.risk_tier import assign_tier
 
-        assert assign_tier(EditOp.SET_AGENT_CLASS) == EditRiskTier.REVIEW
+        assert assign_tier(EditOp.SET_AGENT_CLASS) == EditRiskTier.AUTO
 
-    def test_few_shot_is_review(self) -> None:
+    def test_few_shot_is_auto(self) -> None:
         from openjarvis.learning.distillation.models import EditOp, EditRiskTier
         from openjarvis.learning.distillation.plan.risk_tier import assign_tier
 
-        assert assign_tier(EditOp.EDIT_FEW_SHOT_EXEMPLARS) == EditRiskTier.REVIEW
+        assert assign_tier(EditOp.EDIT_FEW_SHOT_EXEMPLARS) == EditRiskTier.AUTO
 
     def test_lora_is_manual(self) -> None:
         from openjarvis.learning.distillation.models import EditOp, EditRiskTier
@@ -83,19 +83,19 @@ class TestAssignTiers:
         )
         from openjarvis.learning.distillation.plan.risk_tier import assign_tiers
 
-        # Teacher incorrectly sets AUTO for a prompt edit
+        # Teacher incorrectly sets AUTO for a LoRA edit (canonical tier is MANUAL)
         edit = Edit(
             id="edit-001",
-            pillar=EditPillar.AGENT,
-            op=EditOp.PATCH_SYSTEM_PROMPT,
-            target="agents.simple.system_prompt",
-            payload={"diff": "--- a\n+++ b\n@@ -1 +1 @@\n-old\n+new"},
-            rationale="Improve prompt",
+            pillar=EditPillar.ENGINE,
+            op=EditOp.LORA_FINETUNE,
+            target="learning.lora.simple",
+            payload={},
+            rationale="Fine-tune for domain",
             expected_improvement="cluster-001",
-            risk_tier=EditRiskTier.AUTO,  # Wrong — should be REVIEW
+            risk_tier=EditRiskTier.AUTO,  # Wrong — should be MANUAL
         )
         result = assign_tiers([edit])
-        assert result[0].risk_tier == EditRiskTier.REVIEW
+        assert result[0].risk_tier == EditRiskTier.MANUAL
 
     def test_preserves_correct_tier(self) -> None:
         from openjarvis.learning.distillation.models import (


### PR DESCRIPTION
Flip PATCH_SYSTEM_PROMPT, REPLACE_SYSTEM_PROMPT, SET_AGENT_CLASS, and EDIT_FEW_SHOT_EXEMPLARS from REVIEW to AUTO in the canonical tier table so they apply automatically when the benchmark gate passes, without waiting for human approval. LORA_FINETUNE remains MANUAL.

- Update test_risk_tier assertions and rework the overwrites_teacher_tier case around LORA_FINETUNE so the AUTO→MANUAL overwrite is still exercised.
- Update planner docstring guidance for the teacher (its tier guess is overwritten anyway).

## What does this PR do?

<!-- Brief description of the change and its motivation -->

## How was this tested?

<!-- Describe tests added or manual testing performed -->

## Checklist

- [ ] Tests pass (`uv run pytest tests/ -v`)
- [ ] Linter passes (`uv run ruff check src/ tests/`)
- [ ] Formatter passes (`uv run ruff format --check src/ tests/`)
- [ ] New/changed public API has docstrings
- [ ] Follows registry pattern (if adding new component)
- [ ] Documentation updated (if applicable)
