### PR TITLE
feat(evals): add qwen-27b/gemma-31b to comparison catalog

### DIFF
--- a/scripts/smoke_framework_comparison.sh
+++ b/scripts/smoke_framework_comparison.sh
@@ -11,6 +11,11 @@
 #
 # Optional:
 #   JARVIS_ALLOW_COMMIT_DRIFT=1  - bypass commit-pin enforcement
+#   SMOKE_CONFIG_DIR             - generated config dir (default: results/comparison/configs)
+#   SMOKE_OUTPUT_BASE            - smoke result dir (default: results/comparison/smoke)
+#   SMOKE_MODEL                  - model slug to smoke (default: qwen-9b)
+#   OPENJARVIS_BASELINE_CONFIG   - baseline OpenJarvis config for openjarvis cells
+#   OPENJARVIS_DISTILLED_CONFIG  - distilled OpenJarvis config for openjarvis-distilled cells
 
 set -euo pipefail
 
@@ -33,6 +38,11 @@ fi
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
+SMOKE_CONFIG_DIR="${SMOKE_CONFIG_DIR:-results/comparison/configs}"
+SMOKE_OUTPUT_BASE="${SMOKE_OUTPUT_BASE:-results/comparison/smoke}"
+SMOKE_MODEL="${SMOKE_MODEL:-qwen-9b}"
+OPENJARVIS_BASELINE_CONFIG="${OPENJARVIS_BASELINE_CONFIG:-${OPENJARVIS_CONFIG:-configs/openjarvis/config.toml}}"
+
 echo "==> Verifying commit pins"
 uv run python -c "
 from openjarvis.evals.comparison.third_party import (
@@ -45,33 +55,72 @@ for name, entry in cfg.entries.items():
 print('  all pins OK')
 "
 
+echo "==> Verifying model endpoint"
+curl -sf "${JARVIS_MOCK_LLM_URL%/}/models" >/dev/null
+echo "  endpoint OK: ${JARVIS_MOCK_LLM_URL%/}/models"
+
+if [ ! -d "$SMOKE_CONFIG_DIR" ] || ! compgen -G "$SMOKE_CONFIG_DIR/*-${SMOKE_MODEL}.toml" >/dev/null; then
+  echo "==> Materializing generated configs into $SMOKE_CONFIG_DIR"
+  uv run python -m openjarvis.evals.comparison.make_configs \
+    --all-tier1 \
+    --output-dir "$SMOKE_CONFIG_DIR"
+fi
+
 echo "==> Running one-task smoke per (framework, benchmark)"
-mkdir -p results/smoke
+mkdir -p "$SMOKE_OUTPUT_BASE"
 SMOKE_BENCHES=(toolcall15 pinchbench gaia)
-SMOKE_FRAMEWORKS=(hermes openclaw openjarvis)
-SMOKE_MODEL="qwen-9b"
+SMOKE_FRAMEWORKS=(openjarvis openjarvis-distilled hermes openclaw)
+
+run_cell() {
+  local fwk="$1"
+  local bench="$2"
+  local config="$SMOKE_CONFIG_DIR/${bench}-${fwk}-${SMOKE_MODEL}.toml"
+  local output_dir="$SMOKE_OUTPUT_BASE/${fwk}/${SMOKE_MODEL}/${bench}/"
+
+  if [ ! -f "$config" ]; then
+    echo "  ! missing config: $config"
+    return 0
+  fi
+
+  echo "  - $fwk x $bench"
+  case "$fwk" in
+    openjarvis)
+      OPENJARVIS_CONFIG="$OPENJARVIS_BASELINE_CONFIG" \
+        uv run python -m openjarvis.evals run --config "$config" --max-samples 1 \
+          --output-dir "$output_dir" \
+        || echo "    FAILED (continuing)"
+      ;;
+    openjarvis-distilled)
+      if [ -z "${OPENJARVIS_DISTILLED_CONFIG:-}" ]; then
+        echo "    SKIPPED (set OPENJARVIS_DISTILLED_CONFIG for distilled smoke cells)"
+        return 0
+      fi
+      OPENJARVIS_CONFIG="$OPENJARVIS_DISTILLED_CONFIG" \
+        uv run python -m openjarvis.evals run --config "$config" --max-samples 1 \
+          --output-dir "$output_dir" \
+        || echo "    FAILED (continuing)"
+      ;;
+    *)
+      uv run python -m openjarvis.evals run --config "$config" --max-samples 1 \
+        --output-dir "$output_dir" \
+        || echo "    FAILED (continuing)"
+      ;;
+  esac
+}
 
 for fwk in "${SMOKE_FRAMEWORKS[@]}"; do
   for bench in "${SMOKE_BENCHES[@]}"; do
