### PR TITLE
feat(cli): local-first chat with web grounding and sanitized defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,14 @@ Thumbs.db
 # Secrets
 .env
 .env.*
+*.local.toml
+config.local.toml
+**/credentials/
+**/*-credentials.json
+.mcp_*_test.txt
+
+# Local install (never commit — use configs/openjarvis/*.example.*)
+# ~/.openjarvis/config.toml is outside the repo by default
 
 # Project
 *.sqlite

--- a/README.md
+++ b/README.md
@@ -55,6 +55,23 @@ jarvis
 
 `jarvis init --preset <name>` switches to a starter config. Available presets: `morning-digest-mac`, `morning-digest-linux`, `morning-digest-minimal`, `deep-research`, `code-assistant`, `scheduled-monitor`, `chat-simple`.
 
+## CLI chat: model picker and MCP startup
+
+Recent UX changes for the interactive REPL (`jarvis` with no subcommand, or `jarvis chat` / `short` / `long` / `code`):
+
+- **Bare `jarvis` on a TTY** — before the session starts, the CLI lists models from your configured engine. Pick a number or id, or press **Enter** to use the `intelligence` presets (`model_chat`, etc.) and `default_model` from config.
+- **`JARVIS_SKIP_MODEL_PICK=1`** (or `true` / `yes`) — skips that list (scripts, CI, non-interactive stdin).
+- **`jarvis --pick-model`** — forces the picker even when `JARVIS_SKIP_MODEL_PICK` would skip it (top-level flag only).
+- **`jarvis chat`** (and tier shortcuts) — the picker runs only if you pass **`--pick-model`** on that command.
+- **Slow startup after the banner** — the model shown in the banner is already selected; a long pause is usually **MCP** (starting external tool processes, e.g. `npx` on first run), not “loading the LLM”. The CLI states this explicitly and prints **per-MCP-server progress** (connecting, success with elapsed seconds, or failure).
+
+**Grounding (web + indexed memory):**
+
+- Interactive chat **always adds `web_search`** to the tool list when the agent uses tools (`tools.require_web_search = true` in config; set `false` to opt out).
+- **`jarvis long`** defaults to `web_search`, `memory_retrieve`, and `think`, and injects retrieved context from your memory backend when `agent.context_from_memory = true`.
+- **`learn_qdrant` / auto Qdrant chunking** are **off by default** (`tools.auto_learn_qdrant = false`). Index corpora with `jarvis memory index` instead of ad-hoc chunks in the REPL.
+- System prompts tell the model to call **web_search** for current/external facts and **memory_retrieve** for indexed project knowledge before answering from weights alone.
+
 ## Starter Configs
 
 Install any preset with one command:

--- a/configs/openjarvis/config.example.toml
+++ b/configs/openjarvis/config.example.toml
@@ -1,0 +1,35 @@
+# Example ~/.openjarvis/config.toml — copy and customize locally.
+# NEVER commit this file with real tokens or private hostnames.
+
+[engine]
+default = "ollama"
+
+[intelligence]
+default_model = "qwen3:8b"
+
+[agent]
+default_agent = "native_react"
+max_turns = 12
+context_from_memory = true
+
+[tools]
+searxng_url = "http://127.0.0.1:8080"
+searxng_language = "en"
+require_web_search = true
+auto_learn_qdrant = false
+file_allowed_directories = "/path/to/your/projects"
+enabled = [
+    "web_search",
+    "file_read",
+    "think",
+    "memory_retrieve",
+]
+
+[tools.mcp]
+enabled = false
+# Paste JSON array of MCP servers (names only — tokens via env in each server's "env"):
+# servers = '''
+# [
+#   {"name": "my-mcp", "url": "http://127.0.0.1:9000/mcp/"}
+# ]
+# '''

--- a/configs/openjarvis/config.toml
+++ b/configs/openjarvis/config.toml
@@ -1,111 +1,52 @@
-# OpenJarvis configuration — GLM-4.7-Flash eval on 8x A100-80GB
+# OpenJarvis — default template (local-first)
+# Install: copy via `jarvis init` or to ~/.openjarvis/config.toml
+# Do not put API keys or host-specific MCP servers in this file — use env vars
+# and ~/.openjarvis/ for secrets (see config.example.toml).
 
-# ═══════════════════════════════════════════════════════════════
-# PILLAR 1: Intelligence — The Model
-# ═══════════════════════════════════════════════════════════════
+[engine]
+default = "ollama"
+
+[engine.ollama]
+# host = "http://localhost:11434"
+
 [intelligence]
-default_model = "zai-org/GLM-4.7-Flash"   # HuggingFace model ID
-fallback_model = "glm-4.7-flash"          # Catalog alias fallback
-preferred_engine = "vllm"                 # MoE model, vLLM is best for A100s
-provider = "local"                        # Running locally on this machine
-quantization = "none"                     # Full precision, we have 640GB VRAM
-# Generation defaults for eval
-temperature = 0.0                         # Deterministic for reproducibility
-max_tokens = 2048                         # Standard eval output length
-top_p = 0.9
-top_k = 40
-repetition_penalty = 1.0
+# Set after `ollama pull` / `jarvis init`, e.g. qwen3:8b
+default_model = ""
+model_chat = ""
+model_short = ""
+model_long = ""
+model_code = ""
 
-# ═══════════════════════════════════════════════════════════════
-# PILLAR 2: Agent — The Agentic Harness
-# ═══════════════════════════════════════════════════════════════
 [agent]
-default_agent = "native_openhands"        # CodeAct-style agent
-max_turns = 10                            # Up to 10 tool-calling turns
-tools = "code_interpreter,web_search,file_read,calculator,think"
-objective = "Answer questions accurately using available tools"
-context_from_memory = false               # No memory injection during eval
+default_agent = "native_react"
+max_turns = 12
+context_from_memory = true
+tools = ""
 
-# ═══════════════════════════════════════════════════════════════
-# PILLAR 3: Tools — MCP Interface
-# ═══════════════════════════════════════════════════════════════
+[tools]
+# Optional local SearXNG for web_search (overridable: SEARXNG_URL, SEARXNG_LANGUAGE)
+# searxng_url = "http://127.0.0.1:8080"
+# searxng_language = "en"
+require_web_search = true
+auto_learn_qdrant = false
+enabled = "web_search,file_read,think,calculator,code_interpreter"
+
 [tools.storage]
 default_backend = "sqlite"
 db_path = "~/.openjarvis/memory.db"
 
 [tools.mcp]
-enabled = true
+enabled = false
+servers = "[]"
 
-# ═══════════════════════════════════════════════════════════════
-# PILLAR 4: Engine — The Inference Runtime
-# ═══════════════════════════════════════════════════════════════
-[engine]
-default = "vllm"
-
-[engine.vllm]
-host = "http://localhost:8001"            # vLLM serving port
-
-[engine.ollama]
-host = "http://localhost:11434"
-
-[engine.sglang]
-host = "http://localhost:30000"
-
-[engine.llamacpp]
-host = "http://localhost:8080"
-
-[engine.exo]
-host = "http://localhost:52415"
-
-[engine.nexa]
-host = "http://localhost:18181"
-# device = "npu"  # optional: cpu, gpu, npu
-
-[engine.uzu]
-host = "http://localhost:8080"
-
-[engine.apple_fm]
-host = "http://localhost:8079"
-
-# ═══════════════════════════════════════════════════════════════
-# PILLAR 5: Learning — Improvement Methodologies
-# ═══════════════════════════════════════════════════════════════
-[learning]
-enabled = false                           # No learning during eval
-
-[learning.routing]
-policy = "heuristic"
-
-[learning.intelligence]
-policy = "none"
-
-[learning.agent]
-policy = "none"
-
-[learning.metrics]
-accuracy_weight = 0.6
-latency_weight = 0.2
-cost_weight = 0.1
-efficiency_weight = 0.1
-
-# ═══════════════════════════════════════════════════════════════
-# Supporting config
-# ═══════════════════════════════════════════════════════════════
 [telemetry]
 enabled = true
 db_path = "~/.openjarvis/telemetry.db"
-gpu_metrics = true
-gpu_poll_interval_ms = 50
-energy_vendor = ""                       # Auto-detect; or force "nvidia"/"amd"/"apple"/"cpu_rapl"
-warmup_samples = 0                       # Warmup iterations before steady-state measurement
-steady_state_window = 5                  # Sliding window size for CV stability check
-steady_state_threshold = 0.05            # Coefficient of variation threshold for steady state
 
 [traces]
-enabled = true                            # Record traces for analysis
+enabled = true
 db_path = "~/.openjarvis/traces.db"
 
 [server]
-host = "0.0.0.0"
+host = "127.0.0.1"
 port = 8000
-agent = "native_openhands"

--- a/configs/openjarvis/mcp.servers.example.json
+++ b/configs/openjarvis/mcp.servers.example.json
@@ -1,0 +1,16 @@
+[
+  {
+    "name": "example-http-mcp",
+    "url": "http://127.0.0.1:9000/mcp/",
+    "include_tools": []
+  },
+  {
+    "name": "example-stdio-mcp",
+    "command": "npx",
+    "args": ["-y", "@example/mcp-server"],
+    "env": {
+      "EXAMPLE_API_TOKEN": "set-in-shell-not-in-git"
+    },
+    "include_tools": []
+  }
+]

--- a/docs/development/publishing-fork.md
+++ b/docs/development/publishing-fork.md
@@ -1,0 +1,28 @@
+# Publishing a sanitized fork
+
+Before pushing to a public fork, ensure **no personal infrastructure** is in git:
+
+## Never commit
+
+- `~/.openjarvis/config.toml` (local install path)
+- `.env`, `.env.*`, API keys, OAuth JSON, `vault.enc`
+- MCP `servers` blocks with real URLs/tokens
+- Hardware-specific paths (`/home/you/...`)
+- Test artifacts (`.mcp_*_test.txt`)
+
+These are listed in `.gitignore`. Config templates live under `configs/openjarvis/`.
+
+## Pre-push check
+
+```bash
+./scripts/check-no-secrets.sh
+```
+
+## Recommended local setup
+
+```bash
+jarvis init --preset chat-simple
+# Edit ~/.openjarvis/config.toml — engines, SearXNG, MCP, file_allowed_directories
+```
+
+MCP tokens belong in **environment variables** referenced from config, not literal secrets in TOML.

--- a/scripts/check-no-secrets.sh
+++ b/scripts/check-no-secrets.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Quick scan for accidental secrets before git push.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+FAIL=0
+
+_patterns() {
+  rg -n --hidden \
+    -g '!.git' \
+    -g '!uv.lock' \
+    -g '!**/package-lock.json' \
+    -g '!**/Cargo.lock' \
+    -g '!**/*.png' \
+    -g '!**/*.jpg' \
+    -g '!**/tests/**' \
+    -g '!**/test_*.py' \
+    -g '!scripts/check-no-secrets.sh' \
+    -g '!docs/**' \
+    -g '!examples/**' \
+    -g '!frontend/**' \
+    -g '!rust/**' \
+    -g '!src/openjarvis/security/**' \
+    -g '!src/openjarvis/cli/deep_research_setup_cmd.py' \
+    -e "${1}" \
+    . 2>/dev/null || true
+}
+
+echo "Checking for credential patterns..."
+for pat in 'sk-[a-zA-Z0-9]{20,}' 'ghp_[a-zA-Z0-9]{36}' 'xoxb-' 'GITHUB_PERSONAL_ACCESS_TOKEN\s*=\s*["\x27][a-zA-Z0-9]' '/home/dozey' '/home/Dozey'; do
+  hits=$(_patterns "$pat" | head -5)
+  if [[ -n "$hits" ]]; then
+    echo "WARN pattern $pat:"
+    echo "$hits"
+    FAIL=1
+  fi
+done
+
+if git ls-files '*.env' '*.env.*' 2>/dev/null | grep -q .; then
+  echo "FAIL: .env files are tracked by git"
+  git ls-files '*.env' '*.env.*'
+  FAIL=1
+fi
+
+if [[ $FAIL -eq 0 ]]; then
+  echo "OK: no obvious secret patterns in tracked tree (review WARN paths manually)."
+  exit 0
+fi
+echo "Review warnings above before pushing."
+exit 1

--- a/src/openjarvis/agents/grounding.py
+++ b/src/openjarvis/agents/grounding.py
@@ -1,0 +1,68 @@
+"""Heuristics for mandatory web grounding before LLM answers."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, List, Sequence
+
+# Queries that need live web results, not training weights.
+_WEB_QUERY_RE = re.compile(
+    r"(?i)"
+    r"(?:"
+    r"wiadomo[sś]ci|news|aktualn|dzisiaj|wczoraj|teraz|najnowsz"
+    r"|ze\s+[śs]wiata|from\s+the\s+world|current\s+events"
+    r"|web[-\s]?search|wyszukaj|znajd[zź]|poszukaj|sprawd[zź]\s+w\s+si"
+    r"|w\s+internecie|online|google|pogoda|weather"
+    r"|co\s+si[eę]\s+dzi|what\s+happened|latest\s+on"
+    r")",
+)
+
+# Meta questions about capability — do not force search.
+_META_TOOL_RE = re.compile(
+    r"(?i)^\s*(czy\s+)?(używasz|masz|can you use|do you have)\s+.*web",
+)
+
+
+def query_needs_web_search(text: str) -> bool:
+    """Return True if *text* should trigger web_search before answering."""
+    t = (text or "").strip()
+    if not t or _META_TOOL_RE.search(t):
+        return False
+    return bool(_WEB_QUERY_RE.search(t))
+
+
+def web_search_used(tool_results: Sequence[Any]) -> bool:
+    """True if a successful web_search appears in agent tool results."""
+    for tr in tool_results:
+        name = str(getattr(tr, "tool_name", "") or "")
+        if name == "web_search" and bool(getattr(tr, "success", False)):
+            return True
+    return False
+
+
+def tool_names_include_web(tools: List[Any]) -> bool:
+    for t in tools or []:
+        spec = getattr(t, "spec", None)
+        if spec is not None and getattr(spec, "name", "") == "web_search":
+            return True
+    return False
+
+
+def run_web_search_preflight(query: str, *, max_results: int = 8) -> str | None:
+    """Execute web_search and return formatted snippets, or None on failure."""
+    from openjarvis.tools.web_search import WebSearchTool
+
+    tool = WebSearchTool()
+    result = tool.execute(query=query, max_results=max_results)
+    if not result.success:
+        return None
+    body = (result.content or "").strip()
+    return body or None
+
+
+__all__ = [
+    "query_needs_web_search",
+    "run_web_search_preflight",
+    "tool_names_include_web",
+    "web_search_used",
+]

--- a/src/openjarvis/agents/native_react.py
+++ b/src/openjarvis/agents/native_react.py
@@ -10,6 +10,11 @@ import re
 from typing import Any, List, Optional
 
 from openjarvis.agents._stubs import AgentContext, AgentResult, ToolUsingAgent
+from openjarvis.agents.grounding import (
+    query_needs_web_search,
+    tool_names_include_web,
+    web_search_used,
+)
 from openjarvis.agents.prompt_loader import (
     load_few_shot_exemplars,
     load_system_prompt_override,
@@ -21,7 +26,10 @@ from openjarvis.engine._stubs import InferenceEngine
 from openjarvis.tools._stubs import BaseTool, build_tool_descriptions
 
 REACT_SYSTEM_PROMPT = """\
-You are a ReAct agent. For each step, respond with exactly one of:
+You are a ReAct agent. For current events, news, or anything after your training
+cutoff, you MUST call web_search before Final Answer when that tool is listed.
+
+For each step, respond with exactly one of:
 
 1. To think and act:
 Thought: <your reasoning>
@@ -169,6 +177,9 @@ class NativeReActAgent(ToolUsingAgent):
                 messages.insert(-1, Message(role=Role.ASSISTANT, content=ex["output"]))
 
         all_tool_results: list[ToolResult] = []
+        must_web = tool_names_include_web(self._tools) and query_needs_web_search(
+            input,
+        )
         turns = 0
         total_usage: dict[str, int] = {
             "prompt_tokens": 0,
@@ -192,6 +203,19 @@ class NativeReActAgent(ToolUsingAgent):
 
             # Final answer?
             if parsed["final_answer"]:
+                if must_web and not web_search_used(all_tool_results):
+                    messages.append(Message(role=Role.ASSISTANT, content=content))
+                    messages.append(
+                        Message(
+                            role=Role.USER,
+                            content=(
+                                "Observation: Do not give a Final Answer until "
+                                "you have called web_search and read the "
+                                "Observation. Use Action: web_search first."
+                            ),
+                        ),
+                    )
+                    continue
                 self._emit_turn_end(turns=turns)
                 msg_dicts = [_message_to_dict(m) for m in messages]
                 return AgentResult(
@@ -201,8 +225,23 @@ class NativeReActAgent(ToolUsingAgent):
                     metadata={**total_usage, "messages": msg_dicts},
                 )
 
-            # No action? Treat content as final answer
+            # No action? Usually treat as final — unless web grounding still required.
             if not parsed["action"]:
+                if must_web and not web_search_used(all_tool_results):
+                    messages.append(Message(role=Role.ASSISTANT, content=content))
+                    messages.append(
+                        Message(
+                            role=Role.USER,
+                            content=(
+                                "Observation: You must call web_search before "
+                                "answering this question. Respond with:\n"
+                                "Thought: ...\n"
+                                'Action: web_search\n'
+                                'Action Input: {"query": "<search query>"}'
+                            ),
+                        ),
+                    )
+                    continue
                 self._emit_turn_end(turns=turns)
                 msg_dicts = [_message_to_dict(m) for m in messages]
                 return AgentResult(

--- a/src/openjarvis/cli/__init__.py
+++ b/src/openjarvis/cli/__init__.py
@@ -28,6 +28,9 @@ from openjarvis.cli.init_cmd import init
 from openjarvis.cli.memory_cmd import memory
 from openjarvis.cli.mine_cmd import mine
 from openjarvis.cli.model import model
+from openjarvis.cli.modes_cmd import code as code_chat
+from openjarvis.cli.modes_cmd import long as long_chat
+from openjarvis.cli.modes_cmd import short as short_chat
 from openjarvis.cli.operators_cmd import operators
 from openjarvis.cli.optimize_cmd import optimize_group
 from openjarvis.cli.pearl_cmd import pearl
@@ -51,14 +54,30 @@ from openjarvis.learning.distillation.cli import learning_group
 @click.version_option(version=openjarvis.__version__, prog_name="jarvis")
 @click.option("--verbose", is_flag=True, default=False, help="Enable debug logging")
 @click.option("--quiet", is_flag=True, default=False, help="Suppress non-error output")
+@click.option(
+    "--pick-model",
+    "pick_model_bare",
+    is_flag=True,
+    default=False,
+    help=(
+        "Bare ``jarvis``: force the model picker when JARVIS_SKIP_MODEL_PICK would "
+        "otherwise skip it."
+    ),
+)
 @click.pass_context
-def cli(ctx: click.Context, verbose: bool, quiet: bool) -> None:
+def cli(
+    ctx: click.Context,
+    verbose: bool,
+    quiet: bool,
+    pick_model_bare: bool,
+) -> None:
     """Top-level CLI group."""
     from openjarvis.cli.log_config import setup_logging
 
     ctx.ensure_object(dict)
     ctx.obj["verbose"] = verbose
     ctx.obj["quiet"] = quiet
+    ctx.obj["pick_model_bare"] = pick_model_bare
     setup_logging(verbose=verbose, quiet=quiet)
 
     # Check for updates on interactive commands
@@ -77,6 +96,9 @@ def cli(ctx: click.Context, verbose: bool, quiet: bool) -> None:
 cli.add_command(init, "init")
 cli.add_command(ask, "ask")
 cli.add_command(chat, "chat")
+cli.add_command(short_chat, "short")
+cli.add_command(long_chat, "long")
+cli.add_command(code_chat, "code")
 cli.add_command(serve, "serve")
 cli.add_command(model, "model")
 cli.add_command(memory, "memory")

--- a/src/openjarvis/cli/_chat_context.py
+++ b/src/openjarvis/cli/_chat_context.py
@@ -1,0 +1,92 @@
+"""Shared retrieval / web-grounding helpers for interactive chat."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List
+
+from openjarvis.agents.grounding import (
+    query_needs_web_search,
+    run_web_search_preflight,
+    tool_names_include_web,
+)
+
+if TYPE_CHECKING:
+    from openjarvis.core.config import JarvisConfig
+    from openjarvis.core.types import Message
+
+# Prepended to tier system prompts when the agent uses tools.
+WEB_GROUNDING_SYSTEM = (
+    "Grounding priority: local models are weak on post-training facts. "
+    "When web_search is in your tool list, you MUST call it before answering "
+    "questions about current events, news, prices, versions, APIs, laws, "
+    "weather, or anything that may have changed recently — do not guess from "
+    "weights alone. Cite titles/snippets from tool output. "
+    "When memory_retrieve is available, search indexed project knowledge first "
+    "for repo-specific facts, then use web_search for external or fresh data. "
+    "Use qdrant-find only for collections the user already indexed; do not "
+    "chunk or store chat text into Qdrant during the session."
+)
+
+LONG_MEMORY_SYSTEM = (
+    "Long-session memory: use memory_retrieve (and automatic context blocks) "
+    "for prior indexed notes. Index new documents with ``jarvis memory index`` "
+    "outside chat — not ad-hoc chunking in the REPL."
+)
+
+
+def ensure_chat_tool_names(
+    names: List[str],
+    *,
+    require_web_search: bool = True,
+    require_memory_retrieve: bool = False,
+) -> List[str]:
+    """Return *names* with required tools appended if missing."""
+    out = list(names)
+    seen = {n.strip() for n in out if n.strip()}
+    if require_web_search and "web_search" not in seen:
+        out.append("web_search")
+        seen.add("web_search")
+    if require_memory_retrieve and "memory_retrieve" not in seen:
+        out.append("memory_retrieve")
+        seen.add("memory_retrieve")
+    return out
+
+
+def memory_context_messages(
+    query: str,
+    config: JarvisConfig,
+) -> List[Message]:
+    """Retrieve indexed memory context for *query* (empty if disabled/unavailable)."""
+    if not getattr(config.agent, "context_from_memory", True):
+        return []
+    from openjarvis.cli.ask import _get_memory_backend
+    from openjarvis.tools.storage.context import ContextConfig, inject_context
+
+    backend = _get_memory_backend(config)
+    if backend is None:
+        return []
+    ctx_cfg = ContextConfig(
+        top_k=config.memory.context_top_k,
+        min_score=config.memory.context_min_score,
+        max_context_tokens=config.memory.context_max_tokens,
+    )
+    injected = inject_context(query, [], backend, config=ctx_cfg)
+    return injected if injected else []
+
+
+def preflight_web_block(user_input: str, *, max_results: int = 8) -> str | None:
+    """Run web_search for news/current-events queries; return snippet block."""
+    if not query_needs_web_search(user_input):
+        return None
+    return run_web_search_preflight(user_input, max_results=max_results)
+
+
+__all__ = [
+    "LONG_MEMORY_SYSTEM",
+    "WEB_GROUNDING_SYSTEM",
+    "ensure_chat_tool_names",
+    "memory_context_messages",
+    "preflight_web_block",
+    "query_needs_web_search",
+    "tool_names_include_web",
+]

--- a/src/openjarvis/cli/_external_mcp_tools.py
+++ b/src/openjarvis/cli/_external_mcp_tools.py
@@ -1,0 +1,128 @@
+"""Attach external MCP tools (HTTP/stdio) for CLI agents (chat, ask).
+
+Mirrors :meth:`openjarvis.system.builder.SystemBuilder._discover_external_mcp`
+so ``[tools.mcp].servers`` works outside ``jarvis serve`` / SystemBuilder.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from collections.abc import Callable
+from typing import Any, List, Optional, Set
+
+logger = logging.getLogger(__name__)
+
+
+def discover_external_mcp_tools(
+    config: Any,
+    *,
+    allowed_tool_names: Optional[Set[str]] = None,
+    status: Optional[Callable[[str], None]] = None,
+) -> List[Any]:
+    """Return :class:`~openjarvis.tools.mcp_adapter.MCPToolAdapter` instances.
+
+    Parameters
+    ----------
+    config:
+        Loaded :class:`~openjarvis.core.config.JarvisConfig`.
+    allowed_tool_names:
+        If not ``None``, only MCP tools whose ``spec.name`` is in this set are
+        kept (same idea as ``SystemBuilder._resolve_tools``). If ``None``,
+        every discovered MCP tool is returned.
+    status:
+        Optional callback for human-readable progress (e.g. CLI ``print``).
+        Invoked before and after each MCP server handshake.
+    """
+    if not getattr(config.tools.mcp, "enabled", True):
+        return []
+    raw = getattr(config.tools.mcp, "servers", "") or ""
+    if not raw.strip():
+        return []
+
+    try:
+        server_list = json.loads(raw)
+    except (json.JSONDecodeError, TypeError) as exc:
+        logger.warning("Invalid tools.mcp.servers JSON: %s", exc)
+        return []
+
+    if not isinstance(server_list, list):
+        return []
+
+    from openjarvis.mcp.client import MCPClient
+    from openjarvis.mcp.transport import StdioTransport, StreamableHTTPTransport
+    from openjarvis.tools.mcp_adapter import MCPToolProvider
+
+    out: list = []
+    for server_cfg in server_list:
+        cfg = json.loads(server_cfg) if isinstance(server_cfg, str) else server_cfg
+        name = cfg.get("name", "<unnamed>")
+        url = cfg.get("url")
+        command = cfg.get("command", "")
+        args = cfg.get("args", [])
+
+        try:
+            if url:
+                transport = StreamableHTTPTransport(url=url)
+            elif command:
+                extra_env = cfg.get("env") or {}
+                if isinstance(extra_env, dict):
+                    env_map = {str(k): str(v) for k, v in extra_env.items()}
+                else:
+                    env_map = {}
+                transport = StdioTransport(
+                    command=[command] + args,
+                    env=env_map or None,
+                )
+            else:
+                logger.warning(
+                    "MCP server '%s' has neither 'url' nor 'command' — skipping",
+                    name,
+                )
+                continue
+
+            t0 = time.monotonic()
+            if status:
+                status(f"MCP server '{name}': connecting …")
+
+            client = MCPClient(transport)
+            client.initialize()
+            provider = MCPToolProvider(client)
+            discovered = provider.discover()
+
+            include_tools = set(cfg.get("include_tools", []))
+            exclude_tools = set(cfg.get("exclude_tools", []))
+            if include_tools:
+                discovered = [t for t in discovered if t.spec.name in include_tools]
+            if exclude_tools:
+                discovered = [t for t in discovered if t.spec.name not in exclude_tools]
+
+            if allowed_tool_names is not None:
+                discovered = [
+                    t for t in discovered if t.spec.name in allowed_tool_names
+                ]
+
+            out.extend(discovered)
+            logger.info(
+                "CLI: attached %d MCP tool(s) from server '%s'",
+                len(discovered),
+                name,
+            )
+            if status:
+                elapsed = time.monotonic() - t0
+                status(
+                    f"MCP server '{name}': {len(discovered)} tool(s) in {elapsed:.1f}s",
+                )
+        except Exception as exc:
+            logger.warning("CLI: MCP server '%s' failed: %s", name, exc)
+            if status:
+                elapsed = time.monotonic() - t0
+                status(
+                    f"MCP server '{name}': failed after {elapsed:.1f}s — {exc!s}",
+                )
+
+    return out
+
+
+__all__ = ["discover_external_mcp_tools"]

--- a/src/openjarvis/cli/_first_run.py
+++ b/src/openjarvis/cli/_first_run.py
@@ -4,9 +4,16 @@ When the user types ``jarvis`` with no subcommand, route them to the
 chat command if a config exists, otherwise into the init wizard with
 the ``--from-bare-jarvis`` flag (which lets init suppress the
 launch-chat prompt and auto-confirm downstream questions).
+
+On an interactive terminal, bare ``jarvis`` opens the model picker first
+(unless ``JARVIS_SKIP_MODEL_PICK=1``). Use ``jarvis --pick-model`` to
+force the picker even when that env is set.
 """
 
 from __future__ import annotations
+
+import os
+import sys
 
 from typing import TYPE_CHECKING
 
@@ -30,6 +37,13 @@ def check_and_route(ctx: click.Context) -> None:
     from openjarvis.cli.init_cmd import init as init_cmd
 
     if _cfg.DEFAULT_CONFIG_PATH.exists():
-        ctx.invoke(chat_cmd)
+        pick_bare = bool(getattr(ctx, "obj", None) and ctx.obj.get("pick_model_bare"))
+        skip = (os.environ.get("JARVIS_SKIP_MODEL_PICK", "") or "").strip().lower() in (
+            "1",
+            "true",
+            "yes",
+        )
+        use_pick = pick_bare or (sys.stdin.isatty() and not skip)
+        ctx.invoke(chat_cmd, pick_model=use_pick)
     else:
         ctx.invoke(init_cmd, from_bare_jarvis=True)

--- a/src/openjarvis/cli/_model_switch.py
+++ b/src/openjarvis/cli/_model_switch.py
@@ -1,0 +1,104 @@
+"""Resolve chat CLI model: per-command presets, ``-m smart``, ``default_model``."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+SMART_MODEL_TOKEN = "smart"
+
+_VARIANT_ATTR: dict[str, str] = {
+    "chat": "model_chat",
+    "short": "model_short",
+    "long": "model_long",
+    "code": "model_code",
+}
+
+
+def variant_preset_model(config: Any, chat_variant: str) -> str:
+    """Return ``[intelligence] model_<variant>`` if set, else ``\"\"``."""
+    intel = getattr(config, "intelligence", None)
+    if intel is None:
+        return ""
+    attr = _VARIANT_ATTR.get(chat_variant, "model_chat")
+    raw = (getattr(intel, attr, None) or "").strip()
+    return raw
+
+
+def interactive_pick_model(console: Any, engine: Any) -> Optional[str]:
+    """List engine models and read user choice. Returns ``None`` if cancelled."""
+    models: list[str] = []
+    try:
+        models = list(engine.list_models())
+    except Exception:
+        models = []
+    if not models:
+        console.print(
+            "[yellow]Engine did not return any models — cannot pick "
+            "interactively.[/yellow]",
+        )
+        return None
+    console.print("[bold]Available models[/bold] (number or exact id):")
+    for i, mid in enumerate(models, 1):
+        console.print(f"  {i:2}) [cyan]{mid}[/cyan]")
+    try:
+        raw = input(
+            "Choose model [1–%d], id, or Enter for config default: " % len(models)
+        )
+    except (EOFError, KeyboardInterrupt):
+        return None
+    choice = (raw or "").strip()
+    if not choice:
+        return None
+    if choice.isdigit():
+        idx = int(choice)
+        if 1 <= idx <= len(models):
+            return models[idx - 1]
+        return None
+    for mid in models:
+        if mid == choice or choice in mid:
+            return mid
+    return choice
+
+
+def resolve_chat_cli_model(
+    *,
+    console: Any,
+    config: Any,
+    engine: Any,
+    engine_name: str,
+    cli_model: Optional[str],
+    chat_variant: str,
+) -> str:
+    """Resolve model from ``-m``, ``smart`` / presets, or ``default_model``.
+
+    Interactive picking is handled in ``run_chat_interactive`` before this runs.
+    """
+    explicit = (cli_model or "").strip()
+    if explicit and explicit.lower() != SMART_MODEL_TOKEN:
+        return explicit
+
+    preset = variant_preset_model(config, chat_variant)
+    if preset:
+        return preset
+
+    dm = (getattr(config.intelligence, "default_model", None) or "").strip()
+    if dm:
+        return dm
+
+    from openjarvis.engine import discover_engines, discover_models
+
+    all_engines = discover_engines(config)
+    all_models = discover_models(all_engines)
+    engine_models = all_models.get(engine_name, [])
+    if engine_models:
+        return engine_models[0]
+
+    return ""
+
+
+__all__ = [
+    "SMART_MODEL_TOKEN",
+    "interactive_pick_model",
+    "resolve_chat_cli_model",
+    "variant_preset_model",
+]

--- a/src/openjarvis/cli/_tool_names.py
+++ b/src/openjarvis/cli/_tool_names.py
@@ -23,6 +23,18 @@ def _normalize_tool_names(value: Any) -> list[str]:
     return [text] if text else []
 
 
+def parse_file_allowed_directories(config: Any) -> list[str] | None:
+    """Paths from ``[tools] file_allowed_directories`` (comma-separated), or None."""
+    tools = getattr(config, "tools", None)
+    if tools is None:
+        return None
+    raw = (getattr(tools, "file_allowed_directories", "") or "").strip()
+    if not raw:
+        return None
+    paths = [p.strip() for p in raw.split(",") if p.strip()]
+    return paths or None
+
+
 def resolve_tool_names(
     cli_value: str | None,
     *configured_values: Any,

--- a/src/openjarvis/cli/_version_check.py
+++ b/src/openjarvis/cli/_version_check.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 _CACHE_PATH = Path("~/.openjarvis/version-check.json").expanduser()
 _CACHE_TTL = 86400  # 24 hours
 _GITHUB_API = "https://api.github.com/repos/open-jarvis/OpenJarvis/releases/latest"
-_CHECK_COMMANDS = {"ask", "chat", "serve"}
+_CHECK_COMMANDS = {"ask", "chat", "short", "long", "code", "serve"}
 
 
 def check_for_updates(command_name: str) -> None:

--- a/src/openjarvis/cli/ask.py
+++ b/src/openjarvis/cli/ask.py
@@ -11,7 +11,10 @@ import click
 from rich.console import Console
 from rich.table import Table
 
-from openjarvis.cli._tool_names import resolve_tool_names
+from openjarvis.cli._tool_names import (
+    parse_file_allowed_directories,
+    resolve_tool_names,
+)
 from openjarvis.cli.hints import hint_no_engine
 from openjarvis.core.config import load_config
 from openjarvis.core.events import EventBus, EventType
@@ -75,6 +78,7 @@ def _build_tools(
     model_name: str,
     *,
     channel=None,
+    mcp_status=None,
 ):
     """Instantiate tool objects from names.
 
@@ -122,10 +126,21 @@ def _build_tools(
             tools.append(tool_cls(channel=channel))
         elif name == "llm":
             tools.append(tool_cls(engine=engine, model=model_name))
-        elif name == "file_read":
-            tools.append(tool_cls())
+        elif name in ("file_read", "file_write"):
+            fd = parse_file_allowed_directories(config)
+            tools.append(tool_cls(allowed_dirs=fd))
         else:
             tools.append(tool_cls())
+    if tool_names:
+        from openjarvis.cli._external_mcp_tools import discover_external_mcp_tools
+
+        tools.extend(
+            discover_external_mcp_tools(
+                config,
+                allowed_tool_names={n.strip() for n in tool_names if n.strip()},
+                status=mcp_status,
+            )
+        )
     return tools
 
 

--- a/src/openjarvis/cli/chat_cmd.py
+++ b/src/openjarvis/cli/chat_cmd.py
@@ -2,16 +2,30 @@
 
 from __future__ import annotations
 
+import json
 import sys
-from typing import List, Optional
+from typing import Any, Callable, List, Optional
 
 import click
 from rich.console import Console
 from rich.markdown import Markdown
+from rich.markup import escape
 
-from openjarvis.cli._tool_names import resolve_tool_names
+from openjarvis.cli._chat_context import (
+    LONG_MEMORY_SYSTEM,
+    WEB_GROUNDING_SYSTEM,
+    ensure_chat_tool_names,
+    memory_context_messages,
+    preflight_web_block,
+    tool_names_include_web,
+)
+from openjarvis.cli._tool_names import (
+    _normalize_tool_names,
+    resolve_tool_names,
+)
+from openjarvis.core.config import JarvisConfig
 from openjarvis.core.config import load_config
-from openjarvis.core.types import Message, Role
+from openjarvis.core.types import Conversation, Message, Role
 
 
 def _read_input(prompt: str = "You> ") -> Optional[str]:
@@ -22,31 +36,137 @@ def _read_input(prompt: str = "You> ") -> Optional[str]:
         return None
 
 
-@click.command()
-@click.option("-e", "--engine", "engine_key", default=None, help="Engine backend.")
-@click.option("-m", "--model", "model_name", default=None, help="Model to use.")
-@click.option("-a", "--agent", "agent_name", default=None, help="Agent type.")
-@click.option("--tools", default=None, help="Comma-separated tool names.")
-@click.option("--system", "system_prompt", default=None, help="Custom system prompt.")
-def chat(
+_AUTO_LEARN_DEFAULT_SOURCES = (
+    "web_search,file_read,get_file_contents,search_code,search_repositories"
+)
+
+
+def _auto_learn_from_tool_results(
+    *,
+    config: JarvisConfig,
+    tool_results: list[Any],
+    status: Callable[[str], None] | None = None,
+) -> None:
+    """Persist high-value tool outputs to Qdrant without model micromanagement."""
+    tools_cfg = getattr(config, "tools", None)
+    if tools_cfg is None:
+        return
+    if not bool(getattr(tools_cfg, "auto_learn_qdrant", True)):
+        return
+    if not tool_results:
+        return
+
+    mcp_cfg = getattr(tools_cfg, "mcp", None)
+    if mcp_cfg is None or not bool(getattr(mcp_cfg, "enabled", True)):
+        return
+
+    allow_sources = set(
+        _normalize_tool_names(
+            getattr(tools_cfg, "auto_learn_sources", _AUTO_LEARN_DEFAULT_SOURCES)
+        )
+    )
+    if not allow_sources:
+        allow_sources = set(_normalize_tool_names(_AUTO_LEARN_DEFAULT_SOURCES))
+
+    min_chars = int(getattr(tools_cfg, "auto_learn_min_chars", 160) or 160)
+    max_chars = int(getattr(tools_cfg, "auto_learn_max_chars", 8000) or 8000)
+    min_chunk_size = int(getattr(tools_cfg, "auto_learn_min_chunk_size", 20) or 20)
+
+    candidates: list[tuple[str, str]] = []
+    for tr in tool_results:
+        name = str(getattr(tr, "tool_name", "") or "").strip()
+        if not name or name not in allow_sources:
+            continue
+        if not bool(getattr(tr, "success", False)):
+            continue
+        content = str(getattr(tr, "content", "") or "").strip()
+        if len(content) < min_chars:
+            continue
+        candidates.append((name, content[:max_chars]))
+
+    if not candidates:
+        return
+
+    try:
+        from openjarvis.tools.learn_qdrant import LearnQdrantTool
+
+        learner = LearnQdrantTool()
+    except Exception:
+        return
+
+    stored = 0
+    for tool_name, text in candidates:
+        result = learner.execute(
+            text=text,
+            source=f"auto:{tool_name}",
+            origin=tool_name,
+            min_chunk_size=min_chunk_size,
+        )
+        if result.success:
+            stored += 1
+
+    if status and stored:
+        status(f"Auto-memory: stored {stored} tool result(s) in Qdrant.")
+
+
+def run_chat_interactive(
     engine_key: str | None,
     model_name: str | None,
     agent_name: str | None,
     tools: str | None,
     system_prompt: str | None,
+    *,
+    default_agent_when_unset: str | None = None,
+    default_tools_when_unset: str | None = None,
+    extra_system_prompt: str | None = None,
+    session_title: str | None = None,
+    chat_variant: str | None = None,
+    pick_model: bool = False,
 ) -> None:
-    """Start an interactive multi-turn chat session.
-
-    Commands during chat:
-      /quit, /exit  — end session
-      /clear        — clear conversation history
-      /model        — show current model
-      /help         — show available commands
-      /history      — show conversation history
-    """
+    """Run the interactive REPL (shared by ``chat``, ``short``, ``long``, ``code``)."""
     console = Console(stderr=True)
 
+    def _mcp_progress(msg: str) -> None:
+        console.print(f"[dim]{escape(msg)}[/dim]")
+
     config = load_config()
+
+    if agent_name is not None:
+        eff_agent = agent_name
+    elif default_agent_when_unset is not None:
+        eff_agent = default_agent_when_unset
+    else:
+        eff_agent = config.agent.default_agent
+
+    if tools is not None:
+        eff_tools = tools
+    elif default_tools_when_unset is not None:
+        merged = list(_normalize_tool_names(default_tools_when_unset))
+        seen = set(merged)
+        for n in _normalize_tool_names(getattr(config.tools, "enabled", None)):
+            if n not in seen:
+                merged.append(n)
+                seen.add(n)
+        eff_tools = ",".join(merged)
+    else:
+        eff_tools = None
+
+    if extra_system_prompt:
+        eff_system = (
+            f"{system_prompt}\n\n{extra_system_prompt}"
+            if system_prompt
+            else extra_system_prompt
+        )
+    else:
+        eff_system = system_prompt
+
+    if eff_agent not in (None, "none", "simple"):
+        grounding = WEB_GROUNDING_SYSTEM
+        if (chat_variant or "chat") in ("long", "chat"):
+            grounding = f"{grounding}\n{LONG_MEMORY_SYSTEM}"
+        eff_system = (
+            f"{eff_system}\n\n{grounding}" if eff_system else grounding
+        )
 
     # Resolve engine
     from openjarvis.engine import get_engine
@@ -60,22 +180,75 @@ def chat(
         sys.exit(1)
 
     engine_name, engine = resolved
-    model = model_name or config.intelligence.default_model
-    if not model:
-        from openjarvis.engine import discover_engines, discover_models
+    from openjarvis.cli._model_switch import interactive_pick_model, resolve_chat_cli_model
 
-        all_engines = discover_engines(config)
-        all_models = discover_models(all_engines)
-        engine_models = all_models.get(engine_name, [])
-        if engine_models:
-            model = engine_models[0]
-        else:
-            console.print("[red]No model available.[/red]")
-            sys.exit(1)
+    model = ""
+    if pick_model:
+        console.print(
+            "[dim]Pick a model below, or press Enter for config default "
+            "(intelligence presets / default_model).[/dim]\n",
+        )
+        picked = interactive_pick_model(console, engine)
+        if picked:
+            model = picked
+    if not model:
+        model = resolve_chat_cli_model(
+            console=console,
+            config=config,
+            engine=engine,
+            engine_name=engine_name,
+            cli_model=model_name,
+            chat_variant=chat_variant or "chat",
+        )
+    if not model:
+        console.print("[red]No model available.[/red]")
+        sys.exit(1)
+
+    agent_key = eff_agent
+    banner_title = session_title or "OpenJarvis Chat"
+    console.print(
+        f"[green bold]{banner_title}[/green bold]\n"
+        f"  Engine: [cyan]{engine_name}[/cyan]  Model: [cyan]{model}[/cyan]"
+        f"  Agent: [cyan]{agent_key or 'direct'}[/cyan]\n"
+        f"  Type /help for commands, /quit to exit.\n",
+    )
+    mcp_cfg = getattr(config.tools, "mcp", None)
+    mcp_servers = (getattr(mcp_cfg, "servers", None) or "").strip()
+    mcp_startup_hint = False
+    will_load_mcp = False
+    if (
+        agent_key
+        and agent_key != "none"
+        and mcp_cfg
+        and getattr(mcp_cfg, "enabled", True)
+        and mcp_servers
+    ):
+        try:
+            import openjarvis.agents  # noqa: F401 — registration for AgentRegistry
+            from openjarvis.core.registry import AgentRegistry
+
+            if AgentRegistry.contains(agent_key):
+                agent_cls_probe = AgentRegistry.get(agent_key)
+                if getattr(agent_cls_probe, "accepts_tools", False):
+                    preview_tools = resolve_tool_names(
+                        eff_tools,
+                        getattr(config.tools, "enabled", None),
+                        getattr(config.agent, "tools", None),
+                    )
+                    will_load_mcp = bool(preview_tools)
+        except Exception:
+            will_load_mcp = False
+
+    if will_load_mcp:
+        console.print(
+            "[dim]The LLM model above is already selected — this step starts MCP "
+            "(external tool processes), not model weights. Each line below is one "
+            "server; first run can be slow (e.g. npx). Ctrl+C aborts startup.[/dim]\n",
+        )
+        mcp_startup_hint = True
 
     # Resolve agent (optional)
     agent = None
-    agent_key = agent_name or config.agent.default_agent
     if agent_key and agent_key != "none":
         try:
             import openjarvis.agents  # noqa: F401 — trigger registration
@@ -88,25 +261,39 @@ def chat(
 
                 if getattr(agent_cls, "accepts_tools", False):
                     tool_names_list = resolve_tool_names(
-                        tools,
+                        eff_tools,
                         getattr(config.tools, "enabled", None),
                         getattr(config.agent, "tools", None),
                     )
                     if tool_names_list:
                         import openjarvis.tools  # noqa: F401 — trigger registration
-                        from openjarvis.core.registry import ToolRegistry
-                        from openjarvis.tools._stubs import BaseTool
+                        from openjarvis.cli.ask import _build_tools
 
-                        tool_instances = []
-                        for tname in tool_names_list:
-                            if ToolRegistry.contains(tname):
-                                tcls = ToolRegistry.get(tname)
-                                if isinstance(tcls, type) and issubclass(
-                                    tcls, BaseTool
-                                ):
-                                    tool_instances.append(tcls())
-                                elif isinstance(tcls, BaseTool):
-                                    tool_instances.append(tcls)
+                        require_web = bool(
+                            getattr(config.tools, "require_web_search", True),
+                        )
+                        require_mem = (chat_variant or "chat") in ("long", "chat")
+                        tool_names_list = ensure_chat_tool_names(
+                            tool_names_list,
+                            require_web_search=require_web,
+                            require_memory_retrieve=(
+                                require_mem
+                                and bool(
+                                    getattr(
+                                        config.agent,
+                                        "context_from_memory",
+                                        True,
+                                    ),
+                                )
+                            ),
+                        )
+                        tool_instances = _build_tools(
+                            tool_names_list,
+                            config,
+                            engine,
+                            model,
+                            mcp_status=_mcp_progress,
+                        )
                         if tool_instances:
                             kwargs["tools"] = tool_instances
                     kwargs["max_turns"] = config.agent.max_turns
@@ -125,13 +312,8 @@ def chat(
         except Exception as exc:
             console.print(f"[yellow]Agent '{agent_key}' failed: {exc}[/yellow]")
 
-    # Print banner
-    console.print(
-        f"[green bold]OpenJarvis Chat[/green bold]\n"
-        f"  Engine: [cyan]{engine_name}[/cyan]  Model: [cyan]{model}[/cyan]"
-        f"  Agent: [cyan]{agent_key or 'direct'}[/cyan]\n"
-        f"  Type /help for commands, /quit to exit.\n"
-    )
+    if mcp_startup_hint:
+        console.print("[dim]Startup complete — you can type below.[/dim]\n")
 
     # Background-work status banner (disappears after first user message)
     from openjarvis.cli._bg_state import get_status
@@ -148,8 +330,8 @@ def chat(
 
     # Conversation state
     history: List[Message] = []
-    if system_prompt:
-        history.append(Message(role=Role.SYSTEM, content=system_prompt))
+    if eff_system:
+        history.append(Message(role=Role.SYSTEM, content=eff_system))
 
     # REPL loop
     while True:
@@ -172,13 +354,80 @@ def chat(
             break
         elif cmd == "/clear":
             history = []
-            if system_prompt:
-                history.append(Message(role=Role.SYSTEM, content=system_prompt))
+            if eff_system:
+                history.append(Message(role=Role.SYSTEM, content=eff_system))
             console.print("[dim]History cleared.[/dim]")
             continue
         elif cmd == "/model":
             console.print(
                 f"Model: [cyan]{model}[/cyan]  Engine: [cyan]{engine_name}[/cyan]"
+            )
+            continue
+        elif cmd in ("/tools", "/mcp"):
+            tn = resolve_tool_names(
+                eff_tools,
+                getattr(config.tools, "enabled", None),
+                getattr(config.agent, "tools", None),
+            )
+            console.print("[bold]Konfiguracja narzędzi[/bold] (config, nie model LLM)")
+            if tn:
+                joined = ", ".join(tn)
+                console.print(f"  [bold]tools.enabled / agent.tools:[/bold] {joined}")
+            else:
+                console.print("  [dim]Brak listy narzędzi w configu[/dim]")
+            sx = (getattr(config.tools, "searxng_url", "") or "").strip()
+            if sx:
+                console.print(f"  [bold]SearXNG[/bold] (web_search): [cyan]{sx}[/cyan]")
+            mcp_on = getattr(config.tools.mcp, "enabled", False)
+            raw_srv = (getattr(config.tools.mcp, "servers", "") or "").strip()
+            if mcp_on and raw_srv:
+                try:
+                    sl = json.loads(raw_srv)
+                    console.print("  [bold]MCP servers[/bold] ([tools.mcp].servers):")
+                    for s in sl:
+                        if isinstance(s, dict):
+                            nm = s.get("name", "?")
+                            url = s.get("url")
+                            cmd_m = s.get("command")
+                            line = f"    - [cyan]{nm}[/cyan]  {url or cmd_m or '?'}"
+                            console.print(line)
+                except json.JSONDecodeError as exc:
+                    console.print(f"  [red]Zły JSON w tools.mcp.servers: {exc}[/red]")
+            else:
+                console.print("  [dim]MCP wyłączone albo puste servers[/dim]")
+            if tn:
+                try:
+                    from openjarvis.cli._external_mcp_tools import (
+                        discover_external_mcp_tools,
+                    )
+
+                    extra = discover_external_mcp_tools(
+                        config,
+                        allowed_tool_names=set(tn),
+                        status=_mcp_progress,
+                    )
+                    if extra:
+                        console.print(
+                            "  [bold]Narzędzia MCP załadowane[/bold]: "
+                            + ", ".join(t.spec.name for t in extra)
+                        )
+                    else:
+                        console.print(
+                            "  [dim]Żadne narzędzie MCP nie pasuje do listy powyżej "
+                            "(dopisz nazwy z serwera do tools.enabled).[/dim]"
+                        )
+                except Exception as exc:
+                    console.print(f"  [yellow]Połączenie MCP: {exc}[/yellow]")
+            ex = getattr(agent, "_executor", None) if agent is not None else None
+            reg = sorted(getattr(ex, "_tools", {}).keys()) if ex is not None else []
+            if reg:
+                console.print(
+                    "  [bold]Runtime (executor)[/bold]: " + ", ".join(reg)
+                )
+            console.print(
+                "\n[dim]Tip: aktualne fakty → web_search; zindeksowana wiedza → "
+                "memory_retrieve / jarvis memory index; MCP qdrant-find tylko "
+                "dla istniejących kolekcji.[/dim]"
             )
             continue
         elif cmd == "/help":
@@ -187,6 +436,7 @@ def chat(
                 "  /quit, /exit  — end session\n"
                 "  /clear        — clear conversation\n"
                 "  /model        — show model info\n"
+                "  /tools, /mcp  — tools + MCP from config\n"
                 "  /history      — show conversation\n"
                 "  /help         — this message"
             )
@@ -207,9 +457,38 @@ def chat(
         # Generate response
         try:
             if agent is not None:
-                response = agent.run(user_input)
+                from openjarvis.agents._stubs import AgentContext
+
+                # Prior turns only: _build_messages() appends this user_input again.
+                prior = list(history[:-1])
+                conv = Conversation(messages=prior) if prior else Conversation()
+                ctx = AgentContext(conversation=conv)
+                for mem_msg in memory_context_messages(user_input, config):
+                    ctx.conversation.add(mem_msg)
+                agent_input = user_input
+                agent_tools = getattr(agent, "_tools", None) or []
+                if tool_names_include_web(agent_tools):
+                    web_block = preflight_web_block(user_input)
+                    if web_block:
+                        console.print(
+                            "[dim]web_search (preflight) — wyniki wstrzyknięte do "
+                            "kontekstu; model ma odpowiadać tylko na ich podstawie.[/dim]",
+                        )
+                        agent_input = (
+                            f"{user_input}\n\n"
+                            "[Wyniki web_search — odpowiadaj WYŁĄCZNIE na tej "
+                            "podstawie; nie używaj wiedzy z treningu o bieżących "
+                            "wydarzeniach. Język odpowiedzi = język użytkownika.]\n\n"
+                            f"{web_block}"
+                        )
+                response = agent.run(agent_input, context=ctx)
                 content = (
                     response.content if hasattr(response, "content") else str(response)
+                )
+                _auto_learn_from_tool_results(
+                    config=config,
+                    tool_results=list(getattr(response, "tool_results", []) or []),
+                    status=_mcp_progress,
                 )
             else:
                 result = engine.generate(history, model=model)
@@ -229,4 +508,70 @@ def chat(
             console.print(f"\n[red]Error: {exc}[/red]\n")
 
 
-__all__ = ["chat"]
+@click.command()
+@click.option("-e", "--engine", "engine_key", default=None, help="Engine backend.")
+@click.option(
+    "-m",
+    "--model",
+    "model_name",
+    default=None,
+    help=(
+        "Model id. Omit or use ``smart`` for preset: [intelligence] model_chat / "
+        "model_short / model_long / model_code, then default_model."
+    ),
+)
+@click.option(
+    "--pick-model",
+    "pick_model",
+    is_flag=True,
+    default=False,
+    help=(
+        "Show the model list before chat. Bare ``jarvis`` already does this on a TTY "
+        "unless JARVIS_SKIP_MODEL_PICK=1."
+    ),
+)
+@click.option("-a", "--agent", "agent_name", default=None, help="Agent type.")
+@click.option("--tools", default=None, help="Comma-separated tool names.")
+@click.option("--system", "system_prompt", default=None, help="Custom system prompt.")
+def chat(
+    engine_key: str | None,
+    model_name: str | None,
+    pick_model: bool,
+    agent_name: str | None,
+    tools: str | None,
+    system_prompt: str | None,
+) -> None:
+    """Start an interactive multi-turn chat session.
+
+    Model: omit ``-m`` to use ``[intelligence] model_chat`` if set, else
+    ``default_model``; ``-m smart`` is the same. Use ``--pick-model`` to open the
+    engine list first (bare ``jarvis`` does this on a TTY unless
+    ``JARVIS_SKIP_MODEL_PICK=1``).
+
+    Commands during chat:
+      /quit, /exit  — end session
+      /clear        — clear conversation history
+      /model        — show current model
+      /help         — show available commands
+      /history      — show conversation history
+      /tools, /mcp  — show tools + MCP from config (not from the model)
+
+    Tiered shortcuts (same REPL, different defaults): ``jarvis short``, ``jarvis long``,
+    ``jarvis code``.
+    """
+    run_chat_interactive(
+        engine_key,
+        model_name,
+        agent_name,
+        tools,
+        system_prompt,
+        default_agent_when_unset=None,
+        default_tools_when_unset=None,
+        extra_system_prompt=None,
+        session_title=None,
+        chat_variant="chat",
+        pick_model=pick_model,
+    )
+
+
+__all__ = ["chat", "run_chat_interactive"]

--- a/src/openjarvis/cli/modes_cmd.py
+++ b/src/openjarvis/cli/modes_cmd.py
@@ -1,0 +1,197 @@
+"""Tiered chat: ``short``, ``long`` (semantic hints), ``code`` (toolset)."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import click
+
+from openjarvis.cli.chat_cmd import run_chat_interactive
+
+# Mirrors ``code-assistant`` preset; MCP stays in config ``tools.enabled``.
+_CODE_DEFAULT_TOOLS = (
+    "code_interpreter,file_read,file_write,shell_exec,web_search,think,calculator"
+)
+
+# Long mode: retrieval from indexed memory + web for fresh facts.
+_LONG_DEFAULT_TOOLS = "web_search,memory_retrieve,think"
+
+_CODE_EXTRA_SYSTEM = (
+    "To inspect local files or list a directory without a confirmation prompt, use "
+    "file_read (it lists top-level names when the path is a directory). shell_exec "
+    "requires the user to approve each command; if they decline, that is not a "
+    "filesystem permission error on the path. "
+    "If qdrant-find is in your tools, use it only for collections the user already "
+    "indexed — not for ad-hoc chat chunking."
+)
+
+_LONG_EXTRA_SYSTEM = (
+    "Before answering about prior notes or project docs, call memory_retrieve. "
+    "For current or external facts, call web_search. "
+    "Index new corpora with ``jarvis memory index`` outside this session."
+)
+
+
+@click.command(
+    "short",
+    help=(
+        "Interactive chat — session-scoped memory (same engine as ``chat``; "
+        "default agent ``native_react`` when ``-a`` is omitted)."
+    ),
+)
+@click.option("-e", "--engine", "engine_key", default=None, help="Engine backend.")
+@click.option(
+    "-m",
+    "--model",
+    "model_name",
+    default=None,
+    help=(
+        "Model id. Omit or ``smart`` for [intelligence] model_short, "
+        "then default_model."
+    ),
+)
+@click.option(
+    "--pick-model",
+    "pick_model",
+    is_flag=True,
+    default=False,
+    help=(
+        "Show the model list before chat (bare ``jarvis`` does this on a TTY unless "
+        "JARVIS_SKIP_MODEL_PICK=1)."
+    ),
+)
+@click.option("-a", "--agent", "agent_name", default=None, help="Agent type.")
+@click.option("--tools", default=None, help="Comma-separated tool names.")
+@click.option("--system", "system_prompt", default=None, help="Custom system prompt.")
+def short(
+    engine_key: Optional[str],
+    model_name: Optional[str],
+    pick_model: bool,
+    agent_name: Optional[str],
+    tools: Optional[str],
+    system_prompt: Optional[str],
+) -> None:
+    run_chat_interactive(
+        engine_key,
+        model_name,
+        agent_name,
+        tools,
+        system_prompt,
+        default_agent_when_unset="native_react",
+        default_tools_when_unset=None,
+        extra_system_prompt=None,
+        session_title="OpenJarvis · short",
+        chat_variant="short",
+        pick_model=pick_model,
+    )
+
+
+@click.command(
+    "long",
+    help=(
+        "Interactive chat — indexed memory retrieval + web search (default "
+        "``orchestrator``; merges config ``tools.enabled`` and MCP)."
+    ),
+)
+@click.option("-e", "--engine", "engine_key", default=None, help="Engine backend.")
+@click.option(
+    "-m",
+    "--model",
+    "model_name",
+    default=None,
+    help=(
+        "Model id. Omit or ``smart`` for [intelligence] model_long, "
+        "then default_model."
+    ),
+)
+@click.option(
+    "--pick-model",
+    "pick_model",
+    is_flag=True,
+    default=False,
+    help=(
+        "Show the model list before chat (bare ``jarvis`` does this on a TTY unless "
+        "JARVIS_SKIP_MODEL_PICK=1)."
+    ),
+)
+@click.option("-a", "--agent", "agent_name", default=None, help="Agent type.")
+@click.option("--tools", default=None, help="Comma-separated tool names.")
+@click.option("--system", "system_prompt", default=None, help="Custom system prompt.")
+def long(
+    engine_key: Optional[str],
+    model_name: Optional[str],
+    pick_model: bool,
+    agent_name: Optional[str],
+    tools: Optional[str],
+    system_prompt: Optional[str],
+) -> None:
+    run_chat_interactive(
+        engine_key,
+        model_name,
+        agent_name,
+        tools,
+        system_prompt,
+        default_agent_when_unset="orchestrator",
+        default_tools_when_unset=_LONG_DEFAULT_TOOLS,
+        extra_system_prompt=_LONG_EXTRA_SYSTEM,
+        session_title="OpenJarvis · long",
+        chat_variant="long",
+        pick_model=pick_model,
+    )
+
+
+@click.command(
+    "code",
+    help=(
+        "Interactive chat — code-oriented default tools (code-assistant strip); "
+        "override with ``--tools``. Default agent ``orchestrator``."
+    ),
+)
+@click.option("-e", "--engine", "engine_key", default=None, help="Engine backend.")
+@click.option(
+    "-m",
+    "--model",
+    "model_name",
+    default=None,
+    help=(
+        "Model id. Omit or ``smart`` for [intelligence] model_code, "
+        "then default_model."
+    ),
+)
+@click.option(
+    "--pick-model",
+    "pick_model",
+    is_flag=True,
+    default=False,
+    help=(
+        "Show the model list before chat (bare ``jarvis`` does this on a TTY unless "
+        "JARVIS_SKIP_MODEL_PICK=1)."
+    ),
+)
+@click.option("-a", "--agent", "agent_name", default=None, help="Agent type.")
+@click.option("--tools", default=None, help="Comma-separated tool names.")
+@click.option("--system", "system_prompt", default=None, help="Custom system prompt.")
+def code(
+    engine_key: Optional[str],
+    model_name: Optional[str],
+    pick_model: bool,
+    agent_name: Optional[str],
+    tools: Optional[str],
+    system_prompt: Optional[str],
+) -> None:
+    run_chat_interactive(
+        engine_key,
+        model_name,
+        agent_name,
+        tools,
+        system_prompt,
+        default_agent_when_unset="orchestrator",
+        default_tools_when_unset=_CODE_DEFAULT_TOOLS,
+        extra_system_prompt=_CODE_EXTRA_SYSTEM,
+        session_title="OpenJarvis · code",
+        chat_variant="code",
+        pick_model=pick_model,
+    )
+
+
+__all__ = ["short", "long", "code"]

--- a/src/openjarvis/core/config.py
+++ b/src/openjarvis/core/config.py
@@ -537,6 +537,11 @@ class IntelligenceConfig:
     """The model — identity, paths, quantization, and generation defaults."""
 
     default_model: str = ""
+    # Optional per-CLI preset (used when ``-m`` omitted or ``-m smart``).
+    model_chat: str = ""
+    model_short: str = ""
+    model_long: str = ""
+    model_code: str = ""
     fallback_model: str = ""
     model_path: str = ""  # Local weights (HF repo, GGUF file, etc.)
     checkpoint_path: str = ""  # Checkpoint/adapter path
@@ -809,7 +814,24 @@ class ToolsConfig:
     storage: StorageConfig = field(default_factory=StorageConfig)
     mcp: MCPConfig = field(default_factory=MCPConfig)
     browser: BrowserConfig = field(default_factory=BrowserConfig)
+    # Local SearXNG base URL (no trailing slash), e.g. http://127.0.0.1:8085
+    searxng_url: str = ""
+    # SearXNG ``language`` query param (e.g. pl, en). Empty = omit (instance default).
+    searxng_language: str = ""
+    # Comma-separated absolute paths; restricts file_read / file_write to these
+    # trees (empty = no extra restriction beyond sensitive-file rules).
+    file_allowed_directories: str = ""
     enabled: str = ""  # comma-separated default tools
+    # Auto-persist useful tool outputs to Qdrant via learn_qdrant (off by default).
+    auto_learn_qdrant: bool = False
+    # Ensure web_search is available in interactive chat (jarvis / chat / tiers).
+    require_web_search: bool = True
+    auto_learn_sources: str = (
+        "web_search,file_read,get_file_contents,search_code,search_repositories"
+    )
+    auto_learn_min_chars: int = 160
+    auto_learn_max_chars: int = 8000
+    auto_learn_min_chunk_size: int = 20
 
 
 @dataclass

--- a/src/openjarvis/learning/intelligence/orchestrator/prompt_registry.py
+++ b/src/openjarvis/learning/intelligence/orchestrator/prompt_registry.py
@@ -121,10 +121,13 @@ TOOL_DESCRIPTIONS: Dict[str, dict] = {
         "category": "utility",
         "description": (
             "WEB_SEARCH - Real-time internet search\n"
-            "  - BEST FOR: Current events, fact-checking, recent info\n"
-            "  - STRENGTHS: Access to up-to-date information\n"
-            "  - USE WHEN: Question about recent events or needs verification\n"
-            "  - COST: ~$0.001 per search\n"
+            "  - BEST FOR: Current events, news, verification\n"
+            "  - YOU MUST call this tool with a real query before citing news\n"
+            "  - After Observation: only summarize titles/snippets shown; "
+            "never invent headlines\n"
+            "  - For one portal use site:domain (e.g. site:example.com) or pass "
+            "a https URL as the query to fetch page text\n"
+            "  - STRENGTHS: Up-to-date snippets from SearXNG / Tavily / DDG\n"
             "  - Input: search query string"
         ),
         "examples": [
@@ -132,6 +135,11 @@ TOOL_DESCRIPTIONS: Dict[str, dict] = {
                 "task": "Who won the 2024 Nobel Prize in Physics?",
                 "thought": "Recent events - need web_search for current info.",
                 "input": "2024 Nobel Prize Physics winner",
+            },
+            {
+                "task": "What is example.com reporting today?",
+                "thought": "Need scoped search then summarize only returned lines.",
+                "input": "site:example.com news",
             },
         ],
     },

--- a/src/openjarvis/mcp/server.py
+++ b/src/openjarvis/mcp/server.py
@@ -23,6 +23,7 @@ _TOOL_ANNOTATIONS: Dict[str, Dict[str, Any]] = {
     "memory_retrieve": {"readOnlyHint": True, "destructiveHint": False},
     "memory_search": {"readOnlyHint": True, "destructiveHint": False},
     "memory_index": {"destructiveHint": True, "readOnlyHint": False},
+    "learn_qdrant": {"destructiveHint": True, "readOnlyHint": False},
     "calculator": {"readOnlyHint": True, "destructiveHint": False},
     "think": {"readOnlyHint": True, "destructiveHint": False},
     "retrieval": {"readOnlyHint": True, "destructiveHint": False},
@@ -107,6 +108,7 @@ class MCPServer:
 
         # Storage MCP tools
         try:
+            from openjarvis.tools.learn_qdrant import LearnQdrantTool
             from openjarvis.tools.storage_tools import (
                 MemoryIndexTool,
                 MemoryRetrieveTool,
@@ -120,6 +122,7 @@ class MCPServer:
                     MemoryRetrieveTool,
                     MemorySearchTool,
                     MemoryIndexTool,
+                    LearnQdrantTool,
                 ]
             )
         except ImportError:

--- a/src/openjarvis/mcp/transport.py
+++ b/src/openjarvis/mcp/transport.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import subprocess
+import select
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional
 
 from openjarvis.mcp.protocol import MCPRequest, MCPResponse
 
@@ -58,41 +59,159 @@ class StdioTransport(MCPTransport):
     stdin/stdout.
     """
 
-    def __init__(self, command: List[str]) -> None:
+    def __init__(
+        self,
+        command: List[str],
+        *,
+        env: Optional[Dict[str, str]] = None,
+        response_timeout: float = 30.0,
+        message_framing: Literal["auto", "jsonl", "content-length"] = "auto",
+    ) -> None:
         self._command = command
+        self._extra_env = dict(env) if env else {}
+        self._response_timeout = max(0.1, float(response_timeout))
+        self._message_framing = self._resolve_message_framing(message_framing)
         self._process: Optional[subprocess.Popen[str]] = None
         self._start()
 
+    def _resolve_message_framing(
+        self,
+        requested: Literal["auto", "jsonl", "content-length"],
+    ) -> Literal["jsonl", "content-length"]:
+        """Resolve stdio framing mode.
+
+        ``auto`` defaults to JSONL for compatibility with common MCP stdio
+        servers. Content-Length framing can be selected explicitly via
+        ``message_framing='content-length'`` for servers that require it.
+        """
+        if requested in ("jsonl", "content-length"):
+            return requested
+
+        return "jsonl"
+
     def _start(self) -> None:
         """Start the subprocess."""
+        import os
+
+        proc_env = os.environ.copy()
+        for key, value in self._extra_env.items():
+            proc_env[key] = str(value)
         self._process = subprocess.Popen(
             self._command,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
+            env=proc_env,
         )
 
     def send(self, request: MCPRequest) -> MCPResponse:
-        """Write request as JSON line, read response line."""
+        """Write request and read response.
+
+        Some stdio MCP servers (notably Node/npm ones) can drop the very first
+        request while still booting. For ``initialize``, we retry once on
+        timeout if the process is still alive.
+        """
         proc = self._process
         if proc is None or proc.stdin is None or proc.stdout is None:
             raise RuntimeError("Transport process is not running")
 
-        line = request.to_json() + "\n"
-        proc.stdin.write(line)
-        proc.stdin.flush()
+        max_attempts = 2 if request.method == "initialize" else 1
+        last_timeout: RuntimeError | None = None
 
-        response_line = proc.stdout.readline()
-        if not response_line:
-            raise RuntimeError("No response from subprocess")
-        return MCPResponse.from_json(response_line.strip())
+        for attempt in range(1, max_attempts + 1):
+            payload = request.to_json()
+            if self._message_framing == "content-length":
+                msg = (
+                    f"Content-Length: {len(payload.encode('utf-8'))}\r\n\r\n{payload}"
+                )
+            else:
+                msg = payload + "\n"
+            proc.stdin.write(msg)
+            proc.stdin.flush()
+            try:
+                ready, _, _ = select.select([proc.stdout], [], [], self._response_timeout)
+            except Exception as exc:
+                last_timeout = RuntimeError(
+                    "Timeout waiting for MCP stdio response from "
+                    f"{self._command!r} after {self._response_timeout:.1f}s"
+                )
+                if attempt < max_attempts and proc.poll() is None:
+                    continue
+                raise last_timeout from exc
+            if not ready:
+                last_timeout = RuntimeError(
+                    "Timeout waiting for MCP stdio response from "
+                    f"{self._command!r} after {self._response_timeout:.1f}s"
+                )
+                if attempt < max_attempts and proc.poll() is None:
+                    continue
+                raise last_timeout
+
+            response_line = proc.stdout.readline()
+            if not response_line:
+                if proc.poll() is not None:
+                    stderr_note = ""
+                    if proc.stderr is not None:
+                        try:
+                            stderr_text = (proc.stderr.read() or "").strip()
+                        except Exception:
+                            stderr_text = ""
+                        if stderr_text:
+                            stderr_note = f" stderr: {stderr_text[:400]}"
+                    raise RuntimeError(
+                        "No response from subprocess; process exited "
+                        f"with code {proc.returncode}.{stderr_note}"
+                    )
+                raise RuntimeError("No response from subprocess")
+
+            stripped = response_line.strip()
+            if stripped.lower().startswith("content-length:"):
+                try:
+                    content_length = int(stripped.split(":", 1)[1].strip())
+                except (IndexError, ValueError) as exc:
+                    raise RuntimeError(
+                        f"Invalid Content-Length header from subprocess: {stripped!r}"
+                    ) from exc
+
+                # Consume remaining headers until blank line.
+                while True:
+                    header_line = proc.stdout.readline()
+                    if not header_line or header_line in ("\n", "\r\n"):
+                        break
+                body = proc.stdout.read(content_length)
+                if not body:
+                    raise RuntimeError("No response body after Content-Length header")
+                return MCPResponse.from_json(body.strip())
+
+            return MCPResponse.from_json(stripped)
+
+        if last_timeout is not None:
+            raise last_timeout
+        raise RuntimeError("MCP stdio request failed without response")
+
+    def send_notification(self, request: MCPRequest) -> None:
+        """Send JSON-RPC notification over stdio without waiting for response."""
+        proc = self._process
+        if proc is None or proc.stdin is None:
+            raise RuntimeError("Transport process is not running")
+        payload = request.to_json()
+        if self._message_framing == "content-length":
+            msg = f"Content-Length: {len(payload.encode('utf-8'))}\r\n\r\n{payload}"
+        else:
+            msg = payload + "\n"
+        proc.stdin.write(msg)
+        proc.stdin.flush()
 
     def close(self) -> None:
         """Terminate the subprocess."""
         if self._process is not None:
             self._process.terminate()
-            self._process.wait(timeout=5)
+            try:
+                self._process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self._process.kill()
+                self._process.wait(timeout=5)
             self._process = None
 
 

--- a/src/openjarvis/security/capabilities.py
+++ b/src/openjarvis/security/capabilities.py
@@ -176,6 +176,7 @@ DEFAULT_TOOL_CAPABILITIES: Dict[str, List[str]] = {
     "memory_retrieve": [Capability.MEMORY_READ],
     "memory_search": [Capability.MEMORY_READ],
     "memory_index": [Capability.MEMORY_WRITE],
+    "learn_qdrant": [Capability.MEMORY_WRITE],
     "schedule_task": [Capability.SCHEDULE_CREATE],
     "channel_send": [Capability.CHANNEL_SEND],
 }

--- a/src/openjarvis/server/agent_manager_routes.py
+++ b/src/openjarvis/server/agent_manager_routes.py
@@ -515,7 +515,15 @@ def _get_mcp_tools(app_state: Any) -> Tuple[List[Dict[str, Any]], Dict[str, Any]
             if url:
                 transport = StreamableHTTPTransport(url=url)
             elif command:
-                transport = StdioTransport(command=[command] + args)
+                extra_env = cfg.get("env") or {}
+                if isinstance(extra_env, dict):
+                    env_map = {str(k): str(v) for k, v in extra_env.items()}
+                else:
+                    env_map = {}
+                transport = StdioTransport(
+                    command=[command] + args,
+                    env=env_map or None,
+                )
             else:
                 logger.warning(
                     "MCP server '%s' has neither 'url' nor 'command' — skipping",

--- a/src/openjarvis/system/builder.py
+++ b/src/openjarvis/system/builder.py
@@ -590,7 +590,15 @@ class SystemBuilder:
         if url:
             transport = StreamableHTTPTransport(url=url)
         elif command:
-            transport = StdioTransport(command=[command] + args)
+            extra_env = cfg.get("env") or {}
+            if isinstance(extra_env, dict):
+                env_map = {str(k): str(v) for k, v in extra_env.items()}
+            else:
+                env_map = {}
+            transport = StdioTransport(
+                command=[command] + args,
+                env=env_map or None,
+            )
         else:
             logger.warning(
                 "MCP server '%s' has neither 'url' nor 'command' — skipping",

--- a/src/openjarvis/tools/__init__.py
+++ b/src/openjarvis/tools/__init__.py
@@ -58,6 +58,11 @@ except ImportError:
     pass
 
 try:
+    import openjarvis.tools.learn_qdrant  # noqa: F401
+except ImportError:
+    pass
+
+try:
     import openjarvis.tools.mcp_adapter  # noqa: F401
 except ImportError:
     pass

--- a/src/openjarvis/tools/_stubs.py
+++ b/src/openjarvis/tools/_stubs.py
@@ -219,9 +219,16 @@ class ToolExecutor:
                 )
             prompt = f"Allow execution of tool '{tool_call.name}' with args {params}?"
             if not self._confirm_callback(prompt):
+                denied = (
+                    f"Tool '{tool_call.name}' was not run: the user declined the "
+                    "confirmation prompt. This is not a missing filesystem permission "
+                    "on the target path. Prefer read-only tools (e.g. file_read for "
+                    "files and directories), or ask the user to approve the command "
+                    "if a shell is truly required."
+                )
                 return ToolResult(
                     tool_name=tool_call.name,
-                    content=f"Tool '{tool_call.name}' execution denied by user.",
+                    content=denied,
                     success=False,
                 )
 

--- a/src/openjarvis/tools/file_read.py
+++ b/src/openjarvis/tools/file_read.py
@@ -11,6 +11,8 @@ from openjarvis.tools._stubs import BaseTool, ToolSpec
 
 # Maximum file size to read (1 MB)
 _MAX_SIZE_BYTES = 1_048_576
+# Cap directory listings so huge trees do not blow the context window
+_MAX_DIR_ENTRIES = 1000
 
 
 @ToolRegistry.register("file_read")
@@ -29,17 +31,22 @@ class FileReadTool(BaseTool):
     def spec(self) -> ToolSpec:
         return ToolSpec(
             name="file_read",
-            description=("Read the contents of a file. Returns the text content."),
+            description=(
+                "Read a text file, or list top-level names if path is a directory "
+                "(non-recursive; no shell required)."
+            ),
             parameters={
                 "type": "object",
                 "properties": {
                     "path": {
                         "type": "string",
-                        "description": "Path to the file to read.",
+                        "description": "Path to a file or directory.",
                     },
                     "max_lines": {
                         "type": "integer",
-                        "description": ("Max lines to return (default: all)."),
+                        "description": (
+                            "Max lines to return for files (default: all)."
+                        ),
                     },
                 },
                 "required": ["path"],
@@ -54,6 +61,43 @@ class FileReadTool(BaseTool):
         resolved = path.resolve()
         return any(
             resolved == d or resolved.is_relative_to(d) for d in self._allowed_dirs
+        )
+
+    def _list_directory(self, path: Path, file_path: str) -> ToolResult:
+        """List immediate children of *path* (non-recursive)."""
+        from openjarvis.security.file_policy import is_sensitive_file
+
+        try:
+            children = sorted(path.iterdir(), key=lambda p: p.name.lower())
+        except OSError as exc:
+            return ToolResult(
+                tool_name="file_read",
+                content=f"Cannot list directory {file_path}: {exc}",
+                success=False,
+            )
+        visible = [c for c in children if not is_sensitive_file(c)]
+        truncated = visible[:_MAX_DIR_ENTRIES]
+        lines = [
+            f"{c.name}{'/' if c.is_dir() else ''}" for c in truncated
+        ]
+        extra = len(visible) - len(truncated)
+        header = (
+            f"Directory listing for {path.resolve()} "
+            f"({len(truncated)} of {len(visible)} entries shown"
+        )
+        if extra:
+            header += f"; {extra} more not shown (cap {_MAX_DIR_ENTRIES})"
+        header += "):\n"
+        body = "\n".join(lines) if lines else "(empty)"
+        return ToolResult(
+            tool_name="file_read",
+            content=header + body,
+            success=True,
+            metadata={
+                "path": str(path.resolve()),
+                "is_directory": True,
+                "entry_count": len(truncated),
+            },
         )
 
     def execute(self, **params: Any) -> ToolResult:
@@ -80,16 +124,18 @@ class FileReadTool(BaseTool):
                 content=f"File not found: {file_path}",
                 success=False,
             )
-        if not path.is_file():
-            return ToolResult(
-                tool_name="file_read",
-                content=f"Not a file: {file_path}",
-                success=False,
-            )
         if not self._is_path_allowed(path):
             return ToolResult(
                 tool_name="file_read",
                 content=f"Access denied: {file_path} is outside allowed directories.",
+                success=False,
+            )
+        if path.is_dir():
+            return self._list_directory(path, file_path)
+        if not path.is_file():
+            return ToolResult(
+                tool_name="file_read",
+                content=f"Not a readable file: {file_path}",
                 success=False,
             )
         # Check size

--- a/src/openjarvis/tools/learn_qdrant.py
+++ b/src/openjarvis/tools/learn_qdrant.py
@@ -1,0 +1,202 @@
+"""Persist chunked text into Qdrant via the MCP ``qdrant-store`` tool."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, List
+
+from openjarvis.core.registry import ToolRegistry
+from openjarvis.core.types import ToolResult
+from openjarvis.tools._stubs import BaseTool, ToolSpec
+from openjarvis.tools.storage.chunking import ChunkConfig, chunk_text
+
+logger = logging.getLogger(__name__)
+
+# Avoid runaway writes when the model passes huge blobs
+_MAX_CHUNKS_PER_CALL = 200
+
+
+def _discover_qdrant_store_adapters() -> List[Any]:
+    """Return MCP adapters named ``qdrant-store`` from configured servers."""
+    from openjarvis.cli._external_mcp_tools import discover_external_mcp_tools
+    from openjarvis.core.config import load_config
+
+    cfg = load_config()
+    return discover_external_mcp_tools(
+        cfg,
+        allowed_tool_names={"qdrant-store"},
+    )
+
+
+@ToolRegistry.register("learn_qdrant")
+class LearnQdrantTool(BaseTool):
+    """Chunk arbitrary text and store each chunk through MCP ``qdrant-store``.
+
+    Use after high-value ``web_search`` results, ``file_read`` excerpts, or
+    GitHub MCP payloads so ``qdrant-find`` can retrieve them later.
+    """
+
+    tool_id = "learn_qdrant"
+
+    @property
+    def spec(self) -> ToolSpec:
+        return ToolSpec(
+            name="learn_qdrant",
+            description=(
+                "Split long text into chunks and store each in Qdrant via "
+                "qdrant-store (same collection as manual memory). Use after "
+                "useful web_search, file_read, or GitHub tool output so "
+                "qdrant-find can recall it later. Pass a clear ``source`` label "
+                "(e.g. URL or repo:path)."
+            ),
+            parameters={
+                "type": "object",
+                "properties": {
+                    "text": {
+                        "type": "string",
+                        "description": "Full text to chunk and store.",
+                    },
+                    "source": {
+                        "type": "string",
+                        "description": (
+                            "Provenance label: URL, file path, or "
+                            "github:owner/repo/path."
+                        ),
+                    },
+                    "origin": {
+                        "type": "string",
+                        "description": (
+                            "Optional short tag: web_search, github, file_read, "
+                            "user, etc."
+                        ),
+                    },
+                    "chunk_size": {
+                        "type": "integer",
+                        "description": (
+                            "Approximate chunk size in tokens (default 512)."
+                        ),
+                    },
+                    "chunk_overlap": {
+                        "type": "integer",
+                        "description": "Token overlap between chunks (default 64).",
+                    },
+                    "min_chunk_size": {
+                        "type": "integer",
+                        "description": (
+                            "Minimum tokens required to keep a chunk (default 20)."
+                        ),
+                    },
+                    "extra_metadata": {
+                        "type": "string",
+                        "description": (
+                            "Optional JSON object merged into each chunk's metadata."
+                        ),
+                    },
+                },
+                "required": ["text"],
+            },
+            category="storage",
+        )
+
+    def execute(self, **params: Any) -> ToolResult:
+        text = (params.get("text") or "").strip()
+        if not text:
+            return ToolResult(
+                tool_name="learn_qdrant",
+                content="No text provided.",
+                success=False,
+            )
+
+        adapters = _discover_qdrant_store_adapters()
+        if not adapters:
+            return ToolResult(
+                tool_name="learn_qdrant",
+                content=(
+                    "No MCP tool qdrant-store available. Enable [tools.mcp] with a "
+                    "Qdrant MCP server and include qdrant-store in tools.enabled."
+                ),
+                success=False,
+            )
+
+        store = adapters[0]
+        if len(adapters) > 1:
+            logger.debug(
+                "learn_qdrant: multiple qdrant-store adapters (%d), using first",
+                len(adapters),
+            )
+
+        extra: dict[str, Any] = {}
+        raw_extra = params.get("extra_metadata")
+        if isinstance(raw_extra, str) and raw_extra.strip():
+            try:
+                parsed = json.loads(raw_extra)
+                if isinstance(parsed, dict):
+                    extra = parsed
+            except json.JSONDecodeError as exc:
+                return ToolResult(
+                    tool_name="learn_qdrant",
+                    content=f"extra_metadata is not valid JSON: {exc}",
+                    success=False,
+                )
+
+        cfg = ChunkConfig(
+            chunk_size=int(params.get("chunk_size", 512)),
+            chunk_overlap=int(params.get("chunk_overlap", 64)),
+            min_chunk_size=int(params.get("min_chunk_size", 20)),
+        )
+        source = (params.get("source") or "").strip() or "learn_qdrant"
+        origin = (params.get("origin") or "").strip()
+
+        chunks = chunk_text(text, source=source, config=cfg)
+        if not chunks:
+            return ToolResult(
+                tool_name="learn_qdrant",
+                content="No chunks produced (empty or whitespace-only text).",
+                success=False,
+            )
+
+        truncated = False
+        if len(chunks) > _MAX_CHUNKS_PER_CALL:
+            chunks = chunks[:_MAX_CHUNKS_PER_CALL]
+            truncated = True
+
+        failures: list[str] = []
+        for ch in chunks:
+            meta: dict[str, Any] = {
+                "source": source,
+                "chunk_index": ch.index,
+                "learn_qdrant": True,
+                **extra,
+            }
+            if origin:
+                meta["origin"] = origin
+            result = store.execute(
+                information=ch.content,
+                metadata=meta,
+            )
+            if not result.success:
+                failures.append(result.content[:200])
+
+        if failures:
+            return ToolResult(
+                tool_name="learn_qdrant",
+                content=(
+                    f"Stored {len(chunks) - len(failures)}/{len(chunks)} chunks; "
+                    f"errors: {failures[:3]}"
+                ),
+                success=False,
+            )
+
+        msg = f"Stored {len(chunks)} chunk(s) in Qdrant (source={source!r})."
+        if truncated:
+            msg += f" Truncated to {_MAX_CHUNKS_PER_CALL} chunks."
+        return ToolResult(
+            tool_name="learn_qdrant",
+            content=msg,
+            success=True,
+            metadata={"chunks": len(chunks), "source": source},
+        )
+
+
+__all__ = ["LearnQdrantTool", "_discover_qdrant_store_adapters"]

--- a/src/openjarvis/tools/web_search.py
+++ b/src/openjarvis/tools/web_search.py
@@ -1,9 +1,10 @@
-"""Web search tool — Tavily API with DuckDuckGo fallback."""
+"""Web search tool — SearXNG (optional), Tavily API, DuckDuckGo fallback."""
 
 from __future__ import annotations
 
 import logging
 import os
+import urllib.parse
 from typing import Any
 
 from openjarvis.core.registry import ToolRegistry
@@ -12,6 +13,14 @@ from openjarvis.security.ssrf import check_ssrf
 from openjarvis.tools._stubs import BaseTool, ToolSpec
 
 logger = logging.getLogger(__name__)
+
+_GROUNDING_REMINDER = (
+    "\n\n---\nGrounding: Summarize only what appears in the snippets above. "
+    "Do not invent headlines, names, or events. If results are empty, vague, "
+    "or off-topic, say so. For a specific site, use a query like "
+    "``site:example.com keywords`` or pass the page ``https://...`` URL as the "
+    "query to fetch extracted text."
+)
 
 
 @ToolRegistry.register("web_search")
@@ -30,13 +39,24 @@ class WebSearchTool(BaseTool):
         return ToolSpec(
             name="web_search",
             description=(
-                "Search the web for current information."
-                " Returns relevant search results."
+                "Search the web (SearXNG, Tavily, or DuckDuckGo). "
+                "You MUST call this tool with a concrete ``query`` before "
+                "answering questions about current events — do not answer from "
+                "memory alone. "
+                "For one site use ``site:example.com keywords`` or paste a "
+                "full ``https://...`` URL as ``query`` to fetch page text. "
+                "In your reply, stick to titles and snippets returned here."
             ),
             parameters={
                 "type": "object",
                 "properties": {
-                    "query": {"type": "string", "description": "Search query."},
+                    "query": {
+                        "type": "string",
+                        "description": (
+                            "Search query or full https URL to fetch. "
+                            "Use site:domain for one portal."
+                        ),
+                    },
                     "max_results": {
                         "type": "integer",
                         "description": "Maximum results to return.",
@@ -45,7 +65,11 @@ class WebSearchTool(BaseTool):
                 "required": ["query"],
             },
             category="search",
-            metadata={"requires_api_key": "TAVILY_API_KEY", "fallback": "duckduckgo"},
+            metadata={
+                "requires_api_key": "TAVILY_API_KEY",
+                "optional": "SEARXNG_URL or [tools] searxng_url",
+                "fallback": "duckduckgo",
+            },
         )
 
     @staticmethod
@@ -128,6 +152,73 @@ class WebSearchTool(BaseTool):
         )
         return formatted
 
+    def _searxng_base_url(self) -> str:
+        """Resolve SearXNG base URL: env overrides ``[tools].searxng_url``."""
+        for key in ("SEARXNG_URL", "OPENJARVIS_SEARXNG_URL"):
+            v = (os.environ.get(key) or "").strip()
+            if v:
+                return v.rstrip("/")
+        try:
+            from openjarvis.core.config import load_config
+
+            u = (load_config().tools.searxng_url or "").strip()
+            return u.rstrip("/")
+        except Exception:
+            return ""
+
+    def _searxng_language(self) -> str:
+        """BCP 47 language for SearXNG (e.g. pl, en). Env overrides config."""
+        for key in ("SEARXNG_LANGUAGE", "OPENJARVIS_SEARXNG_LANGUAGE"):
+            v = (os.environ.get(key) or "").strip()
+            if v:
+                return v
+        try:
+            from openjarvis.core.config import load_config
+
+            return (load_config().tools.searxng_language or "").strip()
+        except Exception:
+            return ""
+
+    @staticmethod
+    def _with_grounding(body: str) -> str:
+        """Append anti-hallucination hint for the model (observation text)."""
+        text = (body or "").strip()
+        if not text:
+            return body
+        return text + _GROUNDING_REMINDER
+
+    def _searxng_search(self, base_url: str, query: str, max_results: int) -> str:
+        """Query a SearXNG instance (``GET /search?format=json``)."""
+        import httpx
+
+        qparams: dict[str, str] = {
+            "q": query,
+            "format": "json",
+            "categories": "general",
+        }
+        lang = self._searxng_language()
+        if lang:
+            qparams["language"] = lang
+        params = urllib.parse.urlencode(qparams)
+        url = f"{base_url.rstrip('/')}/search?{params}"
+        resp = httpx.get(
+            url,
+            follow_redirects=True,
+            timeout=30.0,
+            headers={
+                "User-Agent": "Mozilla/5.0 (compatible; OpenJarvis/1.0; +https://github.com/open-jarvis)"
+            },
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        results = list(data.get("results") or [])[:max_results]
+        formatted = "\n\n".join(
+            f"**{r.get('title', 'Untitled')}**\n"
+            f"{r.get('url', '')}\n{r.get('content', '')}"
+            for r in results
+        )
+        return formatted
+
     def execute(self, **params: Any) -> ToolResult:
         query = params.get("query", "")
         if not query:
@@ -144,7 +235,7 @@ class WebSearchTool(BaseTool):
                 content = self._fetch_url(url)
                 return ToolResult(
                     tool_name="web_search",
-                    content=content or "No content found at URL.",
+                    content=self._with_grounding(content or "No content found at URL."),
                     success=True,
                     metadata={"url": url, "mode": "fetch"},
                 )
@@ -156,6 +247,21 @@ class WebSearchTool(BaseTool):
                 )
 
         max_results = params.get("max_results", self._max_results)
+
+        searx_base = self._searxng_base_url()
+        if searx_base:
+            try:
+                formatted = self._searxng_search(searx_base, query, max_results)
+                return ToolResult(
+                    tool_name="web_search",
+                    content=self._with_grounding(
+                        formatted or "No results found.",
+                    ),
+                    success=True,
+                    metadata={"engine": "searxng", "base_url": searx_base},
+                )
+            except Exception as exc:
+                logger.debug("SearXNG error (%s), falling back", type(exc).__name__)
 
         try:
             from tavily import TavilyClient
@@ -170,7 +276,7 @@ class WebSearchTool(BaseTool):
             )
             return ToolResult(
                 tool_name="web_search",
-                content=formatted or "No results found.",
+                content=self._with_grounding(formatted or "No results found."),
                 success=True,
                 metadata={"num_results": len(results), "engine": "tavily"},
             )
@@ -183,7 +289,7 @@ class WebSearchTool(BaseTool):
             formatted = self._duckduckgo_search(query, max_results)
             return ToolResult(
                 tool_name="web_search",
-                content=formatted or "No results found.",
+                content=self._with_grounding(formatted or "No results found."),
                 success=True,
                 metadata={"engine": "duckduckgo"},
             )

--- a/tests/agents/test_grounding.py
+++ b/tests/agents/test_grounding.py
@@ -1,0 +1,19 @@
+"""Tests for web grounding heuristics."""
+
+from __future__ import annotations
+
+from openjarvis.agents.grounding import query_needs_web_search
+
+
+def test_news_queries_need_web() -> None:
+    assert query_needs_web_search("znajdź mi wiadomości ze świata")
+    assert query_needs_web_search("latest world news please")
+    assert query_needs_web_search("za pomocą web-search znajdź wiadomości")
+
+
+def test_meta_questions_skip_web() -> None:
+    assert not query_needs_web_search("czy używasz web-search?")
+
+
+def test_plain_chat_skips_web() -> None:
+    assert not query_needs_web_search("napisz funkcję sortowania w Pythonie")

--- a/tests/agents/test_native_react_web_grounding.py
+++ b/tests/agents/test_native_react_web_grounding.py
@@ -1,0 +1,61 @@
+"""native_react must not finalize without web_search on news queries."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from openjarvis.agents.native_react import NativeReActAgent
+from openjarvis.core.types import ToolResult
+from openjarvis.tools._stubs import BaseTool, ToolSpec
+
+
+class _WebStub(BaseTool):
+    tool_id = "web_search"
+    calls = 0
+
+    @property
+    def spec(self) -> ToolSpec:
+        return ToolSpec(
+            name="web_search",
+            description="search",
+            parameters={
+                "type": "object",
+                "properties": {"query": {"type": "string"}},
+                "required": ["query"],
+            },
+        )
+
+    def execute(self, **params) -> ToolResult:
+        _WebStub.calls += 1
+        return ToolResult(
+            tool_name="web_search",
+            content="**Headline** — snippet text",
+            success=True,
+        )
+
+
+def test_plain_answer_rejected_until_web_search() -> None:
+    _WebStub.calls = 0
+    engine = MagicMock()
+    engine.generate.side_effect = [
+        {
+            "content": "Here are world news: BBC said something.",
+            "usage": {},
+        },
+        {
+            "content": (
+                "Thought: search\n"
+                'Action: web_search\n'
+                'Action Input: {"query": "world news"}'
+            ),
+            "usage": {},
+        },
+        {
+            "content": "Thought: done\nFinal Answer: From search: Headline snippet.",
+            "usage": {},
+        },
+    ]
+    agent = NativeReActAgent(engine, "m", tools=[_WebStub()], max_turns=5)
+    result = agent.run("znajdź wiadomości ze świata")
+    assert _WebStub.calls >= 1
+    assert "Headline" in result.content or "snippet" in result.content.lower()

--- a/tests/cli/test_chat_cmd.py
+++ b/tests/cli/test_chat_cmd.py
@@ -13,7 +13,7 @@ from openjarvis.agents._stubs import (
     BaseAgent,
     ToolUsingAgent,
 )
-from openjarvis.cli.chat_cmd import _read_input, chat
+from openjarvis.cli.chat_cmd import _auto_learn_from_tool_results, _read_input, chat
 from openjarvis.core.config import JarvisConfig
 from openjarvis.core.registry import AgentRegistry, ToolRegistry
 from openjarvis.core.types import ToolCall, ToolResult
@@ -69,6 +69,7 @@ class TestChatCommand:
         assert result.exit_code == 0
         assert "--engine" in result.output
         assert "--model" in result.output
+        assert "--pick-model" in result.output
         assert "--agent" in result.output
         assert "--tools" in result.output
         assert "--system" in result.output
@@ -145,3 +146,76 @@ class TestChatAgents:
         assert result.exit_code == 0
         assert "Confirm:" in result.output
         assert "chat executed!" in result.output
+
+
+class TestAutoLearn:
+    def test_auto_learn_default_disabled_in_config(self) -> None:
+        assert JarvisConfig().tools.auto_learn_qdrant is False
+
+    def test_auto_learn_stores_allowed_successful_results(self) -> None:
+        config = JarvisConfig()
+        config.tools.auto_learn_qdrant = True
+        config.tools.auto_learn_sources = "web_search,file_read"
+        config.tools.auto_learn_min_chars = 10
+        config.tools.auto_learn_max_chars = 200
+        config.tools.auto_learn_min_chunk_size = 5
+
+        calls: list[dict] = []
+
+        class _FakeLearner:
+            def execute(self, **kwargs):
+                calls.append(kwargs)
+                return ToolResult(
+                    tool_name="learn_qdrant",
+                    content="ok",
+                    success=True,
+                )
+
+        with patch("openjarvis.tools.learn_qdrant.LearnQdrantTool", _FakeLearner):
+            _auto_learn_from_tool_results(
+                config=config,
+                tool_results=[
+                    ToolResult(
+                        tool_name="web_search",
+                        content="x" * 80,
+                        success=True,
+                    ),
+                    ToolResult(
+                        tool_name="search_code",
+                        content="x" * 80,
+                        success=True,
+                    ),
+                    ToolResult(
+                        tool_name="file_read",
+                        content="too short",
+                        success=True,
+                    ),
+                    ToolResult(
+                        tool_name="web_search",
+                        content="x" * 50,
+                        success=False,
+                    ),
+                ],
+            )
+
+        assert len(calls) == 1
+        assert calls[0]["origin"] == "web_search"
+        assert calls[0]["source"] == "auto:web_search"
+        assert calls[0]["min_chunk_size"] == 5
+
+    def test_auto_learn_can_be_disabled(self) -> None:
+        config = JarvisConfig()
+        config.tools.auto_learn_qdrant = False
+
+        with patch("openjarvis.tools.learn_qdrant.LearnQdrantTool") as mocked:
+            _auto_learn_from_tool_results(
+                config=config,
+                tool_results=[
+                    ToolResult(
+                        tool_name="web_search",
+                        content="x" * 100,
+                        success=True,
+                    )
+                ],
+            )
+        mocked.assert_not_called()

--- a/tests/cli/test_chat_context.py
+++ b/tests/cli/test_chat_context.py
@@ -1,0 +1,69 @@
+"""Tests for chat grounding / tool defaults."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from openjarvis.cli._chat_context import (
+    ensure_chat_tool_names,
+    memory_context_messages,
+    preflight_web_block,
+)
+from openjarvis.core.config import JarvisConfig
+from openjarvis.core.types import Message, Role
+
+
+def test_ensure_chat_tool_names_adds_web_search() -> None:
+    out = ensure_chat_tool_names(["think"], require_web_search=True)
+    assert "web_search" in out
+    assert "think" in out
+
+
+def test_ensure_chat_tool_names_adds_memory_retrieve() -> None:
+    out = ensure_chat_tool_names(
+        ["web_search"],
+        require_web_search=False,
+        require_memory_retrieve=True,
+    )
+    assert out == ["web_search", "memory_retrieve"]
+
+
+def test_ensure_chat_tool_names_idempotent() -> None:
+    out = ensure_chat_tool_names(
+        ["web_search", "memory_retrieve"],
+        require_web_search=True,
+        require_memory_retrieve=True,
+    )
+    assert out.count("web_search") == 1
+    assert out.count("memory_retrieve") == 1
+
+
+def test_memory_context_messages_disabled() -> None:
+    cfg = JarvisConfig()
+    cfg.agent.context_from_memory = False
+    assert memory_context_messages("query", cfg) == []
+
+
+def test_memory_context_messages_injects() -> None:
+    cfg = JarvisConfig()
+    cfg.agent.context_from_memory = True
+    ctx_msg = Message(role=Role.SYSTEM, content="retrieved block")
+    with patch("openjarvis.cli.ask._get_memory_backend") as get_b:
+        get_b.return_value = MagicMock()
+        with patch(
+            "openjarvis.tools.storage.context.inject_context",
+            return_value=[ctx_msg],
+        ):
+            msgs = memory_context_messages("hello", cfg)
+    assert len(msgs) == 1
+    assert "retrieved" in msgs[0].content
+
+
+def test_preflight_web_block_skips_meta() -> None:
+    assert preflight_web_block("czy używasz web-search?") is None
+
+
+def test_tools_config_auto_learn_default_off() -> None:
+    cfg = JarvisConfig()
+    assert cfg.tools.auto_learn_qdrant is False
+    assert cfg.tools.require_web_search is True

--- a/tests/cli/test_model_switch.py
+++ b/tests/cli/test_model_switch.py
@@ -1,0 +1,86 @@
+"""Tests for CLI model preset / smart resolution."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from openjarvis.cli._model_switch import (
+    resolve_chat_cli_model,
+    variant_preset_model,
+)
+from openjarvis.core.config import JarvisConfig
+
+
+def test_variant_preset_long() -> None:
+    cfg = JarvisConfig()
+    cfg.intelligence.model_long = "devstral:q4"
+    assert variant_preset_model(cfg, "long") == "devstral:q4"
+    assert variant_preset_model(cfg, "chat") == ""
+
+
+def test_resolve_explicit_model() -> None:
+    cfg = JarvisConfig()
+    cfg.intelligence.default_model = "fallback"
+    cfg.intelligence.model_long = "preset-long"
+    eng = MagicMock()
+    eng.list_models.return_value = ["a"]
+    m = resolve_chat_cli_model(
+        console=MagicMock(),
+        config=cfg,
+        engine=eng,
+        engine_name="ollama",
+        cli_model="explicit-only",
+        chat_variant="long",
+    )
+    assert m == "explicit-only"
+
+
+def test_resolve_smart_uses_preset() -> None:
+    cfg = JarvisConfig()
+    cfg.intelligence.default_model = "fallback"
+    cfg.intelligence.model_code = "coder-model"
+    eng = MagicMock()
+    eng.list_models.return_value = ["a"]
+    m = resolve_chat_cli_model(
+        console=MagicMock(),
+        config=cfg,
+        engine=eng,
+        engine_name="ollama",
+        cli_model="smart",
+        chat_variant="code",
+    )
+    assert m == "coder-model"
+
+
+def test_resolve_omitted_uses_preset_then_default() -> None:
+    cfg = JarvisConfig()
+    cfg.intelligence.default_model = "defm"
+    cfg.intelligence.model_short = ""
+    eng = MagicMock()
+    eng.list_models.return_value = ["x"]
+    m = resolve_chat_cli_model(
+        console=MagicMock(),
+        config=cfg,
+        engine=eng,
+        engine_name="ollama",
+        cli_model=None,
+        chat_variant="short",
+    )
+    assert m == "defm"
+
+
+def test_resolve_smart_falls_back_to_default() -> None:
+    cfg = JarvisConfig()
+    cfg.intelligence.default_model = "defm"
+    cfg.intelligence.model_code = ""
+    eng = MagicMock()
+    eng.list_models.return_value = ["x"]
+    m = resolve_chat_cli_model(
+        console=MagicMock(),
+        config=cfg,
+        engine=eng,
+        engine_name="ollama",
+        cli_model="smart",
+        chat_variant="code",
+    )
+    assert m == "defm"

--- a/tests/mcp/test_discovery.py
+++ b/tests/mcp/test_discovery.py
@@ -74,7 +74,8 @@ class TestDiscoverStdioServer:
         result = builder._discover_external_mcp(cfg)
 
         mock_transport_cls.assert_called_once_with(
-            command=["node", "server.js", "--stdio"]
+            command=["node", "server.js", "--stdio"],
+            env=None,
         )
         assert len(result) == 1
         assert result[0].spec.name == "read_file"

--- a/tests/mcp/test_transport.py
+++ b/tests/mcp/test_transport.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from openjarvis.mcp.protocol import MCPRequest
+from openjarvis.mcp.client import MCPClient
 from openjarvis.mcp.server import MCPServer
 from openjarvis.mcp.transport import (
     InProcessTransport,
@@ -159,6 +160,153 @@ class TestStdioTransport:
         transport = StdioTransport([sys.executable, str(script)])
         transport.close()
         transport.close()  # Should not raise
+
+    def test_send_times_out_when_subprocess_is_silent(self, tmp_path):
+        script = tmp_path / "silent_server.py"
+        script.write_text(
+            textwrap.dedent("""\
+            import time
+            while True:
+                time.sleep(1)
+        """)
+        )
+
+        transport = StdioTransport(
+            [sys.executable, str(script)],
+            response_timeout=0.2,
+        )
+        try:
+            req = MCPRequest(method="test/timeout", id=99)
+            with pytest.raises(RuntimeError, match="Timeout waiting for MCP stdio"):
+                transport.send(req)
+        finally:
+            transport.close()
+
+    def test_content_length_framing_when_explicitly_requested(self, tmp_path):
+        script = tmp_path / "content_length_server.py"
+        script.write_text(
+            textwrap.dedent("""\
+            import json
+            import sys
+
+            def read_headers(stdin):
+                headers = {}
+                while True:
+                    line = stdin.readline()
+                    if not line or line in ("\\n", "\\r\\n"):
+                        break
+                    if ":" not in line:
+                        continue
+                    k, v = line.split(":", 1)
+                    headers[k.strip().lower()] = v.strip()
+                return headers
+
+            while True:
+                headers = read_headers(sys.stdin)
+                if not headers:
+                    break
+                length = int(headers.get("content-length", "0"))
+                if length <= 0:
+                    continue
+                body = sys.stdin.read(length)
+                req = json.loads(body)
+                resp = {
+                    "jsonrpc": "2.0",
+                    "id": req.get("id", 0),
+                    "result": {"ok": True, "method": req.get("method", "")},
+                }
+                sys.stdout.write(json.dumps(resp) + "\\n")
+                sys.stdout.flush()
+        """)
+        )
+
+        transport = StdioTransport(
+            [sys.executable, str(script)],
+            message_framing="content-length",
+        )
+        try:
+            req = MCPRequest(method="initialize", id=5)
+            resp = transport.send(req)
+            assert resp.error is None
+            assert resp.result["ok"] is True
+            assert resp.result["method"] == "initialize"
+        finally:
+            transport.close()
+
+    def test_initialize_retries_once_on_timeout(self, tmp_path):
+        script = tmp_path / "drop_first_request.py"
+        script.write_text(
+            textwrap.dedent("""\
+            import json
+            import sys
+
+            first = True
+            for line in sys.stdin:
+                line = line.strip()
+                if not line:
+                    continue
+                req = json.loads(line)
+                if first:
+                    first = False
+                    # Simulate startup race: silently drop first request.
+                    continue
+                resp = {
+                    "jsonrpc": "2.0",
+                    "id": req.get("id", 0),
+                    "result": {"ok": True},
+                }
+                sys.stdout.write(json.dumps(resp) + "\\n")
+                sys.stdout.flush()
+        """)
+        )
+
+        transport = StdioTransport(
+            [sys.executable, str(script)],
+            response_timeout=0.2,
+        )
+        try:
+            req = MCPRequest(method="initialize", id=7)
+            resp = transport.send(req)
+            assert resp.error is None
+            assert resp.result["ok"] is True
+        finally:
+            transport.close()
+
+    def test_notification_does_not_wait_for_response(self, tmp_path):
+        script = tmp_path / "init_no_notification_response.py"
+        script.write_text(
+            textwrap.dedent("""\
+            import json
+            import sys
+
+            for line in sys.stdin:
+                line = line.strip()
+                if not line:
+                    continue
+                req = json.loads(line)
+                if req.get("method") == "initialize":
+                    resp = {
+                        "jsonrpc": "2.0",
+                        "id": req.get("id", 0),
+                        "result": {
+                            "protocolVersion": "2025-03-26",
+                            "capabilities": {},
+                            "serverInfo": {"name": "test", "version": "0.1"},
+                        },
+                    }
+                    sys.stdout.write(json.dumps(resp) + "\\n")
+                    sys.stdout.flush()
+                # For notifications and all other methods: intentionally no stdout.
+        """)
+        )
+
+        transport = StdioTransport([sys.executable, str(script)], response_timeout=0.5)
+        client = MCPClient(transport)
+        try:
+            result = client.initialize()
+            assert result["serverInfo"]["name"] == "test"
+        finally:
+            transport.close()
 
 
 class TestStreamableHTTPTransport:

--- a/tests/security/test_tool_confirmation.py
+++ b/tests/security/test_tool_confirmation.py
@@ -82,7 +82,7 @@ class TestToolConfirmation:
         call = ToolCall(id="1", name="dangerous", arguments="{}")
         result = executor.execute(call)
         assert result.success is False
-        assert "denied by user" in result.content
+        assert "declined the confirmation prompt" in result.content
 
     def test_requires_confirmation_approved(self) -> None:
         """Tool requiring confirmation, callback returns True → executes."""

--- a/tests/tools/test_file_read.py
+++ b/tests/tools/test_file_read.py
@@ -57,11 +57,34 @@ class TestFileReadTool:
         assert result.success is True
         assert "ok data" in result.content
 
-    def test_directory_not_file(self, tmp_path):
+    def test_directory_lists(self, tmp_path):
+        (tmp_path / "a.txt").write_text("x", encoding="utf-8")
+        sub = tmp_path / "sub"
+        sub.mkdir()
         tool = FileReadTool()
         result = tool.execute(path=str(tmp_path))
+        assert result.success is True
+        assert "a.txt" in result.content
+        assert "sub/" in result.content
+        assert result.metadata.get("is_directory") is True
+
+    def test_directory_respects_allowed_dirs(self, tmp_path):
+        sub = tmp_path / "inner"
+        sub.mkdir()
+        (sub / "f.txt").write_text("x", encoding="utf-8")
+        tool = FileReadTool(allowed_dirs=[str(sub)])
+        result = tool.execute(path=str(tmp_path))
         assert result.success is False
-        assert "Not a file" in result.content
+        assert "outside allowed" in result.content
+
+    def test_directory_allowed_when_root_matches(self, tmp_path):
+        sub = tmp_path / "inner"
+        sub.mkdir()
+        (sub / "f.txt").write_text("x", encoding="utf-8")
+        tool = FileReadTool(allowed_dirs=[str(tmp_path)])
+        result = tool.execute(path=str(sub))
+        assert result.success is True
+        assert "f.txt" in result.content
 
     def test_blocks_env_file(self, tmp_path):
         f = tmp_path / ".env"

--- a/tests/tools/test_learn_qdrant.py
+++ b/tests/tools/test_learn_qdrant.py
@@ -1,0 +1,98 @@
+"""Tests for learn_qdrant tool."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from openjarvis.core.types import ToolResult
+from openjarvis.tools.learn_qdrant import LearnQdrantTool
+
+
+def test_learn_qdrant_requires_text():
+    tool = LearnQdrantTool()
+    r = tool.execute(text="   ")
+    assert r.success is False
+    assert "No text" in r.content
+
+
+def test_learn_qdrant_no_mcp():
+    tool = LearnQdrantTool()
+    with patch(
+        "openjarvis.tools.learn_qdrant._discover_qdrant_store_adapters",
+        return_value=[],
+    ):
+        r = tool.execute(text="hello world " * 50, source="https://example.com")
+    assert r.success is False
+    assert "qdrant-store" in r.content
+
+
+def test_learn_qdrant_stores_chunks():
+    calls: list[dict] = []
+
+    class FakeStore:
+        def execute(self, **kwargs):
+            calls.append(kwargs)
+            return ToolResult(
+                tool_name="qdrant-store",
+                content="ok",
+                success=True,
+            )
+
+    tool = LearnQdrantTool()
+    with patch(
+        "openjarvis.tools.learn_qdrant._discover_qdrant_store_adapters",
+        return_value=[FakeStore()],
+    ):
+        para = " ".join(f"w{i}" for i in range(60))
+        body = para + "\n\n" + para + "\n\n"
+        r = tool.execute(text=body, source="test:doc", origin="file_read")
+
+    assert r.success is True
+    assert "Stored" in r.content
+    assert len(calls) >= 1
+    assert all("information" in c for c in calls)
+    assert calls[0]["metadata"]["source"] == "test:doc"
+    assert calls[0]["metadata"]["origin"] == "file_read"
+
+
+def test_learn_qdrant_invalid_extra_metadata():
+    tool = LearnQdrantTool()
+    fake = MagicMock()
+    fake.execute.return_value = ToolResult(
+        tool_name="qdrant-store",
+        content="ok",
+        success=True,
+    )
+    with patch(
+        "openjarvis.tools.learn_qdrant._discover_qdrant_store_adapters",
+        return_value=[fake],
+    ):
+        r = tool.execute(text="hello", extra_metadata="not json")
+    assert r.success is False
+    assert "JSON" in r.content
+
+
+def test_learn_qdrant_min_chunk_size_allows_short_notes():
+    calls: list[dict] = []
+
+    class FakeStore:
+        def execute(self, **kwargs):
+            calls.append(kwargs)
+            return ToolResult(
+                tool_name="qdrant-store",
+                content="ok",
+                success=True,
+            )
+
+    tool = LearnQdrantTool()
+    with patch(
+        "openjarvis.tools.learn_qdrant._discover_qdrant_store_adapters",
+        return_value=[FakeStore()],
+    ):
+        r = tool.execute(
+            text="short note for memory",
+            source="note",
+            min_chunk_size=1,
+        )
+    assert r.success is True
+    assert len(calls) == 1

--- a/tests/tools/test_web_search.py
+++ b/tests/tools/test_web_search.py
@@ -10,6 +10,11 @@ from openjarvis.tools.web_search import WebSearchTool
 
 
 class TestWebSearchTool:
+    @staticmethod
+    def _no_searx(monkeypatch):
+        """Force Tavily/DDG path (user config may enable SearXNG)."""
+        monkeypatch.setattr(WebSearchTool, "_searxng_base_url", lambda self: "")
+
     def test_spec_name_and_category(self):
         tool = WebSearchTool(api_key="test-key")
         assert tool.spec.name == "web_search"
@@ -38,6 +43,7 @@ class TestWebSearchTool:
 
     def test_execute_no_api_key(self, monkeypatch):
         """When no API key, falls back to DuckDuckGo."""
+        self._no_searx(monkeypatch)
         tool = WebSearchTool(api_key=None)
         with patch.dict("os.environ", {}, clear=True):
             tool._api_key = None
@@ -47,6 +53,7 @@ class TestWebSearchTool:
         assert result.metadata["engine"] == "duckduckgo"
 
     def test_execute_mocked_tavily(self, monkeypatch):
+        self._no_searx(monkeypatch)
         mock_client = MagicMock()
         mock_client.search.return_value = {
             "results": [
@@ -89,6 +96,7 @@ class TestWebSearchTool:
 
     def test_execute_tavily_error(self, monkeypatch):
         """When Tavily errors (any error), falls back to DuckDuckGo."""
+        self._no_searx(monkeypatch)
         import builtins
         from typing import Any
 
@@ -117,6 +125,7 @@ class TestWebSearchTool:
 
     def test_execute_duckduckgo_fallback_format(self, monkeypatch):
         """DuckDuckGo fallback returns properly formatted results."""
+        self._no_searx(monkeypatch)
         mock_tavily_module = MagicMock()
         mock_tavily_module.TavilyClient.side_effect = ImportError(
             "No module named 'tavily'"
@@ -149,6 +158,7 @@ class TestWebSearchTool:
         assert result.metadata["engine"] == "duckduckgo"
 
     def test_max_results_parameter(self, monkeypatch):
+        self._no_searx(monkeypatch)
         import builtins
 
         original_import = builtins.__import__
@@ -181,6 +191,7 @@ class TestWebSearchTool:
 
     def test_execute_import_error(self, monkeypatch):
         """When tavily-python not installed, falls back to DuckDuckGo."""
+        self._no_searx(monkeypatch)
         monkeypatch.delitem(sys.modules, "tavily", raising=False)
         import builtins
 
@@ -199,6 +210,7 @@ class TestWebSearchTool:
         assert result.metadata["engine"] == "duckduckgo"
 
     def test_empty_results(self, monkeypatch):
+        self._no_searx(monkeypatch)
         import builtins
 
         original_import = builtins.__import__
@@ -221,7 +233,8 @@ class TestWebSearchTool:
         tool = WebSearchTool(api_key="test-key")
         result = tool.execute(query="obscure query")
         assert result.success is True
-        assert result.content == "No results found."
+        assert result.content.startswith("No results found.")
+        assert "Grounding" in result.content
 
     def test_tool_id(self):
         tool = WebSearchTool(api_key="test-key")
@@ -377,6 +390,7 @@ class TestExecuteWithUrl:
         result = tool.execute(query="https://example.com/article")
         assert result.success is True
         assert "Page content here" in result.content
+        assert "Grounding" in result.content
         assert result.metadata.get("mode") == "fetch"
 
     def test_execute_with_embedded_url(self, monkeypatch):


### PR DESCRIPTION
- Interactive model picker on bare jarvis (TTY); JARVIS_SKIP_MODEL_PICK
- Tiered chat modes (short/long/code); MCP startup progress
- Mandatory web_search + preflight for news/current-events queries
- native_react blocks answers without web_search when required
- Memory via memory_retrieve/inject_context; learn_qdrant off by default
- Generic configs/openjarvis templates; publishing-fork docs and secret scan

## What does this PR do?

<!-- Brief description of the change and its motivation -->

## How was this tested?

<!-- Describe tests added or manual testing performed -->

## Checklist

- [ ] Tests pass (`uv run pytest tests/ -v`)
- [ ] Linter passes (`uv run ruff check src/ tests/`)
- [ ] Formatter passes (`uv run ruff format --check src/ tests/`)
- [ ] New/changed public API has docstrings
- [ ] Follows registry pattern (if adding new component)
- [ ] Documentation updated (if applicable)
