### PR TITLE
fix: PyPI v1.0.2 cluster — wheel packaging + pynvml warning + install fallback + uv-sync diagnostics (closes #372, #389, #337, #352, #331)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,11 @@ Thumbs.db
 *.log
 results/
 logs/
-traces/
+# Anchored to repo root — DO NOT use the unanchored form `traces/`.
+# hatchling honors .gitignore when building the wheel; an unanchored
+# `traces/` pattern matches src/openjarvis/traces/ and silently drops
+# the runtime module from the wheel (issue #372).
+/traces/
 coding_task_*
 get-pip.py
 # Junk from mocked-path tests that write to their mock's __repr__ as a path

--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ OpenJarvis is that stack. It is a framework for local-first personal AI, built a
 curl -fsSL https://openjarvis.ai/install.sh | bash
 ```
 
+> **If you see `sslv3 alert handshake failure` on `openjarvis.ai`** ([issue #337](https://github.com/open-jarvis/OpenJarvis/issues/337)), use the GitHub mirror until the domain is restored:
+>
+> ```bash
+> curl -fsSL https://raw.githubusercontent.com/open-jarvis/OpenJarvis/main/scripts/install/install.sh | bash
+> ```
+>
+> Same script, served straight from this repo. The installer itself fetches everything else (uv, the project source, Ollama) from independent CDNs, so the rest of install proceeds normally.
+
 That's it. The installer handles everything: uv, the Python venv, Ollama, and pulling a small starter model. About 3 minutes on a typical broadband connection. Then:
 
 ```bash

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -6,6 +6,18 @@ OpenJarvis ships a one-line installer for macOS, Linux, and WSL2.
 curl -fsSL https://openjarvis.ai/install.sh | bash
 ```
 
+!!! warning "`openjarvis.ai` SSL fallback (issue #337)"
+    If `curl` fails on `openjarvis.ai` with `sslv3 alert handshake failure`,
+    fetch the same script from the GitHub mirror until the domain is restored:
+
+    ```bash
+    curl -fsSL https://raw.githubusercontent.com/open-jarvis/OpenJarvis/main/scripts/install/install.sh | bash
+    ```
+
+    The installer itself pulls everything else (uv, the project source,
+    Ollama) from independent CDNs (`astral.sh`, `github.com`,
+    `ollama.com`), so the rest of install proceeds normally.
+
 About 3 minutes on a typical broadband connection. Type `jarvis` to start chatting.
 
 ## What the installer does

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -643,12 +643,25 @@ async fn boot_backend(backend: SharedBackend, status: SharedStatus) {
 
     let root = project_root.as_ref().unwrap();
 
-    // Install dependencies automatically (handles fresh clones)
+    // Install dependencies automatically (handles fresh clones).
+    //
+    // Previously we ran `uv sync` with both stdout AND stderr piped to
+    // /dev/null and discarded the exit code (`let _ = …`). When `uv sync`
+    // failed — Windows path issues, network problems, lockfile conflicts —
+    // the user saw no error, the boot continued, `uv run jarvis serve`
+    // then ran in an under-provisioned venv, and the user waited the full
+    // 600s health-check window before getting "Jarvis server did not
+    // become healthy in time" with no actionable detail (issue #331).
+    //
+    // Now: capture stderr, check the exit status, surface a useful error
+    // to the user BEFORE the long server-start wait. The status detail
+    // message also indicates this can take a couple of minutes on first
+    // boot so users don't restart the app thinking it's stuck.
     {
         let mut s = status.lock().await;
-        s.detail = "Installing dependencies...".into();
+        s.detail = "Installing dependencies (uv sync — may take 1-2 min on first boot)...".into();
     }
-    let _ = tokio::process::Command::new(&uv_bin)
+    let sync_output = tokio::process::Command::new(&uv_bin)
         .args([
             "sync",
             "--extra", "server",
@@ -656,10 +669,47 @@ async fn boot_backend(backend: SharedBackend, status: SharedStatus) {
             "--extra", "inference-google",
         ])
         .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
+        .stderr(std::process::Stdio::piped())
         .current_dir(root)
-        .status()
+        .output()
         .await;
+    match sync_output {
+        Ok(out) if !out.status.success() => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            // Take the last ~800 chars — uv's most useful diagnostic line
+            // is usually at the tail of the stream.
+            let tail: String = stderr
+                .chars()
+                .rev()
+                .take(800)
+                .collect::<String>()
+                .chars()
+                .rev()
+                .collect();
+            let mut s = status.lock().await;
+            s.error = Some(format!(
+                "`uv sync` failed in {} (exit {}). Last output:\n\n{}\n\n\
+                 Try opening a terminal in that directory and running \
+                 `uv sync --extra server` manually for the full output.",
+                root.display(),
+                out.status.code().unwrap_or(-1),
+                tail.trim(),
+            ));
+            return;
+        }
+        Err(e) => {
+            let mut s = status.lock().await;
+            s.error = Some(format!(
+                "Could not run `uv sync`: {}. Verify uv is installed at \
+                 `{}` and the OpenJarvis repo is at `{}`.",
+                e,
+                uv_bin,
+                root.display(),
+            ));
+            return;
+        }
+        Ok(_) => {} // success — fall through
+    }
 
     {
         let mut s = status.lock().await;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "httpx>=0.27",
     "openai>=1.30",
     "posthog>=3.0",
-    "pynvml>=13.0.1",
+    "nvidia-ml-py>=12.560.30",
     "python-telegram-bot>=22.6",
     "rich>=13",
     "tomli>=2.0; python_version < '3.11'",
@@ -80,10 +80,10 @@ server = [
     "python-multipart>=0.0.9",
 ]
 openhands = ["openhands-sdk>=1.0; python_version >= '3.12'"]
-gpu-metrics = ["pynvml>=12.0"]
+gpu-metrics = ["nvidia-ml-py>=12.560.30"]
 energy-amd = ["amdsmi>=6.1"]
 energy-apple = ["zeus-ml[apple]"]
-energy-all = ["pynvml>=12.0", "amdsmi>=6.1", "zeus-ml[apple]"]
+energy-all = ["nvidia-ml-py>=12.560.30", "amdsmi>=6.1", "zeus-ml[apple]"]
 orchestrator-training = ["torch>=2.0", "transformers>=4.40"]
 learning-dspy = ["dspy>=2.6"]
 learning-gepa = ["gepa>=0.1"]

--- a/src/openjarvis/evals/backends/external/_subprocess_runner.py
+++ b/src/openjarvis/evals/backends/external/_subprocess_runner.py
@@ -201,7 +201,15 @@ class _NullSampler(_Sampler):
 
 def _try_start_nvml() -> Optional[_Sampler]:
     try:
-        import pynvml  # type: ignore
+        # Suppress legacy pynvml deprecation FutureWarning (#389).
+        import warnings as _warnings
+        with _warnings.catch_warnings():
+            _warnings.filterwarnings(
+                "ignore",
+                message=r"The pynvml package is deprecated.*",
+                category=FutureWarning,
+            )
+            import pynvml  # type: ignore
 
         pynvml.nvmlInit()
         handle = pynvml.nvmlDeviceGetHandleByIndex(0)

--- a/src/openjarvis/server/research_router.py
+++ b/src/openjarvis/server/research_router.py
@@ -149,7 +149,15 @@ class _LiveGPUSampler:
         self._t_start = 0.0
         self._t_last = 0.0
         try:
-            import pynvml  # type: ignore
+            # Suppress legacy pynvml deprecation FutureWarning (#389).
+            import warnings as _warnings
+            with _warnings.catch_warnings():
+                _warnings.filterwarnings(
+                    "ignore",
+                    message=r"The pynvml package is deprecated.*",
+                    category=FutureWarning,
+                )
+                import pynvml  # type: ignore
 
             pynvml.nvmlInit()
             count = pynvml.nvmlDeviceGetCount()

--- a/src/openjarvis/telemetry/energy_nvidia.py
+++ b/src/openjarvis/telemetry/energy_nvidia.py
@@ -17,7 +17,16 @@ from openjarvis.telemetry.energy_monitor import (
 logger = logging.getLogger(__name__)
 
 try:
-    import pynvml
+    # See gpu_monitor.py for the rationale — suppress the legacy
+    # `pynvml` package's deprecation FutureWarning narrowly (#389).
+    import warnings
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=r"The pynvml package is deprecated.*",
+            category=FutureWarning,
+        )
+        import pynvml
 
     _PYNVML_AVAILABLE = True
 except ImportError:

--- a/src/openjarvis/telemetry/gpu_monitor.py
+++ b/src/openjarvis/telemetry/gpu_monitor.py
@@ -12,7 +12,20 @@ from typing import Dict, Generator, List, Optional
 logger = logging.getLogger(__name__)
 
 try:
-    import pynvml
+    # The legacy `pynvml` PyPI package installs a meta-path-finder shim
+    # that prints a FutureWarning on every `import pynvml`, even though
+    # our pyproject.toml depends on `nvidia-ml-py` (the official NVIDIA
+    # package, same module name, no shim). The warning still fires if
+    # `pynvml` gets pulled in transitively by torch/vllm/etc. Suppress
+    # it narrowly here so user output stays clean (issue #389).
+    import warnings
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=r"The pynvml package is deprecated.*",
+            category=FutureWarning,
+        )
+        import pynvml
     _PYNVML_AVAILABLE = True
 except ImportError:
     _PYNVML_AVAILABLE = False

--- a/uv.lock
+++ b/uv.lock
@@ -4980,9 +4980,9 @@ dependencies = [
     { name = "datasets" },
     { name = "ddgs" },
     { name = "httpx" },
+    { name = "nvidia-ml-py" },
     { name = "openai" },
     { name = "posthog" },
-    { name = "pynvml" },
     { name = "python-telegram-bot" },
     { name = "rich" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
@@ -5066,7 +5066,7 @@ docs = [
 ]
 energy-all = [
     { name = "amdsmi" },
-    { name = "pynvml" },
+    { name = "nvidia-ml-py" },
     { name = "zeus-ml" },
 ]
 energy-amd = [
@@ -5086,7 +5086,7 @@ framework-comparison = [
     { name = "polars" },
 ]
 gpu-metrics = [
-    { name = "pynvml" },
+    { name = "nvidia-ml-py" },
 ]
 inference-cloud = [
     { name = "anthropic" },
@@ -5222,6 +5222,9 @@ requires-dist = [
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.25" },
     { name = "mlx-lm", marker = "sys_platform == 'darwin' and extra == 'inference-mlx'", specifier = ">=0.31.1" },
     { name = "numpy", marker = "extra == 'memory-faiss'", specifier = ">=1.24" },
+    { name = "nvidia-ml-py", specifier = ">=12.560.30" },
+    { name = "nvidia-ml-py", marker = "extra == 'energy-all'", specifier = ">=12.560.30" },
+    { name = "nvidia-ml-py", marker = "extra == 'gpu-metrics'", specifier = ">=12.560.30" },
     { name = "openai", specifier = ">=1.30" },
     { name = "openai", marker = "extra == 'inference-cloud'", specifier = ">=1.30" },
     { name = "openai", marker = "extra == 'media'", specifier = ">=1.30" },
@@ -5237,9 +5240,6 @@ requires-dist = [
     { name = "pygemma", marker = "extra == 'inference-gemma'", specifier = ">=0.1.3" },
     { name = "pymessenger", marker = "extra == 'channel-messenger'", specifier = ">=0.0.7" },
     { name = "pynostr", marker = "extra == 'channel-nostr'", specifier = ">=0.6" },
-    { name = "pynvml", specifier = ">=13.0.1" },
-    { name = "pynvml", marker = "extra == 'energy-all'", specifier = ">=12.0" },
-    { name = "pynvml", marker = "extra == 'gpu-metrics'", specifier = ">=12.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5" },
@@ -6872,18 +6872,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/46/cc/f1caeadc85bb975e425ee2b6ceeb1f2cdbc1d849bbdced9cdfbc50f9baa7/pynostr-0.7.0.tar.gz", hash = "sha256:05566e18ae0ba467ba1ac6b29d82c271e4ba618ff176df5e56d544c3dee042ba", size = 54696, upload-time = "2025-08-07T05:57:13.743Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/aa/5e/cbcbba2be3acdc9ffce2c109f7d6296fbe2918b170a56f5742b07e000e49/pynostr-0.7.0-py3-none-any.whl", hash = "sha256:9407a64f08f29ec230ff6c5c55404fe6ad77fef1eacf409d03cfd5508ca61834", size = 37829, upload-time = "2025-08-07T05:57:12.945Z" },
-]
-
-[[package]]
-name = "pynvml"
-version = "13.0.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "nvidia-ml-py" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/57/da7dc63a79f59e082e26a66ac02d87d69ea316b35b35b7a00d82f3ce3d2f/pynvml-13.0.1.tar.gz", hash = "sha256:1245991d9db786b4d2f277ce66869bd58f38ac654e38c9397d18f243c8f6e48f", size = 35226, upload-time = "2025-09-05T20:33:25.377Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/4a/cac76c174bb439a0c46c9a4413fcbea5c6cabfb01879f7bbdb9fdfaed76c/pynvml-13.0.1-py3-none-any.whl", hash = "sha256:e2b20e0a501eeec951e2455b7ab444759cf048e0e13a57b08049fa2775266aa8", size = 28810, upload-time = "2025-09-05T20:33:24.13Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Four fixes that together unblock the next PyPI + desktop release. Three
production-breaking issues + one diagnostic improvement. Also addresses
one already-fixed issue and surfaces context on one external bug.

## Fixes in this PR

### #372 — `traces/` missing from PyPI wheel (P0)

Reported by @gilbert-barajas. Every fresh `pip install openjarvis==1.0.1`
failed with `ModuleNotFoundError: No module named 'openjarvis.traces'`
on first use of `jarvis ask`, learning, or the server.

**Root cause** — `.gitignore` had unanchored `traces/`. hatchling
respects `.gitignore` when building the wheel, so it matched the
runtime module at `src/openjarvis/traces/` and silently dropped the
whole package.

**Fix** — anchor to `/traces/` (top-level only). Added a comment so
the gotcha doesn't recur. Wheel build verified: now ships all 4 files
(`__init__.py`, `analyzer.py`, `collector.py`, `store.py`).

### #389 — `pynvml` deprecation `FutureWarning` on every startup (P2)

Reported by @boeani05. The legacy `pynvml` v13.x PyPI package installs
a meta-path-finder that warns on every `import pynvml`.

**Fix**:
1. **`pyproject.toml`**: switch `pynvml>=13.0.1` → `nvidia-ml-py>=12.560.30`
   (NVIDIA's official package, same module name, no warning shim).
2. **Defensive filters** at all 4 `import pynvml` sites with a
   narrowly-scoped `warnings.filterwarnings("ignore", message=r"The pynvml package is deprecated.*", category=FutureWarning)`
   for transitive pulls from torch/vllm/etc.

Verified: `jarvis --version` is silent; `simplefilter("error", FutureWarning)`
test passes.

### #337 + #352 — `openjarvis.ai` SSL handshake failure (P1, infra)

Reported by @kumanday and @filactre. `curl ... https://openjarvis.ai/install.sh`
fails with `sslv3 alert handshake failure`. Reproduced from this
machine — the SSL issue is real and current.

This is an **operational issue on the openjarvis.ai server** (cert /
TLS config) that needs a fix at the infra layer, not in code.

**What this PR does** — adds a documented fallback in `README.md` and
`docs/getting-started/install.md`:
```
curl -fsSL https://raw.githubusercontent.com/open-jarvis/OpenJarvis/main/scripts/install/install.sh | bash
```
Same script, served from GitHub's CDN. Once the installer runs, it
fetches everything else from independent CDNs (`astral.sh`, `github.com`,
`ollama.com`) — `install.sh` makes zero further requests to openjarvis.ai.
When the SSL issue is fixed at the server layer, both callouts can be
removed.

### #331 — "Jarvis server did not become healthy in time" (P1, Windows)

Reported by @Hris4oG; same problem confirmed by @NatanelBranski,
@Robjes87, @EmiDaDuck. Discord support thread shows the pattern:
multiple Windows users stuck on "Starting api server" / health-check
timeout for 4+ minutes, with no actionable error.

**Root cause** — `frontend/src-tauri/src/lib.rs` ran `uv sync` with
**both** stdout AND stderr piped to `/dev/null` and discarded the exit
code (`let _ = …`). When `uv sync` failed for any reason (Windows PATH
issues, network, lockfile conflicts, stale `.venv/`), the user saw
nothing. Boot continued to `uv run jarvis serve` in an under-provisioned
venv, then hit the 600s health-check window with a generic "did not
start" message and no diagnostic.

**Fix** — capture stderr, check exit status, surface a useful error
**before** the long server-start wait:
- Exit code
- Last ~800 chars of `uv sync` stderr (where uv's diagnostic typically lives)
- Concrete next step (run `uv sync --extra server` manually for full output)

Also updated the status detail to indicate `uv sync` can take 1-2 min
on first boot so users don't restart thinking it's stuck.

The community workaround documented in Discord (uninstall, install Feb
pre-release, run a magic `irm` PowerShell command for uv) is the right
diagnosis applied without diagnostic output — this commit makes that
diagnostic output visible so users can self-diagnose in seconds rather
than via Discord support.

Note: this fix lands in the desktop binary's source. Users on the
v1.0.1 desktop binary won't see the improved error message until the
desktop release is re-cut. Until then, the `openjarvis.ai` fallback
(above) gets new users past the initial install step.

## Already-fixed issues this PR also resolves

### #373 — Windows RAM detection broken

Already fixed on `main` by @TX-Huang's PR #293 (commit `31efd9e6`, via
consolidation PR #362). Reporter is on v1.0.1 PyPI which doesn't have
that fix. Cutting v1.0.2 from this branch automatically resolves it.

## Not addressed (different issue)

### #391 — Memory extraction BrokenPipe with Ollama

Reporter (@boeani05) describes a memory server on port 7734 POSTing
to Ollama `/extract`. Searched the codebase: OpenJarvis doesn't ship
this endpoint, doesn't bind port 7734, doesn't write to `facts.json`.
External memory server (third-party or user's own). Leaving a courtesy
comment on the issue asking for clarification.

## Test plan

- [x] `uv run ruff check src/ tests/` → clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (Python's Rust ext) → clean
- [x] `uv run pytest tests/ -m 'not live and not cloud'` → **6756 passed**,
      same 3 baseline failures + 6 environmental errors as main. **Zero regressions.**
- [x] `uv build --wheel` → wheel contains `openjarvis/traces/{__init__.py, analyzer.py, collector.py, store.py}`
- [x] `jarvis --version` and `jarvis doctor` → no FutureWarning
- [x] Markdown for both install-fallback callouts inspected; raw GitHub
      URL serves the same install.sh (verified server-side)
- [x] Tauri fix is straightforward Rust with no new imports. Local
      `cargo check` on frontend/src-tauri fails on an unrelated
      transitive (toml_edit on this machine's Rust toolchain), not my
      change. CI will compile it on the supported toolchain.

## After merge

The PyPI v1.0.2 release (build + upload) requires PyPI credentials
I don't have. Recommended:
```bash
git clean -fdx
uv build
unzip -l dist/openjarvis-1.0.2-*.whl | grep traces  # verify
python -m twine upload dist/openjarvis-1.0.2-*
```

Re-cut the desktop release from this branch too so #331's diagnostic
improvement reaches Windows users. A GitHub Release with the wheel
attached (none exists for v1.0.1) would let users sanity-check artifact
contents — what made #372 hard to diagnose initially.

Separately, the `openjarvis.ai` SSL issue needs a fix at the infra
layer so the README's primary install command works again. This PR
only adds a fallback; the canonical URL stays unchanged in the docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
