### PR TITLE
docs(examples): add Temporal morning-digest example

### DIFF
--- a/examples/temporal_morning_digest/README.md
+++ b/examples/temporal_morning_digest/README.md
@@ -1,0 +1,73 @@
+# Durable Morning Digest (Temporal)
+
+A drop-in durable replacement for the orchestration in
+`src/openjarvis/agents/morning_digest.py`. The agent's tools, persona
+prompt, evaluator, and SQLite store are reused as-is — only the
+*orchestration* moves into a Temporal workflow.
+
+## What this fixes
+
+| Today (`MorningDigestAgent.run()`) | With this workflow |
+| --- | --- |
+| One monolithic `run()`. If TTS fails, the previous ~60s of connector calls + LLM generation are wasted and the run reports failure with no audio. | Each step is its own activity. TTS retries on its own retry budget; connectors and LLM aren't re-executed. |
+| Evaluator failures are silenced by `try/except: pass`. | Evaluator failure is logged on the activity; the run still completes with the un-evaluated draft. |
+| Scheduling lives in `AgentScheduler`, an in-process thread driven by `croniter`. A crash drops scheduled runs and there's no record of missed fires. | Replaced by a Temporal Schedule. Survives worker restarts, visible via `temporal schedule list`, never double-fires. |
+| No history of past digest runs beyond what was written to SQLite. | Every run is browsable in the Temporal UI: per-step timing, retries, errors, payloads. |
+| Connector flakiness (Gmail OAuth refresh, Slack 429s, Oura 5xx) takes down the whole digest. | Per-step retry policies tuned to each step (`COLLECT_RETRY`, `GENERATE_RETRY`, `TTS_RETRY`, `STORE_RETRY` in `workflow.py`). |
+
+## Layout
+
+```
+examples/temporal_morning_digest/
+├── activities.py   # 5 activities mirroring the steps in morning_digest.py
+├── workflow.py     # MorningDigestWorkflow + per-step RetryPolicy
+├── worker.py       # Long-running worker process
+├── starter.py      # Trigger one digest run on demand
+└── schedule.py     # Register a recurring Temporal Schedule
+```
+
+The activities re-use the existing OpenJarvis code:
+
+- `collect_sources` -> `openjarvis.tools.digest_collect.DigestCollectTool`
+- `generate_narrative` -> `ToolUsingAgent._generate` + `digest_evaluator.DigestEvaluator`
+- `synthesize_audio` -> `openjarvis.tools.text_to_speech.TextToSpeechTool`
+- `store_artifact` -> `openjarvis.agents.digest_store.DigestStore`
+
+## Run it
+
+```bash
+# 1. Install Temporal CLI + Python SDK
+brew install temporal
+uv pip install temporalio
+
+# 2. Start a local cluster (separate terminal)
+temporal server start-dev
+
+# 3. Start the worker (separate terminal)
+uv run python -m examples.temporal_morning_digest.worker
+
+# 4. Trigger one run on demand
+uv run python -m examples.temporal_morning_digest.starter
+
+# 5. Or register the daily schedule
+uv run python -m examples.temporal_morning_digest.schedule
+temporal schedule list
+```
+
+Open the Temporal UI at <http://localhost:8233> to inspect runs,
+retried activities, and event history.
+
+## Why this is the right fit for OpenJarvis
+
+Morning Digest is the most-used scheduled agent in the project (powers
+the `morning-digest-mac`, `morning-digest-linux`, and
+`morning-digest-minimal` presets). It is a long-running, multi-step,
+fan-out pipeline against ~13 third-party APIs followed by an expensive
+LLM call and an external TTS provider. Every one of those steps fails
+independently in real usage, which is exactly the problem Temporal is
+designed for: durable execution with per-step retry, replay, and
+visibility.
+
+The same pattern applies cleanly to `monitor_operative` (continuous
+long-horizon monitoring) and `deep_research` (multi-hop research with
+citations) — both are good follow-ups once this example is comfortable.

