### PR TITLE
fix(ci): desktop — translate PEP 440 .devN to SemVer for Tauri

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -188,6 +188,12 @@ jobs:
             echo "prerelease=true" >> "$GITHUB_OUTPUT"
           fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          # Tauri's build script requires strict SemVer (MAJOR.MINOR.PATCH[-pre][+build]).
+          # PEP 440 dev releases (`1.0.2.dev661`) are NOT valid SemVer, so we
+          # translate `.devN` to the SemVer-equivalent `-dev.N` prerelease form.
+          # PyPI keeps the PEP 440 form; only the Tauri bundle uses SemVer.
+          TAURI_VERSION="${VERSION/.dev/-dev.}"
+          echo "tauri_version=${TAURI_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Configure Apple signing
         if: runner.os == 'macOS'
@@ -223,7 +229,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-          TAURI_CONFIG: '{"version":"${{ steps.release-info.outputs.version }}","bundle":{"externalBin":["binaries/ollama"]}}'
+          TAURI_CONFIG: '{"version":"${{ steps.release-info.outputs.tauri_version }}","bundle":{"externalBin":["binaries/ollama"]}}'
         with:
           projectPath: frontend
           tauriScript: npx tauri


### PR DESCRIPTION
## Summary

Second hotfix on top of #358. The first autotag-triggered desktop build for `v1.0.2.dev660` failed with:

```
tauri.conf.json > version must be a semver string
```

Tauri's build script enforces strict **SemVer** (`MAJOR.MINOR.PATCH[-pre][+build]`) but `#358`'s autotag scheme emits **PEP 440** dev releases (`1.0.2.dev661`). PEP 440 separates dev with `.`; SemVer requires `-`. PyPI and Tauri genuinely don't agree on `.devN`.

## Fix

Translate `.devN` → `-dev.N` only for the Tauri bundle. PyPI wheel, git tag, and `latest.json` keep the PEP 440 form. The updater compares bundle-vs-latest.json (both SemVer after this fix), so monotonicity is preserved.

```
1.0.2.dev661  → 1.0.2-dev.661   (valid SemVer prerelease)
1.0.2          → 1.0.2          (passthrough)
1.0.0-rc.1     → 1.0.0-rc.1     (passthrough)
```

## Test plan

- [x] YAML validates
- [x] Bash substitution tested for dev/non-dev/rc inputs
- [ ] After merge, next autotag's desktop run succeeds

## Failing run

[26118619500](https://github.com/open-jarvis/OpenJarvis/actions/runs/26118619500) — Tauri build script rejected `1.0.2.dev660` at the macOS build step.