### PR TITLE
Consolidate contributor PRs #203 + #260 (and notes on #116, #119)

### DIFF
--- a/src/openjarvis/agents/morning_digest.py
+++ b/src/openjarvis/agents/morning_digest.py
@@ -202,6 +202,7 @@ class MorningDigestAgent(ToolUsingAgent):
         tts_text = re.sub(r"\*{1,2}([^*]+)\*{1,2}", r"\1", tts_text)
         tts_text = tts_text.strip()
 
+        output_dir = str(Path.home() / ".openjarvis" / "digests")
         tts_call = ToolCall(
             id="digest-tts-1",
             name="text_to_speech",
@@ -211,6 +212,7 @@ class MorningDigestAgent(ToolUsingAgent):
                     "voice_id": self._voice_id,
                     "backend": self._tts_backend,
                     "speed": self._voice_speed,
+                    "output_dir": output_dir,
                 }
             ),
         )

--- a/src/openjarvis/cli/digest_cmd.py
+++ b/src/openjarvis/cli/digest_cmd.py
@@ -184,10 +184,36 @@ def digest(
             from openjarvis.sdk import Jarvis
 
             with Jarvis() as j:
-                result = j.ask("Generate my morning digest", agent="morning_digest")
-                console.print(Markdown(result))
+                j.ask("Generate my morning digest", agent="morning_digest")
         except Exception as exc:
             console.print(f"[red]Failed to generate digest: {exc}[/red]")
+            store.close()
+            return
+
+        # Reload the freshly-generated digest from the store and play audio
+        store.close()
+        store = DigestStore(db_path=db_path) if db_path else DigestStore()
+        artifact = store.get_latest()
+        if artifact is None:
+            console.print("[red]Digest was not saved.[/red]")
+            store.close()
+            return
+
+        audio_path = str(artifact.audio_path)
+        console.print(f"[dim]Audio path: '{audio_path}'[/dim]")
+        has_audio = bool(audio_path) and artifact.audio_path.exists()
+        console.print(f"[dim]Audio available: {has_audio}[/dim]")
+        if has_audio:
+            audio_thread = threading.Thread(
+                target=_play_audio, args=(audio_path,), daemon=True
+            )
+            audio_thread.start()
+            console.print("[dim]Playing audio...[/dim]")
+        else:
+            console.print("[yellow]Audio unavailable — TTS failed.[/yellow]")
+            console.print("[yellow]Check OPENAI_API_KEY is set.[/yellow]")
+
+        console.print(Markdown(artifact.text))
         store.close()
         return
 

--- a/src/openjarvis/operators/manager.py
+++ b/src/openjarvis/operators/manager.py
@@ -271,12 +271,20 @@ class OperatorManager:
             "total_cost": summary.total_cost,
             "total_latency": summary.total_latency,
             "total_energy_joules": summary.total_energy_joules,
-            "avg_throughput_tok_per_sec": summary.avg_throughput_tok_per_sec,
+            "avg_throughput_tok_per_sec": (
+                summary.avg_throughput_tok_per_sec
+            ),
             "avg_gpu_utilization_pct": summary.avg_gpu_utilization_pct,
-            "avg_energy_per_output_token_joules": summary.avg_energy_per_output_token_joules,
+            "avg_energy_per_output_token_joules": (
+                summary.avg_energy_per_output_token_joules
+            ),
             "avg_throughput_per_watt": summary.avg_throughput_per_watt,
-            "total_prefill_energy_joules": summary.total_prefill_energy_joules,
-            "total_decode_energy_joules": summary.total_decode_energy_joules,
+            "total_prefill_energy_joules": (
+                summary.total_prefill_energy_joules
+            ),
+            "total_decode_energy_joules": (
+                summary.total_decode_energy_joules
+            ),
             "avg_mean_itl_ms": summary.avg_mean_itl_ms,
             "avg_median_itl_ms": summary.avg_median_itl_ms,
             "avg_p95_itl_ms": summary.avg_p95_itl_ms,

--- a/src/openjarvis/operators/manager.py
+++ b/src/openjarvis/operators/manager.py
@@ -1,5 +1,4 @@
 """Operator manager — lifecycle management for autonomous operators."""
-
 from __future__ import annotations
 
 import logging
@@ -61,7 +60,6 @@ class OperatorManager:
         """Activate an operator by creating a scheduler task.
 
         Returns the scheduler task ID (deterministic: ``operator:{id}``).
-
         Raises ``KeyError`` if the operator is not registered, or
         ``RuntimeError`` if the scheduler is not available.
         """
@@ -88,12 +86,12 @@ class OperatorManager:
             pass
 
         tools_str = ",".join(manifest.tools) if manifest.tools else ""
-
         metadata: Dict[str, Any] = {
             "operator_id": operator_id,
             "system_prompt": manifest.system_prompt,
             "temperature": manifest.temperature,
             "max_turns": manifest.max_turns,
+            "metrics": manifest.metrics,
         }
 
         # Use the scheduler's create_task but with a deterministic ID
@@ -105,11 +103,11 @@ class OperatorManager:
             tools=tools_str,
             metadata=metadata,
         )