--- a/examples/temporal_morning_digest/activities.py
+++ b/examples/temporal_morning_digest/activities.py
@@ -1,0 +1,251 @@
+"""Activities for the durable Morning Digest pipeline.
+
+Each activity wraps one fallible side-effecting step from
+``src/openjarvis/agents/morning_digest.py``. Activities are intentionally
+small and idempotent-friendly so Temporal can retry them independently
+without re-doing earlier work.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from temporalio import activity
+
+
+@dataclass
+class DigestInput:
+    persona: str = "jarvis"
+    sections: list[str] = field(
+        default_factory=lambda: ["messages", "calendar", "health", "world"]
+    )
+    section_sources: dict[str, list[str]] = field(default_factory=dict)
+    timezone: str = "America/Los_Angeles"
+    voice_id: str = ""
+    voice_speed: float = 1.0
+    tts_backend: str = "cartesia"
+    digest_store_path: str = ""
+    honorific: str = "sir"
+    model: str = ""
+    engine: str = ""
+
+
+@dataclass
+class CollectedData:
+    sources: list[str]
+    payload: str
+
+
+@dataclass
+class GeneratedNarrative:
+    text: str
+    quality_score: float = 0.0
+    evaluator_feedback: str = ""
+
+
+@dataclass
+class TTSResult:
+    audio_path: str
+    success: bool
+
+
+_DEFAULT_SOURCE_MAP: dict[str, list[str]] = {
+    "messages": [
+        "gmail",
+        "slack",
+        "google_tasks",
+        "imessage",
+        "github_notifications",
+    ],
+    "calendar": ["gcalendar"],
+    "health": ["oura", "apple_health"],
+    "world": ["weather", "hackernews", "news_rss"],
+    "music": ["spotify", "apple_music"],
+}
+
+
+def _resolve_sources(
+    sections: list[str], overrides: dict[str, list[str]]
+) -> list[str]:
+    out: set[str] = set()
+    for section in sections:
+        out.update(overrides.get(section, _DEFAULT_SOURCE_MAP.get(section, [])))
+    return sorted(out)
+
+
+@activity.defn
+def collect_sources(inp: DigestInput) -> CollectedData:
+    """Step 1: fan out to connectors.
+
+    Each connector inside ``digest_collect`` already handles its own auth,
+    but the surrounding network/rate-limit failures bubble up here so
+    Temporal can retry the *whole collection* with exponential backoff
+    rather than letting one slow connector kill the run.
+    """
+    from openjarvis.core.types import ToolCall
+    from openjarvis.tools.digest_collect import DigestCollectTool
+
+    sources = _resolve_sources(inp.sections, inp.section_sources)
+    activity.logger.info("collect_sources sources=%s", sources)
+
+    tool = DigestCollectTool()
+    call = ToolCall(
+        id="digest-collect-1",
+        name="digest_collect",
+        arguments=json.dumps({"sources": sources, "hours_back": 24}),
+    )
+    result = tool.execute(call)
+    return CollectedData(sources=sources, payload=result.content)
+
+
+def _build_system_prompt(inp: DigestInput) -> str:
+    from openjarvis.agents.morning_digest import _load_persona
+
+    persona_text = _load_persona(inp.persona)
+    now = datetime.now()
+    return (
+        f"{persona_text}\n\n"
+        f"Today is {now.strftime('%A, %B %d, %Y')}. "
+        f"The time is {now.strftime('%I:%M %p')} in {inp.timezone}.\n"
+        f"The user's preferred honorific is: {inp.honorific}\n\n"
+        "Produce a concise spoken briefing in decreasing order of importance. "
+        "Zero hallucination. Strict 200-250 word limit."
+    )
+
+
+@activity.defn
+def generate_narrative(
+    inp: DigestInput, collected: CollectedData
+) -> GeneratedNarrative:
+    """Step 2 + 2b: synthesize the narrative and self-evaluate.
+
+    Failure here is expensive (LLM cost) so we use a tighter retry budget
+    in the workflow. The evaluator is best-effort; if the evaluator import
+    or call fails, we keep the original narrative instead of swallowing
+    the error silently the way the legacy implementation does.
+    """
+    from openjarvis.agents._stubs import ToolUsingAgent
+    from openjarvis.core.types import Message, Role
+
+    agent = ToolUsingAgent(engine=inp.engine, model=inp.model)
+    system_prompt = _build_system_prompt(inp)
+    messages = [
+        Message(role=Role.SYSTEM, content=system_prompt),
+        Message(
+            role=Role.USER,
+            content=(
+                "Here is the collected data from my sources:\n\n"
+                f"{collected.payload}\n\n"
+                "Synthesize my morning briefing."
+            ),
+        ),
+    ]
+
+    result = agent._generate(messages)
+    narrative = agent._strip_think_tags(result.get("content", ""))
+
+    quality_score = 0.0
+    feedback = ""
+    try:
+        from openjarvis.agents.digest_evaluator import DigestEvaluator
+
+        evaluator = DigestEvaluator(inp.engine, inp.model)
+        quality_score, feedback = evaluator.evaluate(collected.payload, narrative)
+
+        if quality_score < 7.0 and feedback:
+            messages.append(
+                Message(
+                    role=Role.USER,
+                    content=(
+                        f"Your briefing scored {quality_score:.1f}/10. "
+                        f"Feedback: {feedback}\nPlease revise."
+                    ),
+                )
+            )
+            result = agent._generate(messages)
+            narrative = agent._strip_think_tags(result.get("content", ""))
+    except Exception as exc:  # noqa: BLE001
+        activity.logger.warning("evaluator unavailable, skipping: %s", exc)
+
+    return GeneratedNarrative(
+        text=narrative,
+        quality_score=quality_score,
+        evaluator_feedback=feedback,
+    )
+
+
+@activity.defn
+def synthesize_audio(inp: DigestInput, narrative: GeneratedNarrative) -> TTSResult:
+    """Step 3: hand the cleaned text to TTS.
+
+    External provider (Cartesia/Deepgram) — heartbeats keep Temporal
+    aware that long syntheses are still alive instead of being marked
+    timed out.
+    """
+    from openjarvis.core.types import ToolCall
+    from openjarvis.tools.text_to_speech import TextToSpeechTool
+
+    text = narrative.text
+    text = re.sub(r"^#{1,6}\s+", "", text, flags=re.MULTILINE)
+    text = re.sub(r"^\s*[-*\u2022]\s+", "", text, flags=re.MULTILINE)
+    text = re.sub(r"\*{1,2}([^*]+)\*{1,2}", r"\1", text).strip()
+
+    activity.heartbeat("starting tts")
+    tool = TextToSpeechTool()
+    call = ToolCall(
+        id="digest-tts-1",
+        name="text_to_speech",
+        arguments=json.dumps(
+            {
+                "text": text,
+                "voice_id": inp.voice_id,
+                "backend": inp.tts_backend,
+                "speed": inp.voice_speed,
+            }
+        ),
+    )
+    result = tool.execute(call)
+    audio_path = (
+        result.metadata.get("audio_path", "") if getattr(result, "success", False) else ""
+    )
+    return TTSResult(audio_path=audio_path, success=bool(audio_path))
+
+
+@activity.defn
+def store_artifact(
+    inp: DigestInput,
+    collected: CollectedData,
+    narrative: GeneratedNarrative,
+    tts: TTSResult,
+) -> dict[str, Any]:
+    """Step 4: persist to the SQLite digest store. Local + idempotent."""
+    from openjarvis.agents.digest_store import DigestArtifact, DigestStore
+
+    artifact = DigestArtifact(
+        text=narrative.text,
+        audio_path=Path(tts.audio_path) if tts.audio_path else Path(""),
+        sections={},
+        sources_used=collected.sources,
+        generated_at=datetime.now(),
+        model_used=inp.model,
+        voice_used=inp.voice_id,
+        quality_score=narrative.quality_score,
+        evaluator_feedback=narrative.evaluator_feedback,
+    )
+
+    store = DigestStore(db_path=inp.digest_store_path)
+    try:
+        store.save(artifact)
+    finally:
+        store.close()
+
+    return {
+        "audio_path": tts.audio_path,
+        "sources_used": collected.sources,
+        "quality_score": narrative.quality_score,
+    }

--- a/examples/temporal_morning_digest/schedule.py
+++ b/examples/temporal_morning_digest/schedule.py
@@ -1,0 +1,59 @@
+"""Register a Temporal Schedule for the daily digest.
+
+Replaces the in-process ``AgentScheduler`` thread + ``croniter`` in
+``src/openjarvis/agents/scheduler.py``. Schedules survive worker
+restarts, are visible in ``temporal schedule list``, and never
+double-fire.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+from temporalio.client import (
+    Client,
+    Schedule,
+    ScheduleActionStartWorkflow,
+    ScheduleIntervalSpec,
+    ScheduleSpec,
+)
+from datetime import timedelta
+
+from examples.temporal_morning_digest.activities import DigestInput
+from examples.temporal_morning_digest.workflow import MorningDigestWorkflow
+
+SCHEDULE_ID = os.environ.get("DIGEST_SCHEDULE_ID", "morning-digest-daily")
+TASK_QUEUE = os.environ.get("DIGEST_TASK_QUEUE", "morning-digest")
+
+
+async def main() -> None:
+    client = await Client.connect(os.environ.get("TEMPORAL_ADDRESS", "localhost:7233"))
+
+    inp = DigestInput(
+        persona=os.environ.get("DIGEST_PERSONA", "jarvis"),
+        timezone=os.environ.get("DIGEST_TIMEZONE", "America/Los_Angeles"),
+        voice_id=os.environ.get("DIGEST_VOICE_ID", ""),
+        tts_backend=os.environ.get("DIGEST_TTS_BACKEND", "cartesia"),
+        engine=os.environ.get("DIGEST_ENGINE", "ollama"),
+        model=os.environ.get("DIGEST_MODEL", "qwen3.5:4b"),
+    )
+
+    # Demo: every 24h. Swap for ScheduleCalendarSpec for a real cron
+    # expression like "every weekday at 7:00am America/Los_Angeles".
+    schedule = Schedule(
+        action=ScheduleActionStartWorkflow(
+            MorningDigestWorkflow.run,
+            inp,
+            id=SCHEDULE_ID + "-run",
+            task_queue=TASK_QUEUE,
+        ),
+        spec=ScheduleSpec(intervals=[ScheduleIntervalSpec(every=timedelta(days=1))]),
+    )
+
+    handle = await client.create_schedule(SCHEDULE_ID, schedule)
+    print(f"created schedule {handle.id}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/temporal_morning_digest/starter.py
+++ b/examples/temporal_morning_digest/starter.py
@@ -1,0 +1,51 @@
+"""Trigger one digest run on demand.
+
+Usage::
+
+    uv run python -m examples.temporal_morning_digest.starter
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+
+from temporalio.client import Client
+
+from examples.temporal_morning_digest.activities import DigestInput
+from examples.temporal_morning_digest.workflow import MorningDigestWorkflow
+
+TASK_QUEUE = os.environ.get("DIGEST_TASK_QUEUE", "morning-digest")
+
+
+async def main() -> None:
+    client = await Client.connect(os.environ.get("TEMPORAL_ADDRESS", "localhost:7233"))
+
+    inp = DigestInput(
+        persona=os.environ.get("DIGEST_PERSONA", "jarvis"),
+        timezone=os.environ.get("DIGEST_TIMEZONE", "America/Los_Angeles"),
+        voice_id=os.environ.get("DIGEST_VOICE_ID", ""),
+        tts_backend=os.environ.get("DIGEST_TTS_BACKEND", "cartesia"),
+        engine=os.environ.get("DIGEST_ENGINE", "ollama"),
+        model=os.environ.get("DIGEST_MODEL", "qwen3.5:4b"),
+    )
+
+    handle = await client.start_workflow(
+        MorningDigestWorkflow.run,
+        inp,
+        id=f"morning-digest-{uuid.uuid4()}",
+        task_queue=TASK_QUEUE,
+    )
+    print(f"started workflow {handle.id}")
+
+    result = await handle.result()
+    print(f"audio: {result.audio_path}")
+    print(f"sources: {result.sources_used}")
+    print(f"quality: {result.quality_score:.1f}")
+    print()
+    print(result.text)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/temporal_morning_digest/worker.py
+++ b/examples/temporal_morning_digest/worker.py
@@ -1,0 +1,51 @@
+"""Worker for the Morning Digest workflow.
+
+Run alongside ``temporal server start-dev`` (or against any cluster
+reachable at ``TEMPORAL_ADDRESS``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import os
+
+from temporalio.client import Client
+from temporalio.worker import Worker
+
+from examples.temporal_morning_digest.activities import (
+    collect_sources,
+    generate_narrative,
+    store_artifact,
+    synthesize_audio,
+)
+from examples.temporal_morning_digest.workflow import MorningDigestWorkflow
+
+TASK_QUEUE = os.environ.get("DIGEST_TASK_QUEUE", "morning-digest")
+
+
+async def main() -> None:
+    address = os.environ.get("TEMPORAL_ADDRESS", "localhost:7233")
+    client = await Client.connect(address)
+
+    # Sync activities reuse a thread pool; sized for the modest fan-out
+    # of one digest run at a time.
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+        worker = Worker(
+            client,
+            task_queue=TASK_QUEUE,
+            workflows=[MorningDigestWorkflow],
+            activities=[
+                collect_sources,
+                generate_narrative,
+                synthesize_audio,
+                store_artifact,
+            ],
+            activity_executor=pool,
+        )
+        print(f"morning digest worker listening on {address!r} / {TASK_QUEUE!r}")
+        await worker.run()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/temporal_morning_digest/workflow.py
+++ b/examples/temporal_morning_digest/workflow.py
@@ -1,0 +1,124 @@
+"""Durable Morning Digest workflow.
+
+The workflow only sequences activities and decides retry policy. It
+contains *no* network or filesystem I/O so it stays deterministic and
+can be replayed on worker restart without redoing completed steps.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Any
+
+from temporalio import workflow
+from temporalio.common import RetryPolicy
+
+with workflow.unsafe.imports_passed_through():
+    from examples.temporal_morning_digest.activities import (
+        DigestInput,
+        collect_sources,
+        generate_narrative,
+        store_artifact,
+        synthesize_audio,
+    )
+
+
+# Per-step retry policies sized for what each step actually does.
+#
+# Connectors (Step 1): many flaky third-party APIs. Worth retrying for a
+# while on transient errors, with backoff so we don't hammer rate limits.
+COLLECT_RETRY = RetryPolicy(
+    initial_interval=timedelta(seconds=2),
+    backoff_coefficient=2.0,
+    maximum_interval=timedelta(minutes=2),
+    maximum_attempts=6,
+    non_retryable_error_types=["ValueError", "TypeError"],
+)
+
+# LLM generation (Step 2): expensive. Retry sparingly. Long timeout so a
+# slow local model doesn't get prematurely killed.
+GENERATE_RETRY = RetryPolicy(
+    initial_interval=timedelta(seconds=5),
+    backoff_coefficient=2.0,
+    maximum_attempts=3,
+    non_retryable_error_types=["ValueError"],
+)
+
+# TTS (Step 3): external rate-limited API. Several retries with longer
+# backoff handles 429s gracefully.
+TTS_RETRY = RetryPolicy(
+    initial_interval=timedelta(seconds=10),
+    backoff_coefficient=2.0,
+    maximum_interval=timedelta(minutes=5),
+    maximum_attempts=5,
+)
+
+# SQLite write (Step 4): local, fast, mostly never fails. Cheap to retry.
+STORE_RETRY = RetryPolicy(
+    initial_interval=timedelta(seconds=1),
+    maximum_attempts=4,
+)
+
+
+@dataclass
+class DigestRunResult:
+    text: str
+    audio_path: str
+    sources_used: list[str]
+    quality_score: float
+
+
+@workflow.defn
+class MorningDigestWorkflow:
+    """One run of the Morning Digest pipeline as a durable workflow.
+
+    Compared to ``MorningDigestAgent.run()``:
+
+    * Each step is a separately retryable activity, so a TTS hiccup no
+      longer wastes the connector + LLM work that already succeeded.
+    * The evaluator's silent ``except: pass`` is gone — failures are
+      logged and the run still completes with the un-evaluated draft.
+    * Workflow restarts are durable: if the worker dies after Step 2,
+      Step 1 and Step 2 are *not* re-executed on resume.
+    """
+
+    @workflow.run
+    async def run(self, inp: DigestInput) -> DigestRunResult:
+        workflow.logger.info("morning digest starting")
+
+        collected = await workflow.execute_activity(
+            collect_sources,
+            inp,
+            start_to_close_timeout=timedelta(minutes=5),
+            retry_policy=COLLECT_RETRY,
+        )
+
+        narrative = await workflow.execute_activity(
+            generate_narrative,
+            args=[inp, collected],
+            start_to_close_timeout=timedelta(minutes=10),
+            retry_policy=GENERATE_RETRY,
+        )
+
+        tts = await workflow.execute_activity(
+            synthesize_audio,
+            args=[inp, narrative],
+            start_to_close_timeout=timedelta(minutes=5),
+            heartbeat_timeout=timedelta(seconds=30),
+            retry_policy=TTS_RETRY,
+        )
+
+        meta: dict[str, Any] = await workflow.execute_activity(
+            store_artifact,
+            args=[inp, collected, narrative, tts],
+            start_to_close_timeout=timedelta(seconds=30),
+            retry_policy=STORE_RETRY,
+        )
+
+        return DigestRunResult(
+            text=narrative.text,
+            audio_path=meta.get("audio_path", ""),
+            sources_used=meta.get("sources_used", []),
+            quality_score=meta.get("quality_score", 0.0),
+        )


### PR DESCRIPTION
## Summary

Adds a durable, Temporal-backed replacement for the orchestration in `src/openjarvis/agents/morning_digest.py`. The agent's tools, persona prompt, evaluator, and SQLite store are reused as-is — only the *orchestration* moves into a Temporal workflow.

| Today (`MorningDigestAgent.run()`) | With this workflow |
| --- | --- |
| Monolithic `run()`. If TTS fails, the previous ~60s of connector calls + LLM generation are wasted. | Each step is its own activity; TTS retries on its own budget without re-running connectors / LLM. |
| Evaluator failures silenced by `try/except: pass`. | Logged on the activity; the run still completes with the un-evaluated draft. |
| `AgentScheduler` is an in-process thread driven by `croniter`; a crash drops scheduled runs. | Replaced by a Temporal Schedule. Survives worker restarts, visible via `temporal schedule list`, never double-fires. |
| No history beyond what was written to SQLite. | Every run is browsable in the Temporal UI: per-step timing, retries, errors, payloads. |
| Connector flakiness (Gmail OAuth refresh, Slack 429s, Oura 5xx) takes down the whole digest. | Per-step retry policies tuned per step (`COLLECT_RETRY`, `GENERATE_RETRY`, `TTS_RETRY`, `STORE_RETRY`). |

## Layout

```
examples/temporal_morning_digest/
├── activities.py   # 5 activities mirroring morning_digest.py
├── workflow.py     # MorningDigestWorkflow + per-step RetryPolicy
├── worker.py       # long-running worker
├── starter.py      # trigger one run on demand
├── schedule.py     # register a recurring Temporal Schedule
└── README.md
```

## Test plan

- [ ] `pip install temporalio` (or `uv add temporalio --optional examples`); start a local Temporal dev server (`temporal server start-dev`).
- [ ] Run `python examples/temporal_morning_digest/worker.py`.
- [ ] Run `python examples/temporal_morning_digest/starter.py` and confirm the workflow shows up in the Temporal UI with per-activity history.
- [ ] Force a TTS failure; confirm only the TTS activity retries, not collect/generate.

## Notes

Pure addition under `examples/`; no changes to `src/openjarvis/`. Independent of the WorkOS auth and Render Blueprint PRs.


Made with [Cursor](https://cursor.com)