-    config="src/openjarvis/evals/configs/framework_comparison/${bench}-${fwk}-${SMOKE_MODEL}.toml"
-    if [ ! -f "$config" ]; then
-      echo "  ! missing config: $config (run make_configs --all-tier1 (or materialize the configs you need))"
-      continue
-    fi
-    echo "  ▸ $fwk × $bench"
-    uv run python -m openjarvis.evals run --config "$config" --max-samples 1 \
-      --output-dir "results/smoke/${fwk}/${SMOKE_MODEL}/${bench}/" \
-      || echo "    FAILED (continuing)"
+    run_cell "$fwk" "$bench"
   done
 done
 
 echo "==> Generating T1 from smoke results"
 uv run python -m openjarvis.evals.comparison.table_gen \
-    --results-glob "results/smoke/**/summary.json" \
+    --results-glob "$SMOKE_OUTPUT_BASE/**/summary.json" \
     --tables T1 \
-    --output-dir results/smoke/tables/
+    --output-dir "$SMOKE_OUTPUT_BASE/tables/"
 
 echo "==> Verifying T1.tex non-empty"
-test -s results/smoke/tables/T1.tex && echo "  OK: T1.tex emitted"
+test -s "$SMOKE_OUTPUT_BASE/tables/T1.tex" && echo "  OK: T1.tex emitted"
 
 echo "==> Smoke validation complete"

--- a/src/openjarvis/evals/comparison/make_configs.py
+++ b/src/openjarvis/evals/comparison/make_configs.py
@@ -40,6 +40,20 @@ MODELS: Dict[str, Dict[str, object]] = {
         "num_gpus": 1,
         "max_tokens": 8192,
     },