+
         # Override the random ID with our deterministic one
         task_dict = task.to_dict()
         task_dict["id"] = task_id
         scheduler._store.save_task(task_dict)
-
         logger.info("Activated operator %s (task_id=%s)", operator_id, task_id)
         return task_id
 
@@ -148,7 +146,6 @@ class OperatorManager:
         """
         results: List[Dict[str, Any]] = []
         scheduler = self._system.scheduler
-
         for op_id, manifest in self._manifests.items():
             info: Dict[str, Any] = {
                 "id": op_id,
@@ -157,11 +154,11 @@ class OperatorManager:
                 "schedule_type": manifest.schedule_type,
                 "schedule_value": manifest.schedule_value,
                 "tools": manifest.tools,
+                "metrics": manifest.metrics,
                 "status": "registered",
                 "next_run": None,
                 "last_run": None,
             }
-
             if scheduler is not None:
                 task_id = f"operator:{op_id}"
                 try:
@@ -174,7 +171,6 @@ class OperatorManager:
                             break
                 except Exception:
                     pass
-
             results.append(info)
         return results
 
@@ -199,6 +195,111 @@ class OperatorManager:
         if isinstance(result, dict):
             return result.get("content", str(result))
         return str(result)
+
+    # -- Metrics -------------------------------------------------------------
+
+    def collect_metrics(
+        self,
+        operator_id: str,
+        *,
+        since: Optional[float] = None,
+        until: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        """Collect telemetry metrics declared in the operator's manifest.
+
+        Reads the ``metrics`` list from :class:`OperatorManifest` and queries
+        the system's ``TelemetryAggregator`` (when available) for matching
+        statistics.  Only fields explicitly listed in ``manifest.metrics`` are
+        returned, giving operators fine-grained control over what data they
+        expose.
+
+        Parameters
+        ----------
+        operator_id:
+            ID of the registered operator.
+        since:
+            Optional Unix timestamp; restrict stats to records after this time.
+        until:
+            Optional Unix timestamp; restrict stats to records before this time.
+
+        Returns
+        -------
+        Dict[str, Any]
+            Mapping of ``{metric_name: value}`` for every metric declared in
+            the manifest that could be resolved.  Unknown metric names are
+            silently skipped and logged at DEBUG level.
+
+        Raises
+        ------
+        KeyError
+            If *operator_id* is not registered.
+        """
+        manifest = self._manifests.get(operator_id)
+        if manifest is None:
+            raise KeyError(f"Operator not registered: {operator_id}")
+
+        if not manifest.metrics:
+            logger.debug(
+                "Operator %s declares no metrics; returning empty dict.",
+                operator_id,
+            )
+            return {}
+
+        aggregator = getattr(self._system, "telemetry", None)
+        if aggregator is None:
+            logger.warning(
+                "TelemetryAggregator not available on system; "
+                "cannot collect metrics for operator %s.",
+                operator_id,
+            )
+            return {}
+
+        try:
+            summary = aggregator.summary(since=since, until=until)
+        except Exception as exc:
+            logger.error(
+                "Failed to query telemetry for operator %s: %s",
+                operator_id,
+                exc,
+            )
+            return {}
+
+        # Build a flat lookup of all available summary-level stats
+        available: Dict[str, Any] = {
+            "total_calls": summary.total_calls,
+            "total_tokens": summary.total_tokens,
+            "total_cost": summary.total_cost,
+            "total_latency": summary.total_latency,
+            "total_energy_joules": summary.total_energy_joules,
+            "avg_throughput_tok_per_sec": summary.avg_throughput_tok_per_sec,
+            "avg_gpu_utilization_pct": summary.avg_gpu_utilization_pct,
+            "avg_energy_per_output_token_joules": summary.avg_energy_per_output_token_joules,
+            "avg_throughput_per_watt": summary.avg_throughput_per_watt,
+            "total_prefill_energy_joules": summary.total_prefill_energy_joules,
+            "total_decode_energy_joules": summary.total_decode_energy_joules,
+            "avg_mean_itl_ms": summary.avg_mean_itl_ms,
+            "avg_median_itl_ms": summary.avg_median_itl_ms,
+            "avg_p95_itl_ms": summary.avg_p95_itl_ms,
+        }
+
+        collected: Dict[str, Any] = {}
+        for metric in manifest.metrics:
+            if metric in available:
+                collected[metric] = available[metric]
+            else:
+                logger.debug(
+                    "Operator %s requested unknown metric '%s'; skipping.",
+                    operator_id,
+                    metric,
+                )
+
+        logger.info(
+            "Collected %d/%d metrics for operator %s.",
+            len(collected),
+            len(manifest.metrics),
+            operator_id,
+        )
+        return collected
 
     def get_manifest(self, operator_id: str) -> Optional[OperatorManifest]:
         """Return the manifest for an operator, or None."""

--- a/src/openjarvis/tools/text_to_speech.py
+++ b/src/openjarvis/tools/text_to_speech.py
@@ -59,6 +59,8 @@ class TextToSpeechTool(BaseTool):
         text = params.get("text", "")
         voice_id = params.get("voice_id", "")
         backend_key = params.get("backend", "cartesia")
+        _ALIASES = {"openai": "openai_tts"}
+        backend_key = _ALIASES.get(backend_key, backend_key)
         output_dir = params.get("output_dir", "")
         speed = float(params.get("speed", 1.0))
 


### PR DESCRIPTION
## Summary

Consolidates two contributor PRs that landed cleanly on the current
main. Two related PRs (#116, #119) from the originally-planned set
were excluded — see "Excluded from this batch" below.

## Credits

Each contributor's commit lands on `main` with their original
`Author:` line preserved.

| Author | What landed |
|---|---|
| **@bootcrowns** (Abhinav Cherukuru) | `feat(operators)`: wire the `metrics` field on `OperatorManifest` through `OperatorManager.activate()`, `status()`, and a new `collect_metrics()` method + `fix(lint)`: wrap long lines in the available-metrics dict for E501 (PR #203) |
| **@samy19980109** (Samarth Agarwal) | `adding TTS for morning digest`: sets a default `output_dir` for the digest TTS file, reloads the artifact from `DigestStore` after `j.ask(...)` to access the audio path, plays it via the existing `_play_audio` thread helper, and adds an `openai` → `openai_tts` backend alias in `TextToSpeechTool` (PR #260) |

## Commits (3 total)

| # | Author | Subject |
|---|---|---|
| 1 | Abhinav Cherukuru | `feat(operators): wire metrics field and add collect_metrics() to OperatorManager` |
| 2 | Abhinav Cherukuru | `fix(lint): wrap long lines in collect_metrics available dict (E501)` |
| 3 | Samarth Agarwal | `adding TTS for morning digest` |

No follow-up commits from me on this batch — both PRs apply cleanly to current main and pass the full local matrix.

## Excluded from this batch

- **#116** (@mricharz, "fix: include MCP tools in /v1/tools endpoint")
  — backend intent is already on `main` (the `_get_mcp_tools` helper
  at `agent_manager_routes.py:465` and the `list_tools` modification
  at line 1979 landed via the system refactor / Granola merges).
  Frontend changes (`AgentsPage.tsx`) conflict with significant
  restructuring on main and need a fresh rebase from the author.
  Tests (`test_tools_endpoint.py`) would be welcome on top of the
  existing backend.

- **#119** (@mricharz, "feat(mcp): support external JSON file for
  server configuration") — modifies `src/openjarvis/system.py` which
  has been **deleted on main**. PR #257 decomposed the `JarvisSystem`
  god-object into the `openjarvis/system/` package; the MCP server
  config-loading logic now lives in `system/builder.py` and needs the
  JSON-file dispatch to be ported there. Substantial porting work,
  best done by the original author who knows the change's full intent.

Both PRs are being left **open** with a courtesy comment pointing to
the relevant refactor and explaining what a rebase would need to
touch. The author can decide whether to invest in the port.

## Test plan

- [x] `uv run ruff check src/ tests/` → clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` → clean
- [x] `uv run pytest tests/ -m 'not live and not cloud'` → **6727
      passed, 3 failed, 47 skipped, 6 errors**. The 3 failures + 6
      errors match the main baseline exactly (`test_default_max_turns`
      and 8 `test_dense.py` items that need an Ollama embed model
      pulled). **Zero regressions.**

## Merge style note

Please use **"Create a merge commit"** or **"Rebase and merge"** so
each contributor's commit lands on `main` individually with their
original `Author:` line. Squash would collapse the 3 commits and
drop per-contributor attribution.

After merge, I'll comment on #203 and #260 with commit SHAs and
close them, and leave courtesy rebase-pointer comments on #116 and
#119.

🤖 Generated with [Claude Code](https://claude.com/claude-code)