### PR TITLE
fix(windows): RAM detection and CJK stdout encoding

### DIFF
--- a/src/openjarvis/cli/__init__.py
+++ b/src/openjarvis/cli/__init__.py
@@ -119,6 +119,15 @@ except ImportError:
 
 def main() -> None:
     """Entry point registered as ``jarvis`` console script."""
+    import sys
+
+    if sys.platform == "win32":
+        for _stream in (sys.stdout, sys.stderr):
+            if hasattr(_stream, "reconfigure"):
+                try:
+                    _stream.reconfigure(encoding="utf-8", errors="replace")
+                except (AttributeError, OSError):
+                    pass
     cli()
 
 

--- a/src/openjarvis/core/config.py
+++ b/src/openjarvis/core/config.py
@@ -178,13 +178,34 @@ def _total_ram_gb() -> float:
         if platform.system() == "Darwin":
             raw = _run_cmd(["sysctl", "-n", "hw.memsize"])
             return round(int(raw) / (1024**3), 1) if raw else 0.0
+        if platform.system() == "Windows":
+            import ctypes
+
+            class _MemoryStatusEx(ctypes.Structure):
+                _fields_ = [
+                    ("dwLength", ctypes.c_ulong),
+                    ("dwMemoryLoad", ctypes.c_ulong),
+                    ("ullTotalPhys", ctypes.c_ulonglong),
+                    ("ullAvailPhys", ctypes.c_ulonglong),
+                    ("ullTotalPageFile", ctypes.c_ulonglong),
+                    ("ullAvailPageFile", ctypes.c_ulonglong),
+                    ("ullTotalVirtual", ctypes.c_ulonglong),
+                    ("ullAvailVirtual", ctypes.c_ulonglong),
+                    ("sullAvailExtendedVirtual", ctypes.c_ulonglong),
+                ]
+
+            stat = _MemoryStatusEx()
+            stat.dwLength = ctypes.sizeof(_MemoryStatusEx)
+            if ctypes.windll.kernel32.GlobalMemoryStatusEx(ctypes.byref(stat)):
+                return round(stat.ullTotalPhys / (1024**3), 1)
+            return 0.0
         meminfo = Path("/proc/meminfo")
         if meminfo.exists():
             for line in meminfo.read_text().splitlines():
                 if line.startswith("MemTotal"):
                     kb = int(line.split()[1])
                     return round(kb / (1024**2), 1)
-    except (OSError, ValueError):
+    except (OSError, ValueError, AttributeError):
         pass
     return 0.0
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -2,13 +2,52 @@
 
 from __future__ import annotations
 
+import io
+import sys
 from pathlib import Path
 from unittest import mock
 
 from click.testing import CliRunner
 
 import openjarvis
-from openjarvis.cli import cli
+from openjarvis.cli import cli, main
+
+
+class TestMainEntryPoint:
+    """Tests for the ``jarvis`` console script entry point."""
+
+    def test_windows_reconfigures_stdout_to_utf8(self) -> None:
+        """On Windows, main() must reconfigure stdout/stderr to UTF-8 so that
+        CJK characters in CLI output don't trigger UnicodeEncodeError under
+        legacy code pages (cp950, cp932, cp949)."""
+        stdout_mock = mock.MagicMock(spec=io.TextIOWrapper)
+        stderr_mock = mock.MagicMock(spec=io.TextIOWrapper)
+        with (
+            mock.patch.object(sys, "platform", "win32"),
+            mock.patch.object(sys, "stdout", stdout_mock),
+            mock.patch.object(sys, "stderr", stderr_mock),
+            mock.patch("openjarvis.cli.cli") as cli_mock,
+        ):
+            main()
+        stdout_mock.reconfigure.assert_called_once_with(
+            encoding="utf-8", errors="replace"
+        )
+        stderr_mock.reconfigure.assert_called_once_with(
+            encoding="utf-8", errors="replace"
+        )
+        cli_mock.assert_called_once()
+
+    def test_non_windows_does_not_reconfigure(self) -> None:
+        """On non-Windows platforms, stdout/stderr are left untouched."""
+        stdout_mock = mock.MagicMock(spec=io.TextIOWrapper)
+        with (
+            mock.patch.object(sys, "platform", "linux"),
+            mock.patch.object(sys, "stdout", stdout_mock),
+            mock.patch("openjarvis.cli.cli") as cli_mock,
+        ):
+            main()
+        stdout_mock.reconfigure.assert_not_called()
+        cli_mock.assert_called_once()
 
 
 class TestCLI:

--- a/tests/hardware/test_hardware_profiles.py
+++ b/tests/hardware/test_hardware_profiles.py
@@ -3,13 +3,17 @@ and engine recommendation."""
 
 from __future__ import annotations
 
+import sys
 from unittest.mock import patch
+
+import pytest
 
 from openjarvis.core.config import (
     GpuInfo,
     _detect_amd_gpu,
     _detect_apple_gpu,
     _detect_nvidia_gpu,
+    _total_ram_gb,
     recommend_engine,
 )
 
@@ -73,6 +77,31 @@ class TestDetectHardware:
         assert _detect_nvidia_gpu() is None
         assert _detect_amd_gpu() is None
         assert _detect_apple_gpu() is None
+
+
+# ---------------------------------------------------------------------------
+# RAM detection
+# ---------------------------------------------------------------------------
+
+
+class TestTotalRamGb:
+    """Tests for _total_ram_gb() across platforms."""
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="Requires Windows")
+    def test_total_ram_gb_windows(self):
+        """On Windows, GlobalMemoryStatusEx must return a positive RAM value."""
+        ram = _total_ram_gb()
+        assert ram > 0, f"Expected > 0 GB on Windows, got {ram}"
+
+    @pytest.mark.skipif(sys.platform != "darwin", reason="Requires macOS")
+    def test_total_ram_gb_darwin(self):
+        ram = _total_ram_gb()
+        assert ram > 0, f"Expected > 0 GB on macOS, got {ram}"
+
+    @pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Requires Linux")
+    def test_total_ram_gb_linux(self):
+        ram = _total_ram_gb()
+        assert ram > 0, f"Expected > 0 GB on Linux, got {ram}"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Two independent Windows compatibility fixes encountered during first-time setup on a Win11 + RTX 5070 Ti host:

1. **RAM detection** — `_total_ram_gb()` had no Windows branch, so `jarvis init` reported "0.0 GB RAM" and `recommend_model()` under-sized the model tier.
2. **CJK stdout encoding** — `click.echo()` crashed with `UnicodeEncodeError: 'cp950' codec` when the model returned Chinese characters under the legacy code page.

Each fix is its own commit so they can be reverted/cherry-picked independently. No new dependencies — Windows RAM uses `ctypes.windll.kernel32.GlobalMemoryStatusEx`; the encoding fix uses Python 3.7+ `TextIOWrapper.reconfigure()`.

## Test plan
- [x] `pytest tests/hardware/test_hardware_profiles.py` — passes (1 new Windows test, 2 platform-skipped on macOS/Linux)
- [x] `pytest tests/cli/test_cli.py` — passes (2 new TestMainEntryPoint tests)
- [x] Manual: `jarvis init` reports correct RAM (31.1 GB) on a 32 GB Win11 host instead of 0.0 GB
- [x] Manual: ``jarvis ask "你是誰？"`` runs cleanly without `PYTHONIOENCODING=utf-8`
- [x] Linux/macOS branches untouched — fix gated on `platform.system() == "Windows"` and `sys.platform == "win32"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)