### PR TITLE
fix(ci): publish-to-pypi — match Vite's actual outDir

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -54,19 +54,16 @@ jobs:
           set -euo pipefail
           cd frontend
           npm ci
+          # Vite is configured (frontend/vite.config.ts) with
+          # `outDir: '../src/openjarvis/server/static'` and
+          # `emptyOutDir: true`, so the build writes directly into the
+          # Python package's static dir and clears stale assets itself.
+          # No rm/cp is needed — and the previous `dist/`-assuming logic
+          # was broken because `frontend/dist/` is never produced.
           npm run build
-          # Fail loudly if Vite produced an empty/partial bundle — otherwise
-          # we'd silently ship a wheel with a broken web UI.
-          test -s dist/index.html || {
-            echo "::error::frontend/dist/index.html missing or empty after build"
-            exit 1
-          }
           STATIC=../src/openjarvis/server/static
-          mkdir -p "$STATIC"
-          rm -rf "$STATIC"/*
-          cp -r dist/. "$STATIC/"
           test -s "$STATIC/index.html" || {
-            echo "::error::static/index.html missing after copy"
+            echo "::error::${STATIC}/index.html missing or empty after build"
             exit 1
           }
 


### PR DESCRIPTION
## Summary

Hotfix on top of #358. The first autotag-triggered PyPI publish (`v1.0.2.dev660`) failed at the frontend bundling step because the workflow assumes Vite produces `frontend/dist/`, but `frontend/vite.config.ts` is configured with:

```ts
build: {
  outDir: '../src/openjarvis/server/static',
  emptyOutDir: true,
  ...
}
```

Vite writes directly into the package's static dir and clears stale assets itself. The `rm -rf dist; cp -r dist/.` ceremony in the workflow was dead code; the `test -s dist/index.html` assertion (added in #358) tripped because `frontend/dist/` is never produced.

## Fix

- Drop the `rm -rf` + `cp -r dist/.` dance.
- Assert `src/openjarvis/server/static/index.html` (the actual output location) exists after `npm run build`.
- Keep `set -euo pipefail` so build errors still bubble up.

## Test plan

- [x] YAML validates
- [ ] After merge, autotag's next dispatch lands a `1.0.2.devN+1` wheel on PyPI

## Failure that motivated this

[Run 26118617822](https://github.com/open-jarvis/OpenJarvis/actions/runs/26118617822) — `##[error]frontend/dist/index.html missing or empty after build` at step 4 of 6. No PyPI publish actually attempted; safety check did its job.