### PR TITLE
feat(mining): register ScalingIntelligence Pearl models

### DIFF
--- a/docs/development/pearl-model-enablement.md
+++ b/docs/development/pearl-model-enablement.md
@@ -12,15 +12,17 @@ for the vanilla Pearl GEMM path.
 
 | Raw model | Planned Pearl model | Status | Tracking |
 |---|---|---|---|
-| `Qwen/Qwen3.5-9B` | `pearl-ai/Qwen3.5-9B-pearl` | Planned | [#316](https://github.com/open-jarvis/OpenJarvis/issues/316) |
+| `Qwen/Qwen3.5-9B` | `ScalingIntelligence/Qwen3.5-9B-pearl` | Validated staging | [#316](https://github.com/open-jarvis/OpenJarvis/issues/316) |
 | `Qwen/Qwen3.6-27B` | `pearl-ai/Qwen3.6-27B-pearl` | Planned | [#317](https://github.com/open-jarvis/OpenJarvis/issues/317) |
 | `google/gemma-4-E4B-it` | `pearl-ai/Gemma-4-E4B-it-pearl` | Planned | [#318](https://github.com/open-jarvis/OpenJarvis/issues/318) |
-| `google/gemma-4-31B-it` | `pearl-ai/Gemma-4-31B-it-pearl` | Planned | [#319](https://github.com/open-jarvis/OpenJarvis/issues/319) |
+| `google/gemma-4-31B-it` | `ScalingIntelligence/Gemma-4-31B-it-pearl` | Validated staging | [#319](https://github.com/open-jarvis/OpenJarvis/issues/319) |
 
-The current validated model remains:
+The current validated models are:
 
 ```text
 pearl-ai/Llama-3.3-70B-Instruct-pearl
+ScalingIntelligence/Gemma-4-31B-it-pearl
+ScalingIntelligence/Qwen3.5-9B-pearl
 ```
 
 ## Current Validation Findings
@@ -29,10 +31,10 @@ The H100 smoke run validated the default Llama Pearl model end to end through
 `jarvis mine start`, vLLM `/v1/models`, OpenJarvis inference routing, Pearl
 gateway template refresh, and `jarvis mine validate-model`.
 
-The Qwen targets and smaller Gemma target remain planned:
+The remaining Qwen 3.6 and smaller Gemma target remain planned:
 
-- `pearl-ai/Qwen3.5-9B-pearl`, `pearl-ai/Qwen3.6-27B-pearl`, and
-  `pearl-ai/Gemma-4-E4B-it-pearl` are not publicly available artifacts yet.
+- `pearl-ai/Qwen3.6-27B-pearl` and `pearl-ai/Gemma-4-E4B-it-pearl` are not
+  publicly available artifacts yet.
 - `pearl-ai/Gemma-4-31B-it-pearl` exists and selects Pearl mining kernels on
   H100, but vLLM fails during Gemma4 multimodal profiling because the published
   artifact is missing processor/preprocessor metadata required by Transformers.
@@ -41,7 +43,16 @@ The Qwen targets and smaller Gemma target remain planned:
   OpenJarvis promotion because a clean user install would still fail.
 
 PR #323 added a local staging path for original checkpoint conversion and H100
-runtime validation. Current local evidence:
+runtime validation. The validated staging artifacts are private repositories in
+the `ScalingIntelligence` Hugging Face org and grouped in the
+`OpenJarvis Pearl Mining Models` collection. Users need Hugging Face access to
+the org/repositories before `jarvis mine inspect-model`, `jarvis mine init`, or
+`jarvis mine start` can fetch them:
+
+- `ScalingIntelligence/Gemma-4-31B-it-pearl`
+- `ScalingIntelligence/Qwen3.5-9B-pearl`
+
+Current validation evidence:
 
 - `google/gemma-4-31B-it` converted to
   `/tmp/openjarvis-h100/converted/Gemma-4-31B-it-pearl-experimental`.
@@ -50,6 +61,8 @@ runtime validation. Current local evidence:
   `pearl-ai/Gemma-4-31B-it-pearl` at `/v1/models`, completes a chat prompt,
   and passes `jarvis mine validate-model --allow-planned`. Validation artifact:
   `/tmp/openjarvis-h100/converted/Gemma-4-31B-it-pearl-experimental-validate.json`.
+  The published `ScalingIntelligence/Gemma-4-31B-it-pearl` repo includes the
+  same validation artifact as `openjarvis_validation.json`.
 - `Qwen/Qwen3.5-9B` converted to
   `/tmp/openjarvis-h100/converted/Qwen3.5-9B-pearl-experimental`.
   The local artifact passes `jarvis mine inspect-model`, starts Pearl gateway,
@@ -59,6 +72,8 @@ runtime validation. Current local evidence:
   --allow-planned`. Required validation flags: `--gdn-prefill-backend triton`
   and a 4096-token context. Validation artifact:
   `/tmp/openjarvis-h100/converted/Qwen3.5-9B-pearl-experimental-validate.json`.
+  The published `ScalingIntelligence/Qwen3.5-9B-pearl` repo includes the same
+  validation artifact as `openjarvis_validation.json`.
 
 ## Enablement Checklist
 

--- a/docs/user-guide/mining.md
+++ b/docs/user-guide/mining.md
@@ -78,39 +78,36 @@ jarvis mine models
 OpenJarvis only enables models that have Pearl-compatible quantized artifacts
 and real hardware validation. Raw Hugging Face models such as
 `Qwen/Qwen3.5-9B` or `google/gemma-4-E4B-it` are not mineable by themselves;
-they need corresponding `pearl-ai/*-pearl` variants.
+they need corresponding Pearl-compatible variants.
 
-The default validated model is:
+The validated models are:
 
 ```text
 pearl-ai/Llama-3.3-70B-Instruct-pearl
+ScalingIntelligence/Gemma-4-31B-it-pearl
+ScalingIntelligence/Qwen3.5-9B-pearl
 ```
 
-The Qwen and Gemma targets are tracked in the model registry as planned until
-Pearl quantization and H100/H200 validation are complete.
-
-Current status: the default Llama Pearl model is the only validated model.
-The Gemma 31B Pearl artifact has been seen by OpenJarvis on H100, but it is not
-promoted because the published artifact is missing Gemma4 processor metadata
-needed for clean vLLM startup. The Qwen and smaller Gemma Pearl artifacts still
-need to be published and validated.
+The Gemma 31B and Qwen 3.5 9B artifacts are experimental private staging
+artifacts under the `ScalingIntelligence` Hugging Face org. You need Hugging
+Face access to those repos before OpenJarvis can inspect or run them. They were
+validated on H100 with `jarvis mine validate-model`, but the short validation
+runs did not find a reward-bearing block or accepted share.
 
 When validating a newly converted Pearl model on a mining host, run:
 
 ```bash
 jarvis mine inspect-model \
-  --model pearl-ai/Qwen3.5-9B-pearl \
-  --allow-planned
+  --model ScalingIntelligence/Qwen3.5-9B-pearl
 
 jarvis mine validate-model \
-  --model pearl-ai/Qwen3.5-9B-pearl \
-  --allow-planned \
+  --model ScalingIntelligence/Qwen3.5-9B-pearl \
   --prompt "Say hello in one sentence." \
   --output qwen3.5-9b-pearl-validation.json
 ```
 
-Remove `--allow-planned` only after the model is promoted to validated in the
-OpenJarvis registry. Attach the JSON artifact to the validation issue.
+Attach the JSON artifact to the validation issue when promoting additional
+models.
 
 ## v1 Scope
 

--- a/src/openjarvis/mining/_models.py
+++ b/src/openjarvis/mining/_models.py
@@ -49,6 +49,18 @@ PEARL_MODEL_SPECS: tuple[PearlModelSpec, ...] = (
         ),
     ),
     PearlModelSpec(
+        model_id="ScalingIntelligence/Qwen3.5-9B-pearl",
+        base_model_id="Qwen/Qwen3.5-9B",
+        status="validated",
+        min_vram_gb=24.0,
+        default_max_model_len=4096,
+        notes=(
+            "Experimental OpenJarvis/Pearl artifact validated on H100. "
+            "Runtime requires --language-model-only, --skip-mm-profiling, "
+            "and --gdn-prefill-backend triton."
+        ),
+    ),
+    PearlModelSpec(
         model_id="pearl-ai/Qwen3.6-27B-pearl",
         base_model_id="Qwen/Qwen3.6-27B",
         status="planned",
@@ -80,6 +92,17 @@ PEARL_MODEL_SPECS: tuple[PearlModelSpec, ...] = (
             "Artifact exists but H100 validation is blocked by missing Gemma4 "
             "processor/preprocessor metadata in the published Pearl artifact. "
             "Validation tracked in open-jarvis/OpenJarvis#319."
+        ),
+    ),
+    PearlModelSpec(
+        model_id="ScalingIntelligence/Gemma-4-31B-it-pearl",
+        base_model_id="google/gemma-4-31B-it",
+        status="validated",
+        min_vram_gb=80.0,
+        default_max_model_len=8192,
+        notes=(
+            "Experimental OpenJarvis/Pearl artifact validated on H100 with "
+            "Gemma4 processor/preprocessor metadata included."
         ),
     ),
 )

--- a/tests/cli/test_mine_cmd.py
+++ b/tests/cli/test_mine_cmd.py
@@ -28,9 +28,24 @@ def test_mine_models_lists_validated_and_planned_models() -> None:
     assert result.exit_code == 0
     assert "Pearl Mining Models" in result.output
     assert "pearl-ai/Llama-3.3-70B-Instruct-pearl" in result.output
+    assert "ScalingIntelligence/Gemma-4-31B-it-pearl" in result.output
+    assert "ScalingIntelligence/Qwen3.5-9B-pearl" in result.output
     assert "pearl-ai/Qwen3.5-9B-pearl" in result.output
     assert "validated" in result.output
     assert "planned" in result.output
+
+
+def test_pearl_base_model_lookup_prefers_validated_scalingintelligence_artifacts():
+    from openjarvis.mining._models import pearl_variant_for_base_model
+
+    assert (
+        pearl_variant_for_base_model("google/gemma-4-31B-it")
+        == "ScalingIntelligence/Gemma-4-31B-it-pearl"
+    )
+    assert (
+        pearl_variant_for_base_model("Qwen/Qwen3.5-9B")
+        == "ScalingIntelligence/Qwen3.5-9B-pearl"
+    )
 
 
 def test_mine_inspect_model_validated_artifact_passes(monkeypatch) -> None:

--- a/tests/mining/test_discovery.py
+++ b/tests/mining/test_discovery.py
@@ -96,7 +96,7 @@ def test_detect_raw_planned_model_points_to_pearl_variant(hopper_hw):
     )
 
     assert cap.supported is False
-    assert "pearl-ai/Qwen3.5-9B-pearl" in cap.reason
+    assert "ScalingIntelligence/Qwen3.5-9B-pearl" in cap.reason
 
 
 def test_detect_planned_pearl_model_is_not_enabled_yet(hopper_hw):


### PR DESCRIPTION
## Summary
- register ScalingIntelligence/Gemma-4-31B-it-pearl as a validated Pearl mining model
- register ScalingIntelligence/Qwen3.5-9B-pearl as a validated Pearl mining model
- update mining docs to point users at the published ScalingIntelligence artifacts and collection

## Verification
- env UV_CACHE_DIR=/tmp/openjarvis-uv-cache uv run --no-sync ruff check src/openjarvis/mining/_models.py tests/cli/test_mine_cmd.py docs/development/pearl-model-enablement.md docs/user-guide/mining.md
- env HOME=/tmp/openjarvis-home UV_CACHE_DIR=/tmp/openjarvis-uv-cache uv run --no-sync pytest tests/cli/test_mine_cmd.py -q
- jarvis mine inspect-model --model ScalingIntelligence/Gemma-4-31B-it-pearl
- jarvis mine inspect-model --model ScalingIntelligence/Qwen3.5-9B-pearl