### PR TITLE
docs(mining): record Gemma/Qwen Pearl validation blockers

### DIFF
--- a/docs/development/pearl-model-enablement.md
+++ b/docs/development/pearl-model-enablement.md
@@ -23,6 +23,23 @@ The current validated model remains:
 pearl-ai/Llama-3.3-70B-Instruct-pearl
 ```
 
+## Current Validation Findings
+
+The H100 smoke run validated the default Llama Pearl model end to end through
+`jarvis mine start`, vLLM `/v1/models`, OpenJarvis inference routing, Pearl
+gateway template refresh, and `jarvis mine validate-model`.
+
+The Qwen and Gemma targets remain planned:
+
+- `pearl-ai/Qwen3.5-9B-pearl`, `pearl-ai/Qwen3.6-27B-pearl`, and
+  `pearl-ai/Gemma-4-E4B-it-pearl` are not publicly available artifacts yet.
+- `pearl-ai/Gemma-4-31B-it-pearl` exists and selects Pearl mining kernels on
+  H100, but vLLM fails during Gemma4 multimodal profiling because the published
+  artifact is missing processor/preprocessor metadata required by Transformers.
+  A local cache experiment proved the processor can be loaded only after
+  injecting metadata from `google/gemma-4-31B-it`; that is not sufficient for
+  OpenJarvis promotion because a clean user install would still fail.
+
 ## Enablement Checklist
 
 1. Reproduce the current Llama Pearl model recipe.
@@ -34,6 +51,8 @@ pearl-ai/Llama-3.3-70B-Instruct-pearl
 2. Convert the target model.
    - Start with `Qwen/Qwen3.5-9B`; it is the smallest target.
    - Generate Pearl-compatible quantized weights and metadata.
+   - For Gemma4 artifacts, include the base model's processor metadata required
+     by vLLM's Gemma4 multimodal profiler.
    - Publish under the planned `pearl-ai/*-pearl` id or a staging namespace.
 
 3. Validate the Pearl vLLM plugin path.

--- a/docs/user-guide/mining.md
+++ b/docs/user-guide/mining.md
@@ -88,6 +88,12 @@ pearl-ai/Llama-3.3-70B-Instruct-pearl
 The Qwen and Gemma targets are tracked in the model registry as planned until
 Pearl quantization and H100/H200 validation are complete.
 
+Current status: the default Llama Pearl model is the only validated model.
+The Gemma 31B Pearl artifact has been seen by OpenJarvis on H100, but it is not
+promoted because the published artifact is missing Gemma4 processor metadata
+needed for clean vLLM startup. The Qwen and smaller Gemma Pearl artifacts still
+need to be published and validated.
+
 When validating a newly converted Pearl model on a mining host, run:
 
 ```bash

--- a/src/openjarvis/mining/_models.py
+++ b/src/openjarvis/mining/_models.py
@@ -43,7 +43,10 @@ PEARL_MODEL_SPECS: tuple[PearlModelSpec, ...] = (
         status="planned",
         min_vram_gb=24.0,
         default_max_model_len=8192,
-        notes="Planned target; validation tracked in open-jarvis/OpenJarvis#316.",
+        notes=(
+            "Planned target; Pearl artifact is not publicly available yet. "
+            "Validation tracked in open-jarvis/OpenJarvis#316."
+        ),
     ),
     PearlModelSpec(
         model_id="pearl-ai/Qwen3.6-27B-pearl",
@@ -51,7 +54,10 @@ PEARL_MODEL_SPECS: tuple[PearlModelSpec, ...] = (
         status="planned",
         min_vram_gb=80.0,
         default_max_model_len=8192,
-        notes="Planned target; validation tracked in open-jarvis/OpenJarvis#317.",
+        notes=(
+            "Planned target; Pearl artifact is not publicly available yet. "
+            "Validation tracked in open-jarvis/OpenJarvis#317."
+        ),
     ),
     PearlModelSpec(
         model_id="pearl-ai/Gemma-4-E4B-it-pearl",
@@ -59,7 +65,10 @@ PEARL_MODEL_SPECS: tuple[PearlModelSpec, ...] = (
         status="planned",
         min_vram_gb=24.0,
         default_max_model_len=8192,
-        notes="Planned target; validation tracked in open-jarvis/OpenJarvis#318.",
+        notes=(
+            "Planned target; Pearl artifact is not publicly available yet. "
+            "Validation tracked in open-jarvis/OpenJarvis#318."
+        ),
     ),
     PearlModelSpec(
         model_id="pearl-ai/Gemma-4-31B-it-pearl",
@@ -67,7 +76,11 @@ PEARL_MODEL_SPECS: tuple[PearlModelSpec, ...] = (
         status="planned",
         min_vram_gb=80.0,
         default_max_model_len=8192,
-        notes="Planned target; validation tracked in open-jarvis/OpenJarvis#319.",
+        notes=(
+            "Artifact exists but H100 validation is blocked by missing Gemma4 "
+            "processor/preprocessor metadata in the published Pearl artifact. "
+            "Validation tracked in open-jarvis/OpenJarvis#319."
+        ),
     ),
 )
 


### PR DESCRIPTION
## Summary

- Records H100 validation findings for the planned Gemma/Qwen Pearl models.
- Keeps all new Gemma/Qwen targets planned rather than validated.
- Documents that Gemma 31B currently reaches Pearl kernel selection and weight load, but fails clean vLLM startup because the published Pearl artifact lacks Gemma4 processor/preprocessor metadata.
- Notes that Qwen 9B, Qwen 27B, and Gemma E4B Pearl artifacts are not publicly available yet.

## Verification

- All checks passed!
- ................................                                         [100%]
32 passed in 0.95s
- Pearl Mining Models
Status     Model                                      Base model                   VRAM     Context 
validated  pearl-ai/Llama-3.3-70B-Instruct-pearl      meta-llama/Llama-3.3-70B-Instruct 70 GB   8192    
  Default Pearl-blessed vLLM mining model.
planned    pearl-ai/Qwen3.5-9B-pearl                  Qwen/Qwen3.5-9B              24 GB   8192    
  Planned target; Pearl artifact is not publicly available yet. Validation tracked in open-jarvis/OpenJarvis#316.
planned    pearl-ai/Qwen3.6-27B-pearl                 Qwen/Qwen3.6-27B             80 GB   8192    
  Planned target; Pearl artifact is not publicly available yet. Validation tracked in open-jarvis/OpenJarvis#317.
planned    pearl-ai/Gemma-4-E4B-it-pearl              google/gemma-4-E4B-it        24 GB   8192    
  Planned target; Pearl artifact is not publicly available yet. Validation tracked in open-jarvis/OpenJarvis#318.
planned    pearl-ai/Gemma-4-31B-it-pearl              google/gemma-4-31B-it        80 GB   8192    
  Artifact exists but H100 validation is blocked by missing Gemma4 processor/preprocessor metadata in the published Pearl artifact. Validation tracked in open-jarvis/OpenJarvis#319.

## Tracking

Updated issues #316, #317, #318, and #319 with the H100 validation findings.