+    "qwen-27b": {
+        "model_id": "Qwen/Qwen3.6-27B",
+        "model_pretty": "Qwen3.6-27B",
+        "engine": "vllm",
+        "num_gpus": 1,
+        "max_tokens": 8192,
+    },
+    "gemma-31b": {
+        "model_id": "google/gemma-4-31B-it",
+        "model_pretty": "Gemma 4 31B IT",
+        "engine": "vllm",
+        "num_gpus": 1,
+        "max_tokens": 8192,
+    },
     "qwen-122b": {
         "model_id": "Qwen/Qwen3.5-122B",
         "model_pretty": "Qwen3.5-122B",
@@ -173,7 +187,10 @@ def materialize_config(
 @click.option(
     "--all-tier1",
     is_flag=True,
-    help="Materialize the full configs grid (4 frameworks x 8 benchmarks x 3 models)",
+    help=(
+        "Materialize the full configs grid "
+        "(4 frameworks x 8 benchmarks x all catalog models)"
+    ),
 )
 def main(
     framework: Optional[str],
@@ -184,10 +201,9 @@ def main(
 ) -> None:
     """Generate eval config TOMLs for the framework-comparison experiment."""
     if all_tier1:
-        tier1_models = ["claude-opus-46", "qwen-9b", "qwen-122b"]
         count = 0
         for f in FRAMEWORKS:
-            for m in tier1_models:
+            for m in MODELS:
                 for b in BENCHMARKS:
                     p = materialize_config(f, m, b, output_dir)
                     click.echo(f"  wrote {p.name}")

--- a/tests/evals/comparison/test_make_configs.py
+++ b/tests/evals/comparison/test_make_configs.py
@@ -6,11 +6,13 @@ from pathlib import Path
 
 import pytest
 import tomllib
+from click.testing import CliRunner
 
 from openjarvis.evals.comparison.make_configs import (
     BENCHMARKS,  # noqa: F401  (verify export)
     FRAMEWORKS,  # noqa: F401  (verify export)
     MODELS,
+    main,
     materialize_config,
 )
 
@@ -38,6 +40,30 @@ class TestMaterializeConfig:
             output_dir=tmp_path,
         )
         assert out.name == "gaia-hermes-qwen-9b.toml"
+
+    def test_mid_size_models_available(self, tmp_path: Path) -> None:
+        qwen = materialize_config(
+            framework="openjarvis",
+            model="qwen-27b",
+            benchmark="gaia",
+            output_dir=tmp_path,
+        )
+        gemma = materialize_config(
+            framework="openjarvis",
+            model="gemma-31b",
+            benchmark="gaia",
+            output_dir=tmp_path,
+        )
+
+        with open(qwen, "rb") as fh:
+            qwen_data = tomllib.load(fh)
+        with open(gemma, "rb") as fh:
+            gemma_data = tomllib.load(fh)
+
+        assert qwen.name == "gaia-openjarvis-qwen-27b.toml"
+        assert qwen_data["models"][0]["name"] == "Qwen/Qwen3.6-27B"
+        assert gemma.name == "gaia-openjarvis-gemma-31b.toml"
+        assert gemma_data["models"][0]["name"] == "google/gemma-4-31B-it"
 
     def test_unknown_framework_rejected(self, tmp_path: Path) -> None:
         with pytest.raises(ValueError, match="unknown framework"):
@@ -95,3 +121,18 @@ class TestTemplateStripping:
         assert first_non_blank.startswith("[meta]"), (
             f"Expected first line to be [meta], got: {first_non_blank!r}"
         )
+
+
+class TestCli:
+    def test_all_tier1_emits_expanded_model_grid(self, tmp_path: Path) -> None:
+        result = CliRunner().invoke(
+            main,
+            ["--all-tier1", "--output-dir", str(tmp_path)],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert len(list(tmp_path.glob("*.toml"))) == (
+            len(FRAMEWORKS) * len(MODELS) * len(BENCHMARKS)
+        )
+        assert (tmp_path / "gaia-openjarvis-qwen-27b.toml").exists()
+        assert (tmp_path / "gaia-openjarvis-gemma-31b.toml").exists()


### PR DESCRIPTION
## Summary

- Adds `qwen-27b` and `gemma-31b` to the framework-comparison model catalog so they can be selected via `--model` and included in `--all-tier1` grid generation.
- Updates `--all-tier1` to emit the full catalog grid (frameworks × benchmarks × all catalog models). After this change the grid has 5 models (`qwen-9b`, `qwen-27b`, `gemma-31b`, `qwen-122b`, `claude-opus-46`).
- Generalizes `scripts/smoke_framework_comparison.sh` so the smoke runner targets the generated config directory under `results/comparison/configs` and supports per-framework OpenJarvis config dispatch via env vars (`OPENJARVIS_BASELINE_CONFIG`, `OPENJARVIS_DISTILLED_CONFIG`, `SMOKE_CONFIG_DIR`, `SMOKE_OUTPUT_BASE`, `SMOKE_MODEL`).
- Smoke runner now health-checks the inference endpoint and auto-materializes configs if the smoke config dir is missing.
- Adds unit tests for the new catalog entries and the expanded `--all-tier1` grid count.

No generated TOMLs are committed (results/ remains gitignored). The model_id strings in the catalog are upstream HF names; the FP8/quantization-specific aliases used by individual vLLM endpoints will be aligned at smoke time once the endpoints are up.

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run pytest tests/evals/comparison/ -q` — 59 passed, 3 skipped
- [x] `bash -n scripts/smoke_framework_comparison.sh` — clean
- [x] Generated grid materializes 4×8×5 = 160 TOMLs under `results/comparison/configs/`
- [ ] Live smoke against a vLLM endpoint (deferred to GPU node)

🤖 Generated with [Claude Code](https://claude.com/claude-code)