### PR TITLE
fix(server): inject dependencies into managed-agent streaming tools

### DIFF
--- a/src/openjarvis/cli/ask.py
+++ b/src/openjarvis/cli/ask.py
@@ -28,6 +28,7 @@ from openjarvis.intelligence import (
 )
 from openjarvis.telemetry.instrumented_engine import InstrumentedEngine
 from openjarvis.telemetry.store import TelemetryStore
+from openjarvis.tools.factory import instantiate_tool
 
 logger = logging.getLogger(__name__)
 
@@ -150,9 +151,7 @@ def _run_research(
             trace.print(f"  [dim]↳ Found {n} {label}[/dim]")
         elif etype == "clarify_call":
             q = event.get("question", "") or ""
-            trace.print(
-                f"  [dim]↳ Clarifying:[/dim] [dim italic]{q}[/dim italic]"
-            )
+            trace.print(f"  [dim]↳ Clarifying:[/dim] [dim italic]{q}[/dim italic]")
         # final_answer and clarify_response are handled outside the loop.
 
     agent = ResearchAgent(
@@ -208,8 +207,7 @@ def _run_research(
         src_word = "source" if len(cited) == 1 else "sources"
         trace.print()
         trace.print(
-            f"[dim]Deep Research · {elapsed:.1f}s · "
-            f"{len(cited)} {src_word} cited[/dim]"
+            f"[dim]Deep Research · {elapsed:.1f}s · {len(cited)} {src_word} cited[/dim]"
         )
 
 
@@ -243,12 +241,6 @@ def _get_memory_backend(config):
         return None
 
 
-_MEMORY_TOOLS = frozenset(
-    {"retrieval", "memory_store", "memory_search", "memory_index", "memory_retrieve"}
-)
-_CHANNEL_TOOLS = frozenset({"channel_send", "channel_list", "channel_status"})
-
-
 def _build_tools(
     tool_names: list[str],
     config,
@@ -259,54 +251,25 @@ def _build_tools(
 ):
     """Instantiate tool objects from names.
 
-    ``channel`` is an optional :class:`BaseChannel` used by ``channel_*``
-    tools. Threading it through here mirrors how memory backends are
-    injected; without it, channel tools have no backend and fail at
-    runtime.
-
-    Emits a WARNING when a memory tool is requested but no backend is
-    available, and when a channel tool is requested but no channel is
-    provided — these are the failure modes that silently cascade into
-    hallucinated or dropped replies downstream.
+    Delegates to :func:`openjarvis.tools.factory.instantiate_tool` so
+    the dispatch (memory backend injection, channel injection, llm
+    engine wiring) stays in one place — the streaming managed-agent
+    path uses the same helper.
     """
-    from openjarvis.core.registry import ToolRegistry
-
     tools = []
     for name in tool_names:
         name = name.strip()
         if not name:
             continue
-        if not ToolRegistry.contains(name):
-            continue
-        tool_cls = ToolRegistry.get(name)
-        # Instantiate with appropriate arguments
-        if name in _MEMORY_TOOLS:
-            backend = _get_memory_backend(config)
-            if backend is None:
-                logger.warning(
-                    "Tool %r was requested but no memory backend is "
-                    "available (default=%r). The tool will load but "
-                    "return no results — downstream agents may answer "
-                    "without grounding.",
-                    name,
-                    getattr(config.memory, "default_backend", "?"),
-                )
-            tools.append(tool_cls(backend=backend))
-        elif name in _CHANNEL_TOOLS:
-            if channel is None:
-                logger.warning(
-                    "Tool %r was requested but no channel was injected. "
-                    "The tool will load but every call will fail with "
-                    "'No channel backend configured'.",
-                    name,
-                )
-            tools.append(tool_cls(channel=channel))
-        elif name == "llm":
-            tools.append(tool_cls(engine=engine, model=model_name))
-        elif name == "file_read":
-            tools.append(tool_cls())
-        else:
-            tools.append(tool_cls())
+        tool = instantiate_tool(
+            name,
+            app_config=config,
+            engine=engine,
+            model_name=model_name,
+            channel=channel,
+        )
+        if tool is not None:
+            tools.append(tool)
     return tools
 
 

--- a/src/openjarvis/server/agent_manager_routes.py
+++ b/src/openjarvis/server/agent_manager_routes.py
@@ -1164,18 +1164,30 @@ async def _stream_managed_agent(
                             result = mcp_adapter.execute(**parsed_args)
                             tool_result_content = result.content
                         else:
-                            # Try to use ToolExecutor if tools are configured
-                            from openjarvis.core.registry import ToolRegistry
+                            # Instantiate via the shared factory so memory/
+                            # channel/llm tools get their dependencies
+                            # injected the same way ``jarvis ask`` does
+                            # (#395). Bare ``tool_cls()`` instantiation
+                            # leaves memory_* with backend=None → every
+                            # call returns "No memory backend configured."
+                            from openjarvis.core.config import load_config
                             from openjarvis.tools._stubs import (
                                 ToolCall as StubToolCall,
                             )
                             from openjarvis.tools._stubs import (
                                 ToolExecutor,
                             )
+                            from openjarvis.tools.factory import (
+                                instantiate_tool,
+                            )
 
-                            tool_cls = ToolRegistry.get(tool_name)
-                            if tool_cls is not None:
-                                tool_instance = tool_cls()
+                            tool_instance = instantiate_tool(
+                                tool_name,
+                                app_config=load_config(),
+                                engine=engine,
+                                model_name=model,
+                            )
+                            if tool_instance is not None:
                                 # Tools the user explicitly added to this
                                 # agent's toolkit are considered pre-approved —
                                 # selecting them in the wizard is the

--- a/src/openjarvis/tools/factory.py
+++ b/src/openjarvis/tools/factory.py
@@ -1,0 +1,73 @@
+"""Shared tool-instantiation helper.
+
+The dispatch lives here so that every code path which builds tools from
+their string names (``cli/ask.py``, ``server/agent_manager_routes.py``,
+future call sites) injects the same dependencies. Without a shared
+helper, paths drift — a tool that works under ``jarvis ask`` returns
+``"No memory backend configured."`` under the managed-agent streaming
+endpoint, because the latter forgot to inject the backend (see #395).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from openjarvis.core.registry import ToolRegistry
+
+logger = logging.getLogger(__name__)
+
+
+MEMORY_TOOLS = frozenset(
+    {"retrieval", "memory_store", "memory_search", "memory_index", "memory_retrieve"}
+)
+CHANNEL_TOOLS = frozenset({"channel_send", "channel_list", "channel_status"})
+
+
+def instantiate_tool(
+    name: str,
+    *,
+    app_config: Any,
+    engine: Any = None,
+    model_name: str = "",
+    channel: Any = None,
+) -> Optional[Any]:
+    """Instantiate a tool by name with the right dependencies injected.
+
+    Returns ``None`` if the name is unknown to ``ToolRegistry``. Warns
+    (but still instantiates) when a memory/channel tool is requested
+    without a backend/channel — the tool will load and every call will
+    return its own ``"No X configured."`` error, which is the failure
+    mode we want surfaced loudly rather than silently dropped.
+    """
+    if not ToolRegistry.contains(name):
+        return None
+
+    tool_cls = ToolRegistry.get(name)
+
+    if name in MEMORY_TOOLS:
+        from openjarvis.cli.ask import _get_memory_backend
+
+        backend = _get_memory_backend(app_config)
+        if backend is None:
+            logger.warning(
+                "Tool %r was requested but no memory backend is available "
+                "(default=%r). The tool will load but return no results.",
+                name,
+                getattr(app_config.memory, "default_backend", "?"),
+            )
+        return tool_cls(backend=backend)
+
+    if name in CHANNEL_TOOLS:
+        if channel is None:
+            logger.warning(
+                "Tool %r was requested but no channel was injected. "
+                "Every call will return 'No channel backend configured'.",
+                name,
+            )
+        return tool_cls(channel=channel)
+
+    if name == "llm":
+        return tool_cls(engine=engine, model=model_name)
+
+    return tool_cls()

--- a/tests/tools/test_factory.py
+++ b/tests/tools/test_factory.py
@@ -1,0 +1,119 @@
+"""Tests for ``openjarvis.tools.factory.instantiate_tool``.
+
+Pins the contract that memory/channel/llm tools get their dependencies
+injected when built by name — the regression #395 reported was the
+streaming managed-agent path getting ``backend=None`` and silently
+failing on every call.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from openjarvis.core.registry import ToolRegistry
+from openjarvis.tools.channel_tools import ChannelSendTool
+from openjarvis.tools.factory import (
+    CHANNEL_TOOLS,
+    MEMORY_TOOLS,
+    instantiate_tool,
+)
+from openjarvis.tools.file_read import FileReadTool
+from openjarvis.tools.llm_tool import LLMTool
+from openjarvis.tools.storage_tools import MemoryStoreTool
+
+
+@pytest.fixture
+def _register_tools():
+    """Re-register the tools each test needs after the autouse registry clear."""
+    ToolRegistry.register_value("memory_store", MemoryStoreTool)
+    ToolRegistry.register_value("channel_send", ChannelSendTool)
+    ToolRegistry.register_value("llm", LLMTool)
+    ToolRegistry.register_value("file_read", FileReadTool)
+
+
+class _StubConfig:
+    """Minimal stand-in for the app-config shape ``_get_memory_backend`` needs."""
+
+    class _Mem:
+        default_backend = "sqlite"
+        db_path = "/tmp/test-factory.db"
+
+    memory = _Mem()
+
+
+def test_memory_tool_gets_backend_injected(_register_tools):
+    sentinel = object()
+    with patch(
+        "openjarvis.cli.ask._get_memory_backend",
+        return_value=sentinel,
+    ):
+        tool = instantiate_tool("memory_store", app_config=_StubConfig())
+    assert tool is not None
+    assert tool._backend is sentinel
+
+
+def test_memory_tool_with_no_backend_warns_but_still_instantiates(
+    _register_tools, caplog
+):
+    with (
+        patch(
+            "openjarvis.cli.ask._get_memory_backend",
+            return_value=None,
+        ),
+        caplog.at_level(logging.WARNING, logger="openjarvis.tools.factory"),
+    ):
+        tool = instantiate_tool("memory_store", app_config=_StubConfig())
+    assert tool is not None
+    assert tool._backend is None
+    assert any(
+        "no memory backend is available" in rec.message for rec in caplog.records
+    )
+
+
+def test_channel_tool_gets_channel_injected(_register_tools):
+    sentinel = MagicMock()
+    tool = instantiate_tool(
+        "channel_send",
+        app_config=_StubConfig(),
+        channel=sentinel,
+    )
+    assert tool is not None
+    assert tool._channel is sentinel
+
+
+def test_llm_tool_gets_engine_and_model(_register_tools):
+    engine_sentinel = MagicMock()
+    tool = instantiate_tool(
+        "llm",
+        app_config=_StubConfig(),
+        engine=engine_sentinel,
+        model_name="test-model",
+    )
+    assert tool is not None
+    assert tool._engine is engine_sentinel
+    assert tool._model == "test-model"
+
+
+def test_unknown_tool_returns_none(_register_tools):
+    assert instantiate_tool("nonexistent_tool_xyz", app_config=_StubConfig()) is None
+
+
+def test_plain_tool_instantiates_without_dependencies(_register_tools):
+    tool = instantiate_tool("file_read", app_config=_StubConfig())
+    assert tool is not None
+
+
+def test_memory_tools_set_membership():
+    assert "memory_store" in MEMORY_TOOLS
+    assert "memory_search" in MEMORY_TOOLS
+    assert "memory_retrieve" in MEMORY_TOOLS
+    assert "memory_index" in MEMORY_TOOLS
+
+
+def test_channel_tools_set_membership():
+    assert "channel_send" in CHANNEL_TOOLS
+    assert "channel_list" in CHANNEL_TOOLS
+    assert "channel_status" in CHANNEL_TOOLS


### PR DESCRIPTION
Closes #395.

## Summary

The streaming managed-agent endpoint (`_stream_managed_agent` in `src/openjarvis/server/agent_manager_routes.py`) was instantiating every tool with a bare `tool_cls()` — no dependency injection. Memory/channel/llm tools all loaded with `backend=None` / `channel=None` / `engine=None` and silently failed on every call with messages like `"No memory backend configured."`

`cli/ask.py:_build_tools` already handled the same dispatch correctly. This PR extracts that logic into a new `openjarvis.tools.factory.instantiate_tool` helper and routes both call sites through it, so the two paths stay in lockstep.

## How I found it

Running Kira (a registered managed agent, `agent_type="monitor_operative"`, model = `unsloth/Qwen3.6-35B-A3B-MLX-8bit` served via the `mlx` engine at `:8768`) through streaming chat from a separate app. Every `memory_store` call came back `"No memory backend configured."` even though `/v1/tools` listed the five `memory_*` tools and `_get_memory_backend(load_config())` returned a usable sqlite backend in isolation.

Same architectural shape as #376 / #380 / #382: managed-agent streaming path diverges from `cli/ask` path on setup that should be uniform. Happy to consolidate further related findings into one issue if that's preferred.

## Repro on `main`

```bash
# 1) Create an agent with memory_store wired
curl -X POST http://localhost:8000/v1/managed-agents \
  -H 'content-type: application/json' \
  -d '{"name":"MemTest","agent_type":"monitor_operative",
       "config":{"model":"<your-model>","tools":["memory_store"],
                 "system_prompt":"Use memory_store when asked."}}'

# 2) Ask it to store something
curl -N -X POST http://localhost:8000/v1/managed-agents/<id>/messages \
  -H 'content-type: application/json' \
  -d '{"content":"Call memory_store with content=\"hello\".","mode":"immediate","stream":true}'
```

Observed on `main`: SSE stream emits `event: tool_call_start` (the model called the tool correctly) but the result is `"No memory backend configured."` and the model relays that as text.

After this patch: returns a real `doc_id` and the entry is queryable via `memory_search` and visible in `~/.openjarvis/memory.db`.

## Changes

- **New** `src/openjarvis/tools/factory.py` — `instantiate_tool(name, *, app_config, engine, model_name, channel)` helper that knows the memory/channel/llm injection contract.
- **Refactor** `src/openjarvis/cli/ask.py:_build_tools` — delegates to `instantiate_tool`. Net -50 lines; identical behavior.
- **Patch** `src/openjarvis/server/agent_manager_routes.py:_stream_managed_agent` — replaces bare `tool_cls()` with `instantiate_tool(...)`.

## Tests

- **New** `tests/tools/test_factory.py` — 8 cases: memory backend injection, channel injection, llm engine wiring, missing-backend warning, unknown-name → None, plain tool fallback, and set-membership pins on `MEMORY_TOOLS` / `CHANNEL_TOOLS`.
- Existing `tests/cli/test_ask_agent.py` (26), `tests/server/test_agent_manager_routes.py` (28), `tests/sdk/test_system.py` (36) all still pass — 94 total in the slice that touches the changed code, plus the new 8.

Full suite (`tests/cli tests/server tests/tools tests/sdk`): 1284 passed, 15 skipped. The 4 failures in `tests/cli/test_doctor_*` reproduce on a clean `upstream/main` without these changes — unrelated.
