### PR TITLE
feat(server): expose sampler params (repetition_penalty / top_p / top_k / min_p / *_penalty) for managed agents

### DIFF
--- a/src/openjarvis/server/agent_manager_routes.py
+++ b/src/openjarvis/server/agent_manager_routes.py
@@ -960,6 +960,25 @@ async def _stream_managed_agent(
     if resolved_tools:
         stream_kwargs["tools"] = resolved_tools
 
+    # Per-agent sampler params. The OpenAI-compat engine already forwards
+    # unknown kwargs into the upstream /v1/chat/completions payload, so the
+    # plumbing already works — this just lets the agent's stored config
+    # drive it. Skipped if absent (full backward compat with existing agents).
+    # Names cover both OpenAI-style (frequency/presence_penalty, top_p) and
+    # llama.cpp / vLLM / mlx-style (repetition_penalty, top_k, min_p); the
+    # upstream engine accepts what it accepts and the _OpenAICompatibleEngine
+    # already swallows 400s for unknown payload keys (engine/_openai_compat.py).
+    for _sampler_key in (
+        "repetition_penalty",
+        "top_p",
+        "top_k",
+        "min_p",
+        "frequency_penalty",
+        "presence_penalty",
+    ):
+        if _sampler_key in config:
+            stream_kwargs[_sampler_key] = config[_sampler_key]
+
     # Discover MCP tools and merge into stream_kwargs
     mcp_adapters: Dict[str, Any] = {}
     if app_state is not None:

--- a/tests/server/test_agent_manager_routes.py
+++ b/tests/server/test_agent_manager_routes.py
@@ -385,6 +385,115 @@ class TestAgentManagerStreaming:
         # Last chunk should have finish_reason="stop"
         assert chunks[-1]["choices"][0]["finish_reason"] == "stop"
 
+    def test_send_message_stream_forwards_sampler_params(self, manager):
+        """Per-agent sampler params (repetition_penalty, top_p, top_k, min_p,
+        frequency_penalty, presence_penalty) configured on the agent flow
+        through to engine.stream_full(**kwargs). Other unrelated config keys
+        do NOT leak into kwargs."""
+        from openjarvis.engine._stubs import StreamChunk
+
+        captured_kwargs: dict = {}
+
+        async def _stream_full(messages, *, model, **kwargs):
+            captured_kwargs.update(kwargs)
+            yield StreamChunk(content="ok")
+            yield StreamChunk(finish_reason="stop")
+
+        engine = MagicMock()
+        engine.engine_id = "mock"
+        engine._model = "test-model"
+        engine.stream_full = _stream_full
+
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient as TC
+
+        from openjarvis.server.agent_manager_routes import create_agent_manager_router
+
+        app = FastAPI()
+        app.state.engine = engine
+        app.state.bus = None
+        routers = create_agent_manager_router(manager)
+        for r in routers:
+            app.include_router(r)
+        client = TC(app)
+
+        agent = manager.create_agent(
+            name="sampler_agent",
+            agent_type="simple",
+            config={
+                "repetition_penalty": 1.1,
+                "top_p": 0.95,
+                "top_k": 40,
+                "min_p": 0.05,
+                "frequency_penalty": 0.2,
+                "presence_penalty": 0.1,
+                # Unrelated keys that must NOT be forwarded:
+                "custom_meta": "ignore-me",
+                "owner_email": "test@example.com",
+            },
+        )
+
+        resp = client.post(
+            f"/v1/managed-agents/{agent['id']}/messages",
+            json={"content": "hi", "stream": True},
+        )
+        assert resp.status_code == 200
+        assert captured_kwargs.get("repetition_penalty") == 1.1
+        assert captured_kwargs.get("top_p") == 0.95
+        assert captured_kwargs.get("top_k") == 40
+        assert captured_kwargs.get("min_p") == 0.05
+        assert captured_kwargs.get("frequency_penalty") == 0.2
+        assert captured_kwargs.get("presence_penalty") == 0.1
+        assert "custom_meta" not in captured_kwargs
+        assert "owner_email" not in captured_kwargs
+
+    def test_send_message_stream_omits_unset_sampler_params(self, manager):
+        """Agents without sampler params produce a kwargs dict that doesn't
+        contain any of them (backward compat — no extra keys reach engines
+        that might reject unknown payload fields)."""
+        from openjarvis.engine._stubs import StreamChunk
+
+        captured_kwargs: dict = {}
+
+        async def _stream_full(messages, *, model, **kwargs):
+            captured_kwargs.update(kwargs)
+            yield StreamChunk(content="ok")
+            yield StreamChunk(finish_reason="stop")
+
+        engine = MagicMock()
+        engine.engine_id = "mock"
+        engine._model = "test-model"
+        engine.stream_full = _stream_full
+
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient as TC
+
+        from openjarvis.server.agent_manager_routes import create_agent_manager_router
+
+        app = FastAPI()
+        app.state.engine = engine
+        app.state.bus = None
+        routers = create_agent_manager_router(manager)
+        for r in routers:
+            app.include_router(r)
+        client = TC(app)
+
+        agent = manager.create_agent(name="plain_agent", agent_type="simple")
+        resp = client.post(
+            f"/v1/managed-agents/{agent['id']}/messages",
+            json={"content": "hi", "stream": True},
+        )
+        assert resp.status_code == 200
+        for key in (
+            "repetition_penalty",
+            "top_p",
+            "top_k",
+            "min_p",
+            "frequency_penalty",
+            "presence_penalty",
+        ):
+            assert key not in captured_kwargs
+
     def test_send_message_stream_error_handling(self, manager):
         """Engine errors are reported gracefully via SSE."""
 


### PR DESCRIPTION
Closes #386.

## What this changes

`_stream_managed_agent` now reads six sampler parameters from a managed agent's `config_json` and merges them into the kwargs passed to `engine.stream_full(...)`:

- `repetition_penalty`
- `top_p`
- `top_k`
- `min_p`
- `frequency_penalty`
- `presence_penalty`

Skipped silently when absent — existing agents see no behavior change.

## Why

`_OpenAICompatibleEngine.stream_full` already builds the upstream payload as `{..., **kwargs}` and forwards to `/v1/chat/completions`, so the plumbing already exists. The gap was just *reading* these from `config_json` and merging into `stream_kwargs`. This PR closes that gap.

Concrete motivating bug from my own session: managed agent backed by `qwen3.6-35b-a3b` (MLX 8-bit, Unsloth's clean build or any vendor's) emitted **the same paragraph 32× in one completion** — ~240 KB of SSE before `finish_reason: "stop"` finally fired. Setting `repetition_penalty: 1.1` on the agent record now closes that without per-server-process knobs.

See #386 for the full repro + reasoning.

## What this does NOT change

- No schema migration. `config_json` is `TEXT`; the new keys are read opportunistically.
- No new defaults injected. Agents without these keys behave exactly as before.
- No engine-side changes. The OpenAI-compat engine's existing `**kwargs` passthrough + 400-error tolerance (`engine/_openai_compat.py:63-64`) handles this for free.
- Not touched: `DeepResearchAgent` path (separate branch at `agent_manager_routes.py:679`+). I scoped this PR to the main streaming branch only; happy to extend in a follow-up if you'd like.

## Tests

Two new tests added to `tests/server/test_agent_manager_routes.py::TestAgentManagerStreaming`:

1. `test_send_message_stream_forwards_sampler_params` — agent configured with all six sampler params; mock engine captures `stream_full` kwargs; asserts all six land, and that unrelated config keys (`custom_meta`, `owner_email`) do NOT leak.
2. `test_send_message_stream_omits_unset_sampler_params` — backward-compat: an agent with no sampler config produces a kwargs dict that doesn't include any of the six keys.

Both pass. Full test file (30 tests including the existing streaming suite): `30 passed`.

```
$ pytest tests/server/test_agent_manager_routes.py -q
..............................                                           [100%]
30 passed, 1 warning in 0.80s
```

## Diff size

`+128 / -0`, two files (`agent_manager_routes.py` +15, the rest is tests).