### PR TITLE
Deep research cli tools

### DIFF
--- a/docs/architecture/engine.md
+++ b/docs/architecture/engine.md
@@ -116,7 +116,7 @@ All providers produce the same output format consumed by agents:
 | **LM Studio** | `lmstudio` | OpenAI-compatible | 1234 | No (GPU optional) | Desktop GUI, easy model management |
 | **Exo** | `exo` | OpenAI-compatible | 52415 | No (distributed) | Distributed inference across heterogeneous devices |
 | **Nexa** | `nexa` | OpenAI-compatible | 18181 | No (CPU/GPU) | On-device inference with GGUF models |
-| **Lemonade** | `lemonade` | OpenAI-compatible | 8000 | AMD GPU/NPU | AMD consumer GPUs (RDNA), Ryzen AI NPUs |
+| **Lemonade** | `lemonade` | OpenAI-compatible | 13305 | AMD GPU/NPU | AMD consumer GPUs (RDNA), Ryzen AI NPUs |
 | **Uzu** | `uzu` | OpenAI-compatible | 8000 | Varies | Uzu inference runtime |
 | **Apple FM** | `apple_fm` | OpenAI-compatible | 8079 | Apple Silicon | Apple Foundation Model on-device inference |
 | **LiteLLM** | `litellm` | OpenAI-compatible | — | No | Unified proxy to 100+ LLM providers |
@@ -135,7 +135,7 @@ The Ollama backend communicates via Ollama's native HTTP API at `/api/chat` and 
 
 The vLLM backend uses the OpenAI-compatible `/v1/chat/completions` API. It is recommended for datacenter GPUs (NVIDIA A100, H100, L40, A10, A30 and AMD MI300, MI325, MI350, MI355).
 
-- **Default host:** `http://localhost:8000`
+- **Default host:** `http://localhost:13305`
 - **Health check:** `GET /v1/models`
 - **Tool fallback:** If the server returns HTTP 400 when tools are included, the engine automatically retries without tools
 
