### PR TITLE
docs(index): align homepage with canonical primitives, citation, and socials

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ Build personal AI that runs on your hardware. Cloud APIs are optional.
 
 Personal AI agents are exploding in popularity, but nearly all of them still route intelligence through cloud APIs. Your "personal" AI continues to depend on someone else's server. At the same time, our [Intelligence Per Watt](https://www.intelligence-per-watt.ai/) research showed that local language models already handle 88.7% of single-turn chat and reasoning queries, with intelligence efficiency improving 5.3× from 2023 to 2025. The models and hardware are increasingly ready. What has been missing is the software stack to make local-first personal AI practical.
 
-OpenJarvis is that stack. It is an opinionated framework for local-first personal AI, built around three core ideas: shared primitives for building on-device agents; evaluations that treat energy, FLOPs, latency, and dollar cost as first-class constraints alongside accuracy; and a learning loop that improves models using local trace data. The goal is simple: make it possible to build personal AI agents that run locally by default, calling the cloud only when truly necessary. OpenJarvis aims to be both a research platform and a production foundation for local AI, in the spirit of PyTorch.
+OpenJarvis is that stack. It is a framework for local-first personal AI, built around three core ideas: shared primitives for building on-device agents; evaluations that treat energy, FLOPs, latency, and dollar cost as first-class constraints alongside accuracy; and a learning loop that improves models using local trace data. The goal is simple: make it possible to build personal AI agents that run locally by default, calling the cloud only when truly necessary. OpenJarvis aims to be both a research platform and a production foundation for local AI, in the spirit of PyTorch.
 
 ---
 
@@ -60,7 +60,9 @@ OpenJarvis is that stack. It is an opinionated framework for local-first persona
 
     The app connects to `http://localhost:8000` automatically.
 
-    !!! warning "macOS: run `xattr -cr /Applications/OpenJarvis.app` if the app shows as \"damaged\"."
+    !!! warning "macOS first launch"
+
+        Run `xattr -cr /Applications/OpenJarvis.app` if the app shows as "damaged".
 
 === "Python SDK"
 
@@ -104,9 +106,9 @@ OpenJarvis is that stack. It is an opinionated framework for local-first persona
 OpenJarvis is built around five composable layers. Each has a clean interface and can be swapped independently.
 
 1. **Intelligence** — Pick a model, or let OpenJarvis pick one for your hardware. Manages the full catalog of local models across providers.
-2. **Agents** — Multi-step reasoning with tool use. Seven built-in agent types from simple chat to orchestrated workflows.
-3. **Tools** — Web search, calculator, file I/O, code interpreter, retrieval, and any external MCP server.
-4. **Engine** — The inference runtime: [Ollama](https://ollama.com), [vLLM](https://github.com/vllm-project/vllm), [SGLang](https://github.com/sgl-project/sglang), [llama.cpp](https://github.com/ggerganov/llama.cpp), cloud APIs, and more. Auto-detects your hardware and recommends the best fit.
+2. **Engine** — The inference runtime: [Ollama](https://ollama.com), [vLLM](https://github.com/vllm-project/vllm), [SGLang](https://github.com/sgl-project/sglang), [llama.cpp](https://github.com/ggerganov/llama.cpp), cloud APIs, and more. Auto-detects your hardware and recommends the best fit.
+3. **Agents** — Multi-step reasoning with tool use. Eight built-in agent types from simple chat to orchestrated workflows.
+4. **Tools & Memory** — Web search, calculator, file I/O, code interpreter, retrieval, persistent local state, and any external MCP server.
 5. **Learning** — Your AI gets better over time. Every interaction generates traces that drive automatic improvements to model weights, prompts, and agent behavior.
 
 ---
@@ -206,11 +208,14 @@ Read the [blog post](https://scalingintelligence.stanford.edu/blogs/openjarvis/)
 ## Citation
 
 ```bibtex
-@misc{saadfalcon2026openjarvis,
-  title={OpenJarvis: Personal AI, On Personal Devices},
-  author={Jon Saad-Falcon and Avanika Narayan and Herumb Shandilya and Hakki Orhun Akengin and Robby Manihani and Gabriel Bo and John Hennessy and Christopher R\'{e} and Azalia Mirhoseini},
-  year={2026},
-  howpublished={\url{https://scalingintelligence.stanford.edu/blogs/openjarvis/}},
+@misc{saadfalcon2026openjarvispersonalaipersonal,
+      title={OpenJarvis: Personal AI, On Personal Devices}, 
+      author={Jon Saad-Falcon and Avanika Narayan and Robby Manihani and Tanvir Bhathal and Herumb Shandilya and Hakki Orhun Akengin and Gabriel Bo and Andrew Park and Matthew Hart and Caia Costello and Chuan Li and Christopher Ré and Azalia Mirhoseini},
+      year={2026},
+      eprint={2605.17172},
+      archivePrefix={arXiv},
+      primaryClass={cs.LG},
+      url={https://arxiv.org/abs/2605.17172}, 
 }
 ```
 
@@ -225,3 +230,5 @@ Read the [blog post](https://scalingintelligence.stanford.edu/blogs/openjarvis/)
   <a href="https://research.ibm.com/">IBM Research</a> &bull;
   <a href="https://hai.stanford.edu/">Stanford HAI</a>
 </p>
+
+Follow [@OpenJarvisAI](https://x.com/OpenJarvisAI) on X for updates.


### PR DESCRIPTION
## Summary
- Reorders the **Five Primitives** to the canonical sequence Intelligence → Engine → Agents → Tools & Memory → Learning, fixes the agent count (seven → eight), and adds **persistent local state** to the Tools & Memory description so the primitive isn't silently truncated to "Tools."
- Replaces the **citation BibTeX** with the arXiv version that matches the README byte-for-byte: 13 authors (adds Tanvir Bhathal, Andrew Park, Matthew Hart, Caia Costello, Chuan Li), drops John Hennessy, switches to the `saadfalcon2026openjarvispersonalaipersonal` key with `eprint`/`url`.
- Drops "**opinionated**" from the *Why OpenJarvis?* paragraph for parity with the README and Ollama co-launch blog.
- Rewrites the **macOS first-launch warning** so the `xattr` command and the word "damaged" render correctly. The content moved into the admonition body — admonition titles are plain strings, so backticks and quotes there don't render, which is what caused the literal `\"damaged\"` artifact on the deployed site.
- Adds a **@OpenJarvisAI** follow line at the end of the homepage so the docs surface matches the README header.

The engine-backends Key Features card (the "10+ → Four+Five" rewrite) is intentionally **not** included in this PR.

## Test plan
- [x] `uv run mkdocs build` succeeds; no new warnings introduced (the 18 strict-mode warnings on main are all in `desktop-auto-update.md`, `telemetry.md`, and griffe docstrings — unrelated).
- [x] Rendered `site/index.html` inspected:
  - Ordered list shows Intelligence → Engine → Agents → Tools & Memory → Learning with "Eight" and "persistent local state".
  - macOS warning renders `<code>xattr -cr /Applications/OpenJarvis.app</code>` with plain `"damaged"` quotes.
  - Citation block shows all 13 authors, no Hennessy, with `eprint=2605.17172` and the arXiv URL.
  - `Follow @OpenJarvisAI on X for updates.` renders with an `https://x.com/OpenJarvisAI` anchor.
  - The string `opinionated` is absent from the rendered HTML.
- [x] Citation diff against `README.md` is empty (`diff` exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)