### PR TITLE
fix: improve Windows compatibility in quickstart script

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ jarvis
 
 The Rust extension and bigger models continue downloading in the background while you chat. Run `jarvis doctor` to see status.
 
-**Platforms:** macOS (Intel + Apple Silicon), Linux, WSL2 on Windows.
+**Platforms:** macOS (Intel + Apple Silicon), Linux, Windows (Native/WSL2).
 
 **Manual install / contributors:** see [docs/getting-started/install.md](docs/getting-started/install.md).
 

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -49,16 +49,20 @@ echo -e "${NC}"
 # ── 1. Check Python ──────────────────────────────────────────────────
 info "Checking Python..."
 if command -v python3 &>/dev/null; then
-  PY_VERSION=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
-  PY_MAJOR=$(echo "$PY_VERSION" | cut -d. -f1)
-  PY_MINOR=$(echo "$PY_VERSION" | cut -d. -f2)
-  if [ "$PY_MAJOR" -ge 3 ] && [ "$PY_MINOR" -ge 10 ]; then
-    ok "Python $PY_VERSION"
-  else
-    fail "Python 3.10+ required (found $PY_VERSION)"
-  fi
+  PY_CMD="python3"
+elif command -v python &>/dev/null; then
+  PY_CMD="python"
 else
-  fail "Python 3 not found. Install from https://python.org"
+  fail "Python not found. Install from https://python.org"
+fi
+
+PY_VERSION=$($PY_CMD -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
+PY_MAJOR=$(echo "$PY_VERSION" | cut -d. -f1)
+PY_MINOR=$(echo "$PY_VERSION" | cut -d. -f2)
+if [ "$PY_MAJOR" -ge 3 ] && [ "$PY_MINOR" -ge 10 ]; then
+  ok "Python $PY_VERSION (using $PY_CMD)"
+else
+  fail "Python 3.10+ required (found $PY_VERSION)"
 fi
 
 # ── 2. Check / install uv ───────────────────────────────────────────
@@ -182,6 +186,7 @@ info "Opening $URL ..."
 case "$(uname -s)" in
   Darwin) open "$URL" ;;
   Linux)  xdg-open "$URL" 2>/dev/null || true ;;
+  CYGWIN*|MINGW*|MSYS*) cmd /c start "$URL" ;;
   *)      true ;;
 esac
 


### PR DESCRIPTION
- Handle 'python' as fallback for 'python3'\n- Add Windows support for opening browser via 'cmd /c start'

## What does this PR do?

This PR improves Windows compatibility in the quickstart script by making two key changes:

Python command fallback: Instead of only checking for python3, the script now falls back to python if python3 is not available. This is important because Windows users often only have python in their PATH.

Windows browser opening: Adds support for opening URLs on Windows systems using cmd /c start, which is the Windows equivalent of open (macOS) and xdg-open (Linux).

## How was this tested?

<!-- Describe tests added or manual testing performed -->

## Checklist

- [ ] Tests pass (`uv run pytest tests/ -v`)
- [ ] Linter passes (`uv run ruff check src/ tests/`)
- [ ] Formatter passes (`uv run ruff format --check src/ tests/`)
- [ ] New/changed public API has docstrings
- [ ] Follows registry pattern (if adding new component)
- [ ] Documentation updated (if applicable)
