### PR TITLE
fix(engine): convert apple_fm_shim cumulative snapshots to OpenAI deltas

### DIFF
--- a/src/openjarvis/engine/apple_fm_shim.py
+++ b/src/openjarvis/engine/apple_fm_shim.py
@@ -101,10 +101,22 @@ async def chat_completions(
 
         async def generate():
             cid = f"chatcmpl-{uuid.uuid4().hex[:12]}"
-            async for token in session.stream_response(
+            # Apple FM yields cumulative snapshots, OpenAI clients expect
+            # incremental deltas — diff against last to convert.
+            sent = ""
+            async for snapshot in session.stream_response(
                 prompt,
                 max_tokens=req.max_tokens,
             ):
+                if not snapshot.startswith(sent):
+                    # Snapshot diverged (model revised earlier text);
+                    # fall back to resending the full snapshot.
+                    delta = snapshot
+                else:
+                    delta = snapshot[len(sent) :]
+                sent = snapshot
+                if not delta:
+                    continue
                 chunk = {
                     "id": cid,
                     "object": "chat.completion.chunk",
@@ -113,7 +125,7 @@ async def chat_completions(
                     "choices": [
                         {
                             "index": 0,
-                            "delta": {"content": token},
+                            "delta": {"content": delta},
                             "finish_reason": None,
                         }
                     ],


### PR DESCRIPTION
## Summary

Fixes #378 — the `apple_fm_shim` streaming path was forwarding Apple FM's cumulative-snapshot output verbatim as `choices[0].delta.content`, breaking standards-compliant OpenAI clients which concatenate deltas.

`apple_fm_sdk.LanguageModelSession.stream_response` is documented to yield "complete text snapshots (not deltas)" — so the variable named `token` in the shim was actually a cumulative snapshot. Convert by tracking the last sent text and emitting `current[len(sent):]` per chunk. Defensive fallback to resending the full snapshot if it ever diverges from the previous (undocumented but cheap to guard).

## Repro before / after

```bash
curl -s -N -X POST http://127.0.0.1:8079/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"apple-fm","stream":true,"messages":[{"role":"user","content":"Count from one to five, one number per line."}]}'
```

**Before** — each chunk's `delta.content` is the cumulative response so far:
```
data: {"choices":[{"delta":{"content":"Sure! Here are the numbers:\n\n1"}, ...}]}
data: {"choices":[{"delta":{"content":"Sure! Here are the numbers:\n\n1.  \n2.  \n3.  "}, ...}]}
data: {"choices":[{"delta":{"content":"Sure! Here are the numbers:\n\n1.  \n2.  \n3.  \n4.  \n5."}, ...}]}
```

**After** — each chunk carries only the new text:
```
data: {"choices":[{"delta":{"content":"Sure! Here are the numbers:\n\n1"}, ...}]}
data: {"choices":[{"delta":{"content":".  \n2.  \n3.  "}, ...}]}
data: {"choices":[{"delta":{"content":"\n4.  \n5."}, ...}]}
```

Concatenated stream is now exactly `"Sure! Here are the numbers:\n\n1.  \n2.  \n3.  \n4.  \n5."`.

## Test plan

- [x] Smoke-tested with `curl` on a locally running shim — clean incremental deltas, no stutter.
- [x] Non-streaming path (`stream=false`) unchanged.
- [x] `pre-commit` (ruff + ruff-format) passes.
- [ ] Worth adding an automated test that asserts non-overlapping deltas; happy to follow up in a second PR if desired.