### PR TITLE
fix(mcp): StdioTransport.send_notification must not read response

### DIFF
--- a/src/openjarvis/mcp/transport.py
+++ b/src/openjarvis/mcp/transport.py
@@ -88,6 +88,20 @@ class StdioTransport(MCPTransport):
             raise RuntimeError("No response from subprocess")
         return MCPResponse.from_json(response_line.strip())
 
+    def send_notification(self, request: MCPRequest) -> None:
+        """Send a JSON-RPC notification — write only, never read.
+
+        Overrides the base implementation: stdio servers do not reply
+        to notifications, so the default ``send()`` would block forever
+        on ``proc.stdout.readline()``.
+        """
+        proc = self._process
+        if proc is None or proc.stdin is None:
+            raise RuntimeError("Transport process is not running")
+        line = request.to_json() + "\n"
+        proc.stdin.write(line)
+        proc.stdin.flush()
+
     def close(self) -> None:
         """Terminate the subprocess."""
         if self._process is not None:


### PR DESCRIPTION
## Summary

`MCPTransport.send_notification` falls back to `self.send()` (writes + reads). Stdio MCP servers don't reply to JSON-RPC notifications, so the followup `notifications/initialized` after `MCPClient.initialize()` hangs forever on `proc.stdout.readline()`.

`StreamableHTTPTransport.send_notification` already overrides this correctly (transport.py:213-217). This adds the symmetric fix on `StdioTransport`.

## Repro

Any stdio MCP server triggers it. Reproduced here with [`CyberStrikeAI`](https://github.com/Ed1s0nZ/CyberStrikeAI)'s `cmd/mcp-stdio` (78 tools): without the fix, `_discover_external_mcp` hangs in `MCPClient.initialize`. With it, all 78 tools discover cleanly and end-to-end via `SystemBuilder.build()` (`Discovered 78 tools from MCP server 'cyberstrike'` at INFO).

## Change

`src/openjarvis/mcp/transport.py`: override `send_notification` on `StdioTransport` to write the JSON line and not read a response.

## Test plan

- [ ] `pytest` (no existing tests for `send_notification` on `StdioTransport` — happy to add one if you have a preferred pattern)
- [x] Manual: stdio MCP server completes init handshake; `MCPClient.list_tools()` returns all advertised tools.
- [x] `SystemBuilder.build()` discovers stdio MCP tools without hang.