### PR TITLE
fix(ask): honor agent.default_agent from config when --agent is omitted

### DIFF
--- a/src/openjarvis/cli/ask.py
+++ b/src/openjarvis/cli/ask.py
@@ -354,7 +354,11 @@ def _print_profile(
     "--agent",
     "agent_name",
     default=None,
-    help="Agent to use (simple, orchestrator).",
+    help=(
+        "Agent to use (simple, orchestrator, ...). "
+        "When omitted, falls back to ``agent.default_agent`` from config. "
+        "Pass ``--agent ''`` to force direct-to-engine mode (no agent)."
+    ),
 )
 @click.option(
     "--tools",
@@ -389,6 +393,16 @@ def ask(
 
     # Load config
     config = load_config()
+
+    # Honor `agent.default_agent` from config when --agent was not explicitly
+    # passed. Pass `--agent ""` to opt out and use direct-to-engine mode.
+    # Without this fallback, `[agent].default_system_prompt` and the
+    # SOUL.md / MEMORY.md / USER.md persona system are silently bypassed for
+    # the most common command (`jarvis ask "..."`).
+    if agent_name is None:
+        configured_default = (config.agent.default_agent or "").strip()
+        if configured_default:
+            agent_name = configured_default
 
     # Track whether the user explicitly set --max-tokens
     user_set_max_tokens = max_tokens is not None
@@ -500,8 +514,8 @@ def ask(
             model_name,
         )
 
-    # Agent mode
-    if agent_name is not None:
+    # Agent mode (treat empty-string `--agent ""` as explicit opt-out)
+    if agent_name:
         parsed_tools = resolve_tool_names(
             tool_names,
             getattr(config.tools, "enabled", None),

--- a/tests/cli/test_ask_agent.py
+++ b/tests/cli/test_ask_agent.py
@@ -212,7 +212,39 @@ class TestAskAgentOption:
         )
         assert result.exit_code != 0
 
-    def test_no_agent_uses_direct_mode(self, runner, mock_setup):
+    def test_no_agent_flag_falls_back_to_config_default_agent(
+        self, runner, mock_setup
+    ):
+        """When --agent is omitted, ``config.agent.default_agent`` is used.
+
+        The default ``JarvisConfig`` sets ``default_agent = "simple"``, so
+        ``jarvis ask "..."`` should route through SimpleAgent rather than
+        the direct-to-engine path. Without this fallback, persona settings
+        (``default_system_prompt`` and SOUL.md/MEMORY.md/USER.md) would be
+        silently bypassed.
+        """
+        result = runner.invoke(cli, ["ask", "Hello"])
+        assert result.exit_code == 0
+        assert "Hello from engine" in result.output
+
+    def test_explicit_empty_agent_opts_out_of_agent_mode(
+        self, runner, mock_setup
+    ):
+        """``--agent ""`` is the explicit opt-out: use direct-to-engine."""
+        result = runner.invoke(cli, ["ask", "--agent", "", "Hello"])
+        assert result.exit_code == 0
+        assert "Hello from engine" in result.output
+
+    def test_no_agent_with_blank_config_default_uses_direct_mode(
+        self, runner, mock_setup, monkeypatch
+    ):
+        """When config's ``default_agent`` is blank and --agent is omitted,
+        the original direct-to-engine path is preserved."""
+        from openjarvis.core.config import JarvisConfig
+
+        cfg = JarvisConfig()
+        cfg.agent.default_agent = ""
+        monkeypatch.setattr(_ask_mod, "load_config", lambda *a, **kw: cfg)
         result = runner.invoke(cli, ["ask", "Hello"])
         assert result.exit_code == 0
         assert "Hello from engine" in result.output

--- a/tests/cli/test_ask_e2e.py
+++ b/tests/cli/test_ask_e2e.py
@@ -32,6 +32,15 @@ def _mock_engine_response():
 
 def _patch_ask(monkeypatch, tmp_path, *, engine_result=None, no_engine=False):
     """Set up common mocks for ask tests."""
+    # Re-register SimpleAgent after the autouse `_clean_registries` conftest
+    # fixture clears it. ``JarvisConfig().agent.default_agent`` defaults to
+    # ``"simple"``, so ``jarvis ask "..."`` (no --agent) routes through it.
+    from openjarvis.agents.simple import SimpleAgent
+    from openjarvis.core.registry import AgentRegistry
+
+    if not AgentRegistry.contains("simple"):
+        AgentRegistry.register_value("simple", SimpleAgent)
+
     cfg = JarvisConfig()
     cfg.telemetry.db_path = str(tmp_path / "telemetry.db")
 

--- a/tests/cli/test_ask_router.py
+++ b/tests/cli/test_ask_router.py
@@ -27,8 +27,23 @@ def _mock_engine():
     return engine
 
 
+def _register_agents():
+    """Re-register agents after the conftest registry clear.
+
+    The default ``JarvisConfig().agent.default_agent`` is ``"simple"``,
+    so ``jarvis ask "..."`` (without ``--agent``) routes through SimpleAgent.
+    Without this re-registration, that path raises ``Unknown agent: simple``.
+    """
+    from openjarvis.agents.simple import SimpleAgent
+    from openjarvis.core.registry import AgentRegistry
+
+    if not AgentRegistry.contains("simple"):
+        AgentRegistry.register_value("simple", SimpleAgent)
+
+
 def _patch_engine(engine):
     """Return context managers that patch engine discovery to use our mock."""
+    _register_agents()
     return (
         mock.patch.object(
             _ask_mod,
@@ -96,6 +111,7 @@ class TestAskModelResolution:
             cfg.intelligence.temperature = 0.7
             cfg.intelligence.max_tokens = 1024
             cfg.agent.context_from_memory = False
+            cfg.agent.default_agent = ""
             result = CliRunner().invoke(cli, ["ask", "Hello"])
         assert result.exit_code == 0
 
@@ -127,5 +143,6 @@ class TestAskModelResolution:
             cfg.intelligence.temperature = 0.7
             cfg.intelligence.max_tokens = 1024
             cfg.agent.context_from_memory = False
+            cfg.agent.default_agent = ""
             result = CliRunner().invoke(cli, ["ask", "Hello"])
         assert result.exit_code == 0


### PR DESCRIPTION
## Summary

`jarvis ask \"...\"` (no \`--agent\` flag) was routing straight to \`engine.generate()\`, completely bypassing the agent layer. As a side-effect, the entire persona system — \`agent.default_system_prompt\`, plus the SOUL.md / MEMORY.md / USER.md files — was silently ignored for the most common command.

This was surprising. The user reads \`agent.default_agent = \"simple\"\` in their generated config, sets \`default_system_prompt\`, restarts \`jarvis ask\`, and the model still answers as the underlying base model with its default identity. The persona machinery exists; it just isn't reached.

## Behavior change

| Invocation | Before | After |
|---|---|---|
| \`jarvis ask --agent simple \"...\"\` | agent path | agent path (unchanged) |
| \`jarvis ask \"...\"\` | direct-to-engine | falls back to \`config.agent.default_agent\` (default \`\"simple\"\`) |
| \`jarvis ask --agent \"\" \"...\"\` | (was treated as agent named \"\") | **new**: explicit opt-out, direct-to-engine |

Existing scripts that rely on direct-to-engine mode can opt back in with \`--agent \"\"\` (or \`agent.default_agent = \"\"\` in config).

## Implementation

\`\`\`python
# src/openjarvis/cli/ask.py
config = load_config()

if agent_name is None:
    configured_default = (config.agent.default_agent or \"\").strip()
    if configured_default:
        agent_name = configured_default

# ...

if agent_name:  # was: if agent_name is not None
    # agent path
\`\`\`

The condition tightening from \`is not None\` to truthy is required so \`--agent \"\"\` becomes the explicit opt-out signal.

## Test plan

- [x] \`pytest tests/cli/test_ask_agent.py tests/cli/test_ask_router.py tests/cli/test_ask_e2e.py\` — 29/29 pass
- [x] Rename \`test_no_agent_uses_direct_mode\` → \`test_no_agent_flag_falls_back_to_config_default_agent\`, update docstring
- [x] Add \`test_explicit_empty_agent_opts_out_of_agent_mode\`
- [x] Add \`test_no_agent_with_blank_config_default_uses_direct_mode\`
- [x] Update \`_patch_engine\` and \`_patch_ask\` test helpers to re-register \`SimpleAgent\` after the autouse \`_clean_registries\` conftest fixture
- [x] Add explicit \`cfg.agent.default_agent = \"\"\` to two router tests that mock \`load_config\` with a MagicMock
- [x] Manual: \`jarvis ask \"你是誰？\"\` now uses \`default_system_prompt\` from config (persona honored); \`jarvis ask --agent \"\" \"What is 2+2?\"\` runs direct-to-engine

## Out of scope (FYI)

- \`tests/cli/test_ask_context.py\` has 2 pre-existing failures on \`origin/main\` (memory backend returns \`None\` on Windows) — unrelated to this change.
- The full \`SystemPromptBuilder\` integration (so SOUL.md / MEMORY.md / USER.md actually load when the agent runs) is a separate, larger change. This PR is the smaller prerequisite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)