### PR TITLE
docs: add Hermes Tweet GitHub skill install example

### DIFF
--- a/docs/user-guide/skills.md
+++ b/docs/user-guide/skills.md
@@ -148,6 +148,14 @@ jarvis skill sync openclaw --search "web3|crypto"
 jarvis skill install github:user/repo/path/to/skill --url https://github.com/user/repo
 ```
 
+For example, install the Hermes Tweet skill when you want an agent to search
+Twitter/X, read tweet replies, monitor tweets, export followers, and run
+gated post, reply, or DM workflows:
+
+```bash
+jarvis skill install github:Xquik-dev/hermes-tweet/skills/hermes-tweet --url https://github.com/Xquik-dev/hermes-tweet
+```
+
 ### Config-Driven Auto Import
 
 Add sources to `~/.openjarvis/config.toml` for automatic syncing:


### PR DESCRIPTION
## Summary

- Add a concrete GitHub skill install example for Hermes Tweet in the skills user guide
- Show the stable skill path for an X/Twitter workflow skill that can search Twitter/X, read tweet replies, monitor tweets, export followers, and run gated post/reply/DM workflows

## Validation

- Reviewed README, CONTRIBUTING, PR template, skills guide, skills tutorial, open PRs/issues, and duplicate PR/issue searches for Hermes Tweet, Xquik, TweetClaw, x-twitter, and Twitter Hermes
- `git diff --check`
- `uv run --extra docs mkdocs build`
- Checked touched links with curl: OpenJarvis skills docs, Hermes Tweet repo, Hermes Tweet skill path, and Hermes Tweet docs

## Note

`uv run --extra docs mkdocs build --strict` currently aborts on existing mkdocstrings/autorefs warnings outside this docs change; the non-strict docs build succeeds.