### PR TITLE
fix(server): allow Tauri 2 webview origins on every platform

### DIFF
--- a/src/openjarvis/core/config.py
+++ b/src/openjarvis/core/config.py
@@ -845,7 +845,14 @@ class ServerConfig:
             "http://localhost:5173",
             "http://127.0.0.1:3000",
             "http://127.0.0.1:5173",
+            # Tauri 2 production webview origins.
+            # macOS / Linux / iOS use the custom scheme; Windows /
+            # Android use http(s)://tauri.localhost. All three must
+            # be allowed so the desktop app's chat-completions stream
+            # is not blocked by CORS in production builds.
             "tauri://localhost",
+            "http://tauri.localhost",
+            "https://tauri.localhost",
         ]
     )
 

--- a/src/openjarvis/server/app.py
+++ b/src/openjarvis/server/app.py
@@ -187,7 +187,14 @@ def create_app(
         else [
             "http://localhost:5173",
             "http://127.0.0.1:5173",
+            # Tauri 2 production webview origins:
+            #   macOS / Linux / iOS  -> tauri://localhost
+            #   Windows / Android    -> http://tauri.localhost (default),
+            #                           https://tauri.localhost when
+            #                           windows.useHttpsScheme is enabled
             "tauri://localhost",
+            "http://tauri.localhost",
+            "https://tauri.localhost",
         ]
     )
     app.add_middleware(

--- a/tests/security/test_network_defaults.py
+++ b/tests/security/test_network_defaults.py
@@ -29,7 +29,11 @@ class TestServerConfigDefaults:
         assert isinstance(cfg.cors_origins, list)
         assert "http://localhost:3000" in cfg.cors_origins
         assert "http://localhost:5173" in cfg.cors_origins
+        # All three Tauri 2 production webview origins must be allowed
+        # so the desktop chat stream works on every platform.
         assert "tauri://localhost" in cfg.cors_origins
+        assert "http://tauri.localhost" in cfg.cors_origins
+        assert "https://tauri.localhost" in cfg.cors_origins
         assert "*" not in cfg.cors_origins
 
 
@@ -137,3 +141,44 @@ class TestCORSConfiguration:
             },
         )
         assert resp2.headers.get("access-control-allow-origin") != "http://evil.com"
+
+    def test_default_origins_allow_tauri_webview(self) -> None:
+        """Regression: Tauri 2 desktop chat-completions stream must not
+        be blocked by CORS preflight on any platform.
+
+        macOS / Linux use ``tauri://localhost``; Windows / Android use
+        ``http://tauri.localhost`` (or the ``https`` variant when
+        ``windows.useHttpsScheme`` is enabled). The default origin list
+        in ``create_app`` must accept all three so the user does not
+        see "Stream error: Failed to fetch" in the desktop logs.
+        """
+        pytest.importorskip("fastapi")
+        from unittest.mock import MagicMock
+
+        from fastapi.testclient import TestClient
+
+        from openjarvis.server.app import create_app
+
+        mock_engine = MagicMock()
+        mock_engine.health.return_value = True
+        mock_engine.list_models.return_value = ["test-model"]
+
+        app = create_app(mock_engine, "test-model")
+        client = TestClient(app)
+
+        for origin in (
+            "tauri://localhost",
+            "http://tauri.localhost",
+            "https://tauri.localhost",
+        ):
+            resp = client.options(
+                "/v1/chat/completions",
+                headers={
+                    "Origin": origin,
+                    "Access-Control-Request-Method": "POST",
+                    "Access-Control-Request-Headers": "content-type",
+                },
+            )
+            assert resp.headers.get("access-control-allow-origin") == origin, (
+                f"Tauri origin {origin} was not allowed by default CORS list"
+            )


### PR DESCRIPTION
## What does this PR do?

The desktop app's chat-completions stream relies on a raw browser fetch from the Tauri webview to the FastAPI backend, so it is subject to CORS. The default allowlist only contained `tauri://localhost`, which is the production webview origin on macOS, Linux, and iOS. On Windows and Android, Tauri 2 serves the app from `http://tauri.localhost` (or `https://tauri.localhost` when `windows.useHttpsScheme` is enabled), so the preflight for `POST /v1/chat/completions` was rejected and the streaming fetch threw `TypeError: Failed to fetch` before any byte was read.

Symptom users reported: in the Logs tab the request appears to succeed up to "Request sent", followed immediately by "Stream error: Failed to fetch" and "Response: 22 chars" -- which is exactly the length of the synthesized fallback string `Error: Failed to fetch` written by InputArea.tsx when streamChat throws.

Add `http://tauri.localhost` and `https://tauri.localhost` to both default origin lists (`ServerConfig.cors_origins` and the `create_app` fallback), and add a regression test that drives a real preflight against `/v1/chat/completions` for each of the three Tauri origin schemes.

Browser model loading kept working because it is routed through the Rust `tauriInvoke('fetch_models')` command, which is a server-to-server HTTP call not subject to browser CORS -- only streaming chat goes through the webview's fetch.

## Checklist

- [ ] Tests pass (`uv run pytest tests/ -v`)
- [ ] Linter passes (`uv run ruff check src/ tests/`)
- [ ] Formatter passes (`uv run ruff format --check src/ tests/`)
- [ ] New/changed public API has docstrings
- [ ] Follows registry pattern (if adding new component)
- [ ] Documentation updated (if applicable)
