### PR TITLE
fix(install): serve install.sh from GitHub Pages as canonical URL (closes #337, #352)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,10 @@ OpenJarvis is that stack. It is a framework for local-first personal AI, built a
 **macOS / Linux:**
 
 ```bash
-curl -fsSL https://openjarvis.ai/install.sh | bash
+curl -fsSL https://open-jarvis.github.io/OpenJarvis/install.sh | bash
 ```
+
+The installer handles everything for you — including [uv](https://docs.astral.sh/uv/), the Python venv, Ollama, and a small starter model. You don't need to install anything first.
 
 **Windows:** the installer is a `bash` script and won't run in PowerShell or `cmd`. Pick one of:
 
@@ -44,17 +46,12 @@ curl -fsSL https://openjarvis.ai/install.sh | bash
   wsl --install -d Ubuntu-24.04
   ```
   Open the Ubuntu shell that gets installed, then follow [WSL2 install instructions](https://open-jarvis.github.io/OpenJarvis/getting-started/wsl2/).
-- **Desktop app** — download the `.exe` from the [Releases page](https://github.com/open-jarvis/OpenJarvis/releases) for the GUI experience, no terminal required.
+- **Desktop app** — download the `.exe` from the [Releases page](https://github.com/open-jarvis/OpenJarvis/releases) for the GUI experience, no terminal required. **Prerequisite:** the desktop app expects [uv](https://docs.astral.sh/uv/) to be installed already — if it isn't, install it first in PowerShell, then launch the app:
+  ```powershell
+  powershell -ExecutionPolicy Bypass -c "irm https://astral.sh/uv/install.ps1 | iex"
+  ```
 
-> **If `curl` fails on `openjarvis.ai` with `sslv3 alert handshake failure`** ([issue #337](https://github.com/open-jarvis/OpenJarvis/issues/337)), use the GitHub mirror until the domain is restored:
->
-> ```bash
-> curl -fsSL https://raw.githubusercontent.com/open-jarvis/OpenJarvis/main/scripts/install/install.sh | bash
-> ```
->
-> Same script, served straight from this repo. The installer itself fetches everything else (uv, the project source, Ollama) from independent CDNs, so the rest of install proceeds normally.
-
-That's it. The installer handles everything: uv, the Python venv, Ollama, and pulling a small starter model. About 3 minutes on a typical broadband connection. Then:
+About 3 minutes on a typical broadband connection. Then:
 
 ```bash
 jarvis
@@ -69,7 +66,7 @@ The Rust extension and bigger models continue downloading in the background whil
 ## Quick Start
 
 ```bash
-curl -fsSL https://openjarvis.ai/install.sh | bash
+curl -fsSL https://open-jarvis.github.io/OpenJarvis/install.sh | bash
 jarvis
 ```
 

--- a/docs/gen_install_script.py
+++ b/docs/gen_install_script.py
@@ -1,0 +1,21 @@
+"""Publish the canonical install.sh into the docs site.
+
+Serves the installer at ``https://open-jarvis.github.io/OpenJarvis/install.sh``
+so users have an HTTPS-valid, project-controlled install URL that does not
+depend on the externally-hosted ``openjarvis.ai`` domain — whose TLS config
+broke and which the project does not control (issue #337).
+
+Single source of truth: the script lives at ``scripts/install/install.sh``
+(also bundled into the wheel as ``_install_scripts/``). This copies it
+verbatim into the built site at ``install.sh`` on every ``mkdocs build``,
+so the published copy can never drift from the canonical one.
+"""
+
+from pathlib import Path
+
+import mkdocs_gen_files
+
+_SRC = Path("scripts/install/install.sh")
+
+with mkdocs_gen_files.open("install.sh", "wb") as dst:
+    dst.write(_SRC.read_bytes())

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -3,20 +3,19 @@
 OpenJarvis ships a one-line installer for macOS, Linux, and WSL2.
 
 ```bash
-curl -fsSL https://openjarvis.ai/install.sh | bash
+curl -fsSL https://open-jarvis.github.io/OpenJarvis/install.sh | bash
 ```
 
-!!! warning "`openjarvis.ai` SSL fallback (issue #337)"
-    If `curl` fails on `openjarvis.ai` with `sslv3 alert handshake failure`,
-    fetch the same script from the GitHub mirror until the domain is restored:
+The installer downloads everything for you — including [uv](https://docs.astral.sh/uv/)
+(the Python package manager), the Python venv, Ollama, and a small starter
+model. **You don't need to install uv or any other prerequisite first.**
 
-    ```bash
-    curl -fsSL https://raw.githubusercontent.com/open-jarvis/OpenJarvis/main/scripts/install/install.sh | bash
-    ```
-
-    The installer itself pulls everything else (uv, the project source,
-    Ollama) from independent CDNs (`astral.sh`, `github.com`,
-    `ollama.com`), so the rest of install proceeds normally.
+!!! info "Install URL"
+    This script is served straight from the project's own GitHub Pages site,
+    so HTTPS always works. You may also see `https://openjarvis.ai/install.sh`
+    referenced in older docs — that domain is community-operated and has had
+    intermittent TLS issues ([#337](https://github.com/open-jarvis/OpenJarvis/issues/337)).
+    The `open-jarvis.github.io` URL above is the canonical one.
 
 About 3 minutes on a typical broadband connection. Type `jarvis` to start chatting.
 

--- a/docs/getting-started/linux.md
+++ b/docs/getting-started/linux.md
@@ -1,7 +1,7 @@
 # Linux Install
 
 ```bash
-curl -fsSL https://openjarvis.ai/install.sh | bash
+curl -fsSL https://open-jarvis.github.io/OpenJarvis/install.sh | bash
 ```
 
 Tested on: Ubuntu 22.04 / 24.04, Fedora 40, Debian 12, Arch.

--- a/docs/getting-started/macos.md
+++ b/docs/getting-started/macos.md
@@ -1,7 +1,7 @@
 # macOS Install
 
 ```bash
-curl -fsSL https://openjarvis.ai/install.sh | bash
+curl -fsSL https://open-jarvis.github.io/OpenJarvis/install.sh | bash
 ```
 
 Works on Intel and Apple Silicon. The installer auto-detects your CPU/GPU.

--- a/docs/getting-started/wsl2.md
+++ b/docs/getting-started/wsl2.md
@@ -15,7 +15,7 @@ Then open the Ubuntu (or Debian) shell that gets installed.
 ## Install OpenJarvis
 
 ```bash
-curl -fsSL https://openjarvis.ai/install.sh | bash
+curl -fsSL https://open-jarvis.github.io/OpenJarvis/install.sh | bash
 ```
 
 About 3 minutes. Type `jarvis` to start.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,7 @@ plugins:
   - gen-files:
       scripts:
         - docs/gen_ref_pages.py
+        - docs/gen_install_script.py
   - literate-nav:
       nav_file: SUMMARY.md
   - mkdocstrings:

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -2,7 +2,7 @@
 # install.sh — OpenJarvis curl-pipe-bash installer.
 #
 # Usage:
-#   curl -fsSL https://openjarvis.ai/install.sh | bash
+#   curl -fsSL https://open-jarvis.github.io/OpenJarvis/install.sh | bash
 #
 # Flags (only used in tests / power users):
 #   --no-bg-orchestrator   Skip the detached background orchestrator
@@ -49,9 +49,7 @@ OpenJarvis runs on Windows via WSL2. Two paths:
 
      Open the Ubuntu shell that gets installed, then re-run:
 
-       curl -fsSL https://openjarvis.ai/install.sh | bash
-
-     (or the github mirror — see README if openjarvis.ai is down.)
+       curl -fsSL https://open-jarvis.github.io/OpenJarvis/install.sh | bash
 
   2. Desktop app — download the .exe from the Releases page:
      https://github.com/open-jarvis/OpenJarvis/releases

--- a/scripts/install/jarvis-wrapper.sh
+++ b/scripts/install/jarvis-wrapper.sh
@@ -7,7 +7,7 @@ VENV="$OPENJARVIS_HOME/.venv"
 
 if [[ ! -d "$VENV" ]]; then
     echo "jarvis: venv not found at $VENV" >&2
-    echo "Re-run the installer: curl -fsSL https://openjarvis.ai/install.sh | bash" >&2
+    echo "Re-run the installer: curl -fsSL https://open-jarvis.github.io/OpenJarvis/install.sh | bash" >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

Resolves the `openjarvis.ai` SSL handshake failure (#337, #352) by moving
the installer onto infrastructure the project controls — the GitHub Pages
docs site — and making that the canonical install URL. Also closes the uv
discoverability gap surfaced in the Discord support threads.

### Why

`openjarvis.ai` is **community-operated, not controlled by this project**.
Its TLS config broke (reproduced: server sends `alert handshake failure`
with no peer certificate at all), so every `curl -fsSL https://openjarvis.ai/install.sh | bash`
fails. We can't fix a domain we don't own — so the fix is to stop depending
on it.

### What changed

**Installer now served from GitHub Pages** (`docs/gen_install_script.py` + `mkdocs.yml`)
- A `gen-files` hook copies `scripts/install/install.sh` verbatim into the
  built site at `install.sh` on every `mkdocs build`.
- New canonical URL: `https://open-jarvis.github.io/OpenJarvis/install.sh`
- Single source of truth: the script stays at `scripts/install/install.sh`
  (still bundled in the wheel); the published copy can't drift.
- Verified locally — `mkdocs build` emits `site/install.sh` byte-identical
  to the source.

**Canonical URL switched everywhere**
- `README.md` (Installation + Quick Start)
- `docs/getting-started/{install,wsl2,macos,linux}.md`
- `scripts/install/install.sh` (usage comment + WSL re-run hint)
- `scripts/install/jarvis-wrapper.sh` (re-install message)

**uv discoverability** (the second Discord ask)
- README now explicitly says the curl installer downloads uv for you (no
  prerequisite needed for the curl-pipe-bash path).
- The Windows **desktop .exe** path documents that uv must be installed
  first, with the exact `irm https://astral.sh/uv/install.ps1 | iex` command.
- `docs/getting-started/install.md` gains an "Install URL" note explaining
  github.io is canonical and openjarvis.ai is community-operated.

### What this does NOT do

Doesn't touch `openjarvis.ai` itself — that's outside our control. But there's
a clean migration path documented in the commit message: **ask whoever operates
openjarvis.ai to CNAME it to `open-jarvis.github.io`**. Once they do,
`openjarvis.ai/install.sh` serves this same GitHub Pages content with a valid
GitHub-managed cert, and the brand URL can become canonical again with zero
further code changes.

### Test plan

- [x] `mkdocs build` → `site/install.sh` produced, byte-identical to
      `scripts/install/install.sh`
- [x] `bash -n` on both modified shell scripts → syntax OK
- [x] `grep` confirms all *canonical* install commands now use the github.io
      URL; the only remaining `openjarvis.ai/install` reference is the
      explanatory note in `install.md` (intentional)
- [x] No Python source touched → no pytest regression risk

### After merge

1. The docs deploy workflow publishes `site/install.sh` to GitHub Pages
   automatically on push to main. Verify `curl -fsSL https://open-jarvis.github.io/OpenJarvis/install.sh | head` returns the script.
2. (Optional, recommended) Coordinate with the openjarvis.ai operator to
   CNAME the domain to `open-jarvis.github.io` so the brand URL works again
   with a valid cert.
3. #337 and #352 can be closed once the github.io URL is confirmed live
   post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)