### PR TITLE
feat: let `jarvis agents ask` use MCP-discovered tools with --yes auto-approve

### DIFF
--- a/src/openjarvis/agents/executor.py
+++ b/src/openjarvis/agents/executor.py
@@ -303,6 +303,21 @@ class AgentExecutor:
                         tool_instances.append(tool)
                     except Exception:
                         logger.warning("Failed to instantiate tool %s", tname)
+
+            # Pull tools already discovered by SystemBuilder (e.g. external MCP
+            # adapters) that aren't in the static ToolRegistry. Without this,
+            # agents declaring MCP-discovered tools in their template would
+            # silently fall back to natives only.
+            if self._system is not None and getattr(self._system, "tool_executor", None) is not None:
+                mcp_pool = getattr(self._system.tool_executor, "_tools", {}) or {}
+                existing = {t.spec.name for t in tool_instances}
+                for tname in tool_names:
+                    if tname in existing:
+                        continue
+                    pooled = mcp_pool.get(tname)
+                    if pooled is not None:
+                        tool_instances.append(pooled)
+
             if tool_instances:
                 logger.info(
                     "Agent %s: resolved %d/%d tools",
@@ -318,6 +333,12 @@ class AgentExecutor:
             agent_kwargs["system_prompt"] = sys_prompt
         if getattr(agent_cls, "accepts_tools", False) and tool_instances:
             agent_kwargs["tools"] = tool_instances
+        # Propagate confirmation policy from the AgentExecutor down to the
+        # agent's own ToolExecutor. Set by CLI paths like `jarvis agents ask`
+        # so non-interactive runs can auto-approve tool execution.
+        if getattr(self, "_confirm_callback", None) is not None:
+            agent_kwargs["interactive"] = True
+            agent_kwargs["confirm_callback"] = self._confirm_callback
         try:
             agent_instance = agent_cls(engine, model, **agent_kwargs)
         except TypeError:

--- a/src/openjarvis/cli/agent_cmd.py
+++ b/src/openjarvis/cli/agent_cmd.py
@@ -702,16 +702,34 @@ def errors():
 @agent.command("ask")
 @click.argument("agent_id")
 @click.argument("message")
-def ask(agent_id, message):
+@click.option(
+    "--yes/--no-yes",
+    "auto_approve",
+    default=True,
+    help="Auto-approve tool execution that would otherwise need confirmation. "
+    "Default: on (suits non-interactive CLI use). Pass --no-yes to require a "
+    "TTY prompt for tools whose ToolSpec sets requires_confirmation=True.",
+)
+def ask(agent_id, message, auto_approve):
     """Ask an agent a question (immediate response)."""
     manager = _get_manager()
     agent_id = _resolve_agent_id(manager, agent_id)
     manager.send_message(agent_id, message, mode="immediate")
     click.echo("Asking agent...")
-    _, executor, _ = _get_scheduler_and_executor()
+    _, executor, system = _get_scheduler_and_executor()
     if executor is None:
         click.echo("Executor not available", err=True)
         raise SystemExit(1)
+    # Wire a confirmation callback so the agent's own ToolExecutor can actually
+    # run tools whose ToolSpec sets requires_confirmation=True (e.g. shell_exec,
+    # git_*). `executor` is the AgentExecutor; the callback is read in
+    # _invoke_agent and propagated to the constructed agent via agent_kwargs.
+    if auto_approve:
+        executor._confirm_callback = lambda _prompt: True
+    else:
+        executor._confirm_callback = (
+            lambda prompt: click.confirm(f"\n{prompt}", default=False)
+        )
     executor.execute_tick(agent_id)
     msgs = manager.list_messages(agent_id)
     responses = [m for m in msgs if m["direction"] == "agent_to_user"]

--- a/src/openjarvis/mcp/transport.py
+++ b/src/openjarvis/mcp/transport.py
@@ -88,6 +88,20 @@ class StdioTransport(MCPTransport):
             raise RuntimeError("No response from subprocess")
         return MCPResponse.from_json(response_line.strip())
 
+    def send_notification(self, request: MCPRequest) -> None:
+        """Send a JSON-RPC notification — write only, never read.
+
+        Overrides the base implementation: stdio servers do not reply
+        to notifications, so the default ``send()`` would block forever
+        on ``proc.stdout.readline()``.
+        """
+        proc = self._process
+        if proc is None or proc.stdin is None:
+            raise RuntimeError("Transport process is not running")
+        line = request.to_json() + "\n"
+        proc.stdin.write(line)
+        proc.stdin.flush()
+
     def close(self) -> None:
         """Terminate the subprocess."""
         if self._process is not None:


### PR DESCRIPTION
## Summary

Two related changes that together make `jarvis agents ask` actually usable with stdio MCP servers.

### 1. `executor.py`: pull MCP tools into the agent's tool list

`AgentExecutor._invoke_agent` resolves a template's `tools` whitelist against the static `ToolRegistry`. MCP tools discovered at `SystemBuilder.build()` time (via `_discover_external_mcp`) live on `system.tool_executor._tools` but were never read from there for the per-agent build. Net effect: any agent whose template named MCP tools got **zero** of them at runtime — the system prompt could describe them but the model could only call natives like `shell_exec`.

Fix: after the `ToolRegistry` loop, fall back to `self._system.tool_executor._tools` for any unresolved names. Registry tools still take precedence on name collision.

### 2. `cli/agent_cmd.py`: wire a `confirm_callback` for the `ask` CLI

`jarvis agents ask` is non-interactive, so the `AgentExecutor`'s `ToolExecutor` had `_confirm_callback=None`. Tools whose `ToolSpec` sets `requires_confirmation=True` (`shell_exec`, `git_*`, …) returned `"requires confirmation but no confirmation callback is available"`. The agent dutifully relayed that as natural language ("It appears the tool requires confirmation…") and never executed.

This adds a `--yes/--no-yes` flag (default `--yes`):
- `--yes` → auto-approve (`lambda _: True`). Suits CLI scripting where the operator already approved scope.
- `--no-yes` → `click.confirm` on TTY.

The callback is set on the `AgentExecutor`; `_invoke_agent` reads it and forwards it to the constructed agent via `agent_kwargs["interactive"]` and `agent_kwargs["confirm_callback"]`.

## Repro

Configured a stdio MCP server with 78 tools (`CyberStrikeAI cmd/mcp-stdio`) and a template enumerating them in `tools`. Before either patch: agent built with 4 tools, every tool call returned confirmation-error. After both: agent built with 4 native + 78 MCP, `--yes` lets the agent actually call them end-to-end.

(Depends on #339 for the stdio handshake to even complete; without that the discovery hangs before tools land on `system.tool_executor`.)

## Test plan

- [x] `agents ask <id> "..."` against an agent with MCP tools in its template — agent now resolves them and executes (verified with `exec` tool on CyberStrikeAI MCP, ran `nmap` on 127.0.0.1, returned actual scan output).
- [x] `agents ask --no-yes <id> "use shell_exec to run X"` — TTY prompt appears.
- [ ] Adding a regression test for `_invoke_agent` MCP fallback would be welcome — happy to add one if you point me at the preferred mocking pattern.