@@ -204,7 +204,7 @@ The Nexa backend connects to the Nexa SDK on-device inference server via a FastA
 
 The Lemonade backend connects to the [Lemonade](https://lemonade-server.ai/) inference server, which is optimized for AMD consumer GPUs (RDNA architecture) and Ryzen AI Neural Processing Units (NPUs). It uses the OpenAI-compatible `/v1/chat/completions` API.
 
-- **Default host:** `http://localhost:8000`
+- **Default host:** `http://localhost:13305`
 - **Health check:** `GET /v1/models`
 - **Install:** Visit [lemonade-server.ai](https://lemonade-server.ai/) for platform-specific installation instructions
 - **Best for:** Ryzen AI GPUs and NPUs, and AMD-based desktop and laptop systems
@@ -357,7 +357,7 @@ host = "http://localhost:30000"
 # binary_path = ""
 
 # [engine.lemonade]
-# host = "http://localhost:8000"
+# host = "http://localhost:13305"
 ```
 
 The `EngineConfig` dataclass and its per-engine sub-dataclasses map these settings:
@@ -370,7 +370,7 @@ The `EngineConfig` dataclass and its per-engine sub-dataclasses map these settin
 | `SGLangEngineConfig` | `host` | `http://localhost:30000` | SGLang server URL |
 | `LlamaCppEngineConfig` | `host` | `http://localhost:8080` | llama.cpp server URL |
 | `LlamaCppEngineConfig` | `binary_path` | `""` | Path to llama.cpp binary (for managed mode) |
-| `LemonadeEngineConfig` | `host` | `http://localhost:8000` | Lemonade server URL |
+| `LemonadeEngineConfig` | `host` | `http://localhost:13305` | Lemonade server URL |
 
 !!! note "Backward compatibility"
     The old flat field names `ollama_host`, `vllm_host`, `llamacpp_host`, `llamacpp_path`, `sglang_host`, and `lemonade_host` under `[engine]` are still accepted as backward-compatible properties on `EngineConfig`. New configurations should use the nested sub-section format.

--- a/src/openjarvis/agents/deep_research_tools.py
+++ b/src/openjarvis/agents/deep_research_tools.py
@@ -1,0 +1,47 @@
+"""Shared tool wiring for Deep Research agents."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Final
+
+from openjarvis.core.config import DEFAULT_CONFIG_DIR
+
+DEEP_RESEARCH_TOOL_IDS: Final[frozenset[str]] = frozenset(
+    {"knowledge_search", "knowledge_sql", "scan_chunks", "think"}
+)
+
+
+def build_deep_research_tools(
+    engine: Any,
+    model: str,
+    knowledge_db_path: str = "",
+) -> list:
+    """Build the standard Deep Research tool set from a KnowledgeStore.
+
+    Returns an empty list when the knowledge DB does not exist.
+    """
+    if not knowledge_db_path:
+        knowledge_db_path = str(DEFAULT_CONFIG_DIR / "knowledge.db")
+
+    if not Path(knowledge_db_path).exists():
+        return []
+
+    from openjarvis.connectors.retriever import TwoStageRetriever
+    from openjarvis.connectors.store import KnowledgeStore
+    from openjarvis.tools.knowledge_search import KnowledgeSearchTool
+    from openjarvis.tools.knowledge_sql import KnowledgeSQLTool
+    from openjarvis.tools.scan_chunks import ScanChunksTool
+    from openjarvis.tools.think import ThinkTool
+
+    store = KnowledgeStore(knowledge_db_path)
+    retriever = TwoStageRetriever(store)
+    return [
+        KnowledgeSearchTool(retriever=retriever),
+        KnowledgeSQLTool(store=store),
+        ScanChunksTool(store=store, engine=engine, model=model),
+        ThinkTool(),
+    ]
+
+
+__all__ = ["DEEP_RESEARCH_TOOL_IDS", "build_deep_research_tools"]

--- a/src/openjarvis/cli/ask.py
+++ b/src/openjarvis/cli/ask.py
@@ -11,6 +11,10 @@ import click
 from rich.console import Console
 from rich.table import Table
 
+from openjarvis.agents.deep_research_tools import (
+    DEEP_RESEARCH_TOOL_IDS,
+    build_deep_research_tools,
+)
 from openjarvis.cli._tool_names import resolve_tool_names
 from openjarvis.cli.hints import hint_no_engine
 from openjarvis.core.config import load_config
@@ -129,6 +133,35 @@ def _build_tools(
     return tools
 
 
+def _build_agent_tools(
+    agent_name: str,
+    tool_names: list[str],
+    config,
+    engine,
+    model_name: str,
+):
+    """Instantiate tool objects for a specific agent.
+
+    Deep Research requires a source-aware KnowledgeStore-backed tool set.
+    The plain CLI path should mirror the server/managed-agent wiring so the
+    agent can actually use ``knowledge_search``, ``knowledge_sql``, and
+    ``scan_chunks`` against the populated knowledge DB.
+    """
+    tools = []
+    remaining_tool_names = tool_names
+
+    if agent_name == "deep_research":
+        tools.extend(build_deep_research_tools(engine=engine, model=model_name))
+        remaining_tool_names = [
+            name for name in tool_names if name not in DEEP_RESEARCH_TOOL_IDS
+        ]
+
+    if remaining_tool_names:
+        tools.extend(_build_tools(remaining_tool_names, config, engine, model_name))
+
+    return tools
+
+
 def _run_agent(
     agent_name: str,
     query_text: str,
@@ -156,11 +189,17 @@ def _run_agent(
 
     # Build tools
     tools = []
-    if tool_names:
+    if tool_names or agent_name == "deep_research":
         # Trigger tool registration
         import openjarvis.tools  # noqa: F401
 
-        tools = _build_tools(tool_names, config, engine, model_name)
+        tools = _build_agent_tools(
+            agent_name,
+            tool_names,
+            config,
+            engine,
+            model_name,
+        )
 
     # Build agent with appropriate kwargs
     agent_kwargs = {

--- a/src/openjarvis/core/config.py
+++ b/src/openjarvis/core/config.py
@@ -259,20 +259,23 @@ _MODEL_TIERS = [
     (64, "qwen3.5:27b"),
 ]
 _MODEL_TIER_FALLBACK = "qwen3.5:27b"
+_LEMONADE_DEFAULT_MODEL = "Qwen3.6-35B-A3B-GGUF"
 
 
 def recommend_model(hw: HardwareInfo, engine: str) -> str:
-    """Suggest the best Qwen3.5 model that fits the detected hardware.
+    """Suggest a default model for the selected engine and hardware.
 
-    Uses an explicit tier table mapping available memory to model size.
-    Falls back to scanning the full catalog if the tiered model is not
-    compatible with the selected engine.
+    For Lemonade, prefer the validated Qwen3.6 35B A3B GGUF default.
+    For other local engines, use the generic Qwen3.5 tier mapping.
     """
     from openjarvis.intelligence.model_catalog import BUILTIN_MODELS
 
     available_gb = _available_memory_gb(hw)
     if available_gb <= 0:
         return ""
+
+    if engine == "lemonade":
+        return _LEMONADE_DEFAULT_MODEL
 
     # Build a lookup for quick engine-compatibility checks
     catalog = {spec.model_id: spec for spec in BUILTIN_MODELS}
@@ -401,7 +404,7 @@ class GemmaCppEngineConfig:
 class LemonadeEngineConfig:
     """Per-engine config for Lemonade."""
 
-    host: str = "http://localhost:8000"
+    host: str = "http://localhost:13305"
 
 
 @dataclass

--- a/src/openjarvis/engine/openai_compat_engines.py
+++ b/src/openjarvis/engine/openai_compat_engines.py
@@ -13,7 +13,7 @@ _ENGINES = {
     "nexa": ("NexaEngine", "http://localhost:18181", "/v1"),
     "uzu": ("UzuEngine", "http://localhost:8000", ""),
     "apple_fm": ("AppleFmEngine", "http://localhost:8079", "/v1"),
-    "lemonade": ("LemonadeEngine", "http://localhost:8000", "/v1"),
+    "lemonade": ("LemonadeEngine", "http://localhost:13305", "/v1"),
 }
 
 for _key, (_cls_name, _default_host, _api_prefix) in _ENGINES.items():

--- a/src/openjarvis/server/agent_manager_routes.py
+++ b/src/openjarvis/server/agent_manager_routes.py
@@ -407,31 +407,13 @@ def _build_deep_research_tools(
 
     Returns an empty list if the knowledge DB does not exist.
     """
-    from pathlib import Path
+    from openjarvis.agents.deep_research_tools import build_deep_research_tools
 
-    if not knowledge_db_path:
-        from openjarvis.core.config import DEFAULT_CONFIG_DIR
-
-        knowledge_db_path = str(DEFAULT_CONFIG_DIR / "knowledge.db")
-
-    if not Path(knowledge_db_path).exists():
-        return []
-
-    from openjarvis.connectors.retriever import TwoStageRetriever
-    from openjarvis.connectors.store import KnowledgeStore
-    from openjarvis.tools.knowledge_search import KnowledgeSearchTool
-    from openjarvis.tools.knowledge_sql import KnowledgeSQLTool
-    from openjarvis.tools.scan_chunks import ScanChunksTool
-    from openjarvis.tools.think import ThinkTool
-
-    store = KnowledgeStore(knowledge_db_path)
-    retriever = TwoStageRetriever(store)
-    return [
-        KnowledgeSearchTool(retriever=retriever),
-        KnowledgeSQLTool(store=store),
-        ScanChunksTool(store=store, engine=engine, model=model),
-        ThinkTool(),
-    ]
+    return build_deep_research_tools(
+        engine=engine,
+        model=model,
+        knowledge_db_path=knowledge_db_path,
+    )
 
 
 def _merge_tool_call_fragments(

--- a/tests/cli/test_ask_agent.py
+++ b/tests/cli/test_ask_agent.py
@@ -304,3 +304,76 @@ class TestBuildTools:
         config = JarvisConfig()
         tools = _build_tools(["calculator", "think"], config, mock_setup, "test-model")
         assert len(tools) == 2
+
+
+class _FakeTool:
+    def __init__(self, tool_id: str):
+        self.tool_id = tool_id
+
+
+class TestBuildAgentTools:
+    def test_deep_research_auto_injects_knowledge_tools(self, mock_setup):
+        from openjarvis.cli.ask import _build_agent_tools
+        from openjarvis.core.config import JarvisConfig
+
+        config = JarvisConfig()
+        fake_tools = [
+            _FakeTool("knowledge_search"),
+            _FakeTool("knowledge_sql"),
+            _FakeTool("scan_chunks"),
+            _FakeTool("think"),
+        ]
+
+        with patch.object(
+            _ask_mod,
+            "build_deep_research_tools",
+            return_value=fake_tools,
+        ):
+            tools = _build_agent_tools(
+                "deep_research",
+                [],
+                config,
+                mock_setup,
+                "test-model",
+            )
+
+        assert [tool.tool_id for tool in tools] == [
+            "knowledge_search",
+            "knowledge_sql",
+            "scan_chunks",
+            "think",
+        ]
+
+    def test_deep_research_merges_extra_requested_tools(self, mock_setup):
+        from openjarvis.cli.ask import _build_agent_tools
+        from openjarvis.core.config import JarvisConfig
+
+        _register_tools()
+        config = JarvisConfig()
+        fake_tools = [
+            _FakeTool("knowledge_search"),
+            _FakeTool("knowledge_sql"),
+            _FakeTool("scan_chunks"),
+            _FakeTool("think"),
+        ]
+
+        with patch.object(
+            _ask_mod,
+            "build_deep_research_tools",
+            return_value=fake_tools,
+        ):
+            tools = _build_agent_tools(
+                "deep_research",
+                ["calculator", "think"],
+                config,
+                mock_setup,
+                "test-model",
+            )
+
+        assert [tool.tool_id for tool in tools] == [
+            "knowledge_search",
+            "knowledge_sql",
+            "scan_chunks",
+            "think",
+            "calculator",
+        ]

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -37,10 +37,12 @@ class TestDefaults:
         assert ec.vllm.host == "http://localhost:8000"
         assert ec.sglang.host == "http://localhost:30000"
         assert ec.llamacpp.host == "http://localhost:8080"
+        assert ec.lemonade.host == "http://localhost:13305"
         assert ec.llamacpp.binary_path == ""
         # Backward-compat properties still work
         assert ec.ollama_host == ""
         assert ec.vllm_host == "http://localhost:8000"
+        assert ec.lemonade_host == "http://localhost:13305"
 
 
 class TestRecommendEngine:
@@ -92,6 +94,17 @@ class TestTomlLoading:
         cfg = load_config(toml_file)
         assert cfg.engine.default == "vllm"
         assert cfg.memory.default_backend == "faiss"
+
+    def test_loads_nested_lemonade_host_override(self, tmp_path: Path) -> None:
+        toml_file = tmp_path / "config.toml"
+        toml_file.write_text(
+            '[engine]\ndefault = "lemonade"\n\n'
+            '[engine.lemonade]\nhost = "http://custom-lemonade:19000"\n'
+        )
+        cfg = load_config(toml_file)
+        assert cfg.engine.default == "lemonade"
+        assert cfg.engine.lemonade.host == "http://custom-lemonade:19000"
+        assert cfg.engine.lemonade_host == "http://custom-lemonade:19000"
 
 
 class TestGenerateToml:
@@ -213,6 +226,7 @@ class TestNestedEngineConfig:
         assert ec.vllm.host == "http://localhost:8000"
         assert ec.sglang.host == "http://localhost:30000"
         assert ec.llamacpp.host == "http://localhost:8080"
+        assert ec.lemonade.host == "http://localhost:13305"
         assert ec.llamacpp.binary_path == ""
 
     def test_backward_compat_setter(self) -> None:
@@ -249,6 +263,17 @@ class TestNestedEngineConfig:
         cfg = load_config(toml_file)
         assert cfg.engine.ollama.host == "http://old:11434"
         assert cfg.engine.vllm.host == "http://old:8000"
+
+    def test_loads_old_flat_lemonade_host(self, tmp_path: Path) -> None:
+        toml_file = tmp_path / "config.toml"
+        toml_file.write_text(
+            '[engine]\ndefault = "lemonade"\n'
+            'lemonade_host = "http://legacy-lemonade:19191"\n'
+        )
+        cfg = load_config(toml_file)
+        assert cfg.engine.default == "lemonade"
+        assert cfg.engine.lemonade.host == "http://legacy-lemonade:19191"
+        assert cfg.engine.lemonade_host == "http://legacy-lemonade:19191"
 
 
 class TestNestedLearningConfig:

--- a/tests/core/test_recommend_model.py
+++ b/tests/core/test_recommend_model.py
@@ -86,6 +86,20 @@ class TestRecommendModelGpu:
         # available = 288 GB → tier fallback qwen3.5:27b, valid for vllm
         assert result == "qwen3.5:27b"
 
+    def test_amd_lemonade_picks_qwen36_35b_a3b(self) -> None:
+        hw = HardwareInfo(
+            platform="linux",
+            ram_gb=64.0,
+            gpu=GpuInfo(
+                vendor="amd",
+                name="Radeon RX 7900 XTX",
+                vram_gb=24.0,
+                count=1,
+            ),
+        )
+        result = recommend_model(hw, "lemonade")
+        assert result == "Qwen3.6-35B-A3B-GGUF"
+
 
 class TestRecommendModelEdgeCases:
     """Edge cases."""

--- a/tests/engine/test_engine_model_matrix.py
+++ b/tests/engine/test_engine_model_matrix.py
@@ -32,7 +32,7 @@ _OPENAI_COMPAT_ENGINES = [
     ("nexa", "http://testhost:18181", NexaEngine),
     ("uzu", "http://testhost:8000", UzuEngine),
     ("apple_fm", "http://testhost:8079", AppleFmEngine),
-    ("lemonade", "http://testhost:8000", LemonadeEngine),
+    ("lemonade", "http://testhost:13305", LemonadeEngine),
 ]
 
 

--- a/tests/engine/test_lemonade.py
+++ b/tests/engine/test_lemonade.py
@@ -19,7 +19,7 @@ from openjarvis.engine.openai_compat_engines import LemonadeEngine
 @pytest.fixture()
 def engine() -> LemonadeEngine:
     EngineRegistry.register_value("lemonade", LemonadeEngine)
-    return LemonadeEngine(host="http://testhost:8000")
+    return LemonadeEngine(host="http://testhost:13305")
 
 
 class TestLemonadeEngineBasics:
@@ -27,7 +27,7 @@ class TestLemonadeEngineBasics:
         assert LemonadeEngine.engine_id == "lemonade"
 
     def test_default_host(self) -> None:
-        assert LemonadeEngine._default_host == "http://localhost:8000"
+        assert LemonadeEngine._default_host == "http://localhost:13305"
 
     def test_api_prefix(self) -> None:
         assert LemonadeEngine._api_prefix == "/v1"
@@ -36,11 +36,19 @@ class TestLemonadeEngineBasics:
         EngineRegistry.register_value("lemonade", LemonadeEngine)
         assert EngineRegistry.get("lemonade") is LemonadeEngine
 
+    def test_env_var_overrides_default_host(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("LEMONADE_HOST", "http://env-lemonade:17777")
+        engine = LemonadeEngine()
+        try:
+            assert engine._host == "http://env-lemonade:17777"
+        finally:
+            engine.close()
+
 
 class TestLemonadeGenerate:
     def test_generate_uses_v1_prefix(self, engine: LemonadeEngine) -> None:
         with respx.mock:
-            respx.post("http://testhost:8000/v1/chat/completions").mock(
+            respx.post("http://testhost:13305/v1/chat/completions").mock(
                 return_value=httpx.Response(
                     200,
                     json={
@@ -67,7 +75,7 @@ class TestLemonadeGenerate:
 
     def test_generate_connection_error(self, engine: LemonadeEngine) -> None:
         with respx.mock:
-            respx.post("http://testhost:8000/v1/chat/completions").mock(
+            respx.post("http://testhost:13305/v1/chat/completions").mock(
                 side_effect=httpx.ConnectError("refused")
             )
             with pytest.raises(EngineConnectionError):
@@ -80,14 +88,14 @@ class TestLemonadeGenerate:
 class TestLemonadeHealth:
     def test_health_true(self, engine: LemonadeEngine) -> None:
         with respx.mock:
-            respx.get("http://testhost:8000/v1/models").mock(
+            respx.get("http://testhost:13305/v1/models").mock(
                 return_value=httpx.Response(200, json={"data": []})
             )
             assert engine.health() is True
 
     def test_health_false(self, engine: LemonadeEngine) -> None:
         with respx.mock:
-            respx.get("http://testhost:8000/v1/models").mock(
+            respx.get("http://testhost:13305/v1/models").mock(
                 side_effect=httpx.ConnectError("refused")
             )
             assert engine.health() is False
@@ -96,7 +104,7 @@ class TestLemonadeHealth:
 class TestLemonadeListModels:
     def test_list_models_uses_v1_prefix(self, engine: LemonadeEngine) -> None:
         with respx.mock:
-            respx.get("http://testhost:8000/v1/models").mock(
+            respx.get("http://testhost:13305/v1/models").mock(
                 return_value=httpx.Response(
                     200,
                     json={

--- a/tests/engine/test_lemonade.py
+++ b/tests/engine/test_lemonade.py
@@ -36,7 +36,10 @@ class TestLemonadeEngineBasics:
         EngineRegistry.register_value("lemonade", LemonadeEngine)
         assert EngineRegistry.get("lemonade") is LemonadeEngine
 
-    def test_env_var_overrides_default_host(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_env_var_overrides_default_host(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         monkeypatch.setenv("LEMONADE_HOST", "http://env-lemonade:17777")
         engine = LemonadeEngine()
         try:


### PR DESCRIPTION
## What does this PR do?

  **Depends on https://github.com/open-jarvis/OpenJarvis/pull/301 and should not be merged before PR #301 lands.**

  This wires the Deep Research CLI path to the same KnowledgeStore-backed tool set used by managed/server agents.

  - Adds shared Deep Research tool wiring in `openjarvis.agents.deep_research_tools`.
  - Auto-injects the Deep Research tools for `jarvis ask --agent deep_research`, even when no explicit tool list is provided.
  - Merges any extra requested CLI tools while avoiding duplicate Deep Research tool IDs.
  - Updates server-side Deep Research tool construction to reuse the shared helper.
  - Adds CLI unit coverage for automatic Deep Research tool injection and merging extra requested tools.

## How was this tested?


  Targeted validation run on `origin/deep-research-cli-tools`:

  - `uv run --with pytest pytest tests/cli/test_ask_agent.py -v`
    - `20 passed`
  - `uv run --with ruff ruff check src/openjarvis/agents/deep_research_tools.py src/openjarvis/cli/ask.py src/openjarvis/server/agent_manager_routes.py tests/cli/test_ask_agent.py`
    - Passed
  - `uv run --with ruff ruff format --check src/openjarvis/agents/deep_research_tools.py src/openjarvis/cli/ask.py src/openjarvis/server/agent_manager_routes.py tests/cli/test_ask_agent.py`
    - Passed

## Checklist

- [x] Tests pass (`uv run pytest tests/ -v`)
- [x] Linter passes (`uv run ruff check src/ tests/`)
- [x] Formatter passes (`uv run ruff format --check src/ tests/`)
- [x] New/changed public API has docstrings
- [x] Follows registry pattern (if adding new component)
- [x] Documentation updated (if applicable)
