### PR TITLE
ci: add windows-latest job to empirically verify Windows code paths (#373, #293)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,56 @@ jobs:
           path: coverage.xml
           if-no-files-found: warn
 
+  # Windows job — empirically exercises the platform-specific code paths that
+  # the Ubuntu `test` job can never reach: GlobalMemoryStatusEx RAM detection
+  # (#373) and the cp9xx -> UTF-8 stdout reconfigure (#293). Also the only CI
+  # job that builds + imports the mandatory `openjarvis_rust` PyO3 extension
+  # on Windows. Public repo -> Windows runner minutes are free.
+  #
+  # All `run:` steps use static commands only (no `github.event.*`
+  # interpolation), so there is no workflow-injection surface here.
+  test-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.0.0
+
+      - name: Install dependencies
+        run: uv sync --extra dev --extra server
+
+      # Pure-Python check — runs before the Rust build so a flaky toolchain
+      # install can never mask the actual RAM-detection verification.
+      - name: Verify Windows RAM detection (#373)
+        shell: bash
+        run: |
+          uv run python -c "from openjarvis.core.config import _total_ram_gb; ram = _total_ram_gb(); print(f'GlobalMemoryStatusEx RAM = {ram} GB'); assert ram > 0, f'Windows RAM detection returned {ram}, expected > 0'"
+
+      - name: Run Windows-specific tests (hardware + CLI)
+        shell: bash
+        run: |
+          uv run pytest tests/hardware/test_hardware_profiles.py tests/cli/test_cli.py -v -m "not live and not cloud"
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build + import the PyO3 extension on Windows
+        shell: bash
+        run: |
+          uv run maturin develop --manifest-path rust/crates/openjarvis-python/Cargo.toml
+          uv run python -c "import openjarvis_rust; print('openjarvis_rust imports on Windows OK')"
+
+      - name: Smoke-test CLI
+        shell: bash
+        run: |
+          uv run jarvis --version
+
   rust:
     runs-on: ubuntu-latest
     defaults:


### PR DESCRIPTION
## Summary

The `test` job in `ci.yml` runs only on `ubuntu-latest`, so the
Windows-specific branches we added for **#373** (RAM detection via
`GlobalMemoryStatusEx`) and **#293** (cp9xx → UTF-8 stdout reconfigure)
were never *executed* in CI — only unit-tested with mocks on Linux.

`tests/hardware/test_hardware_profiles.py::test_total_ram_gb_windows`
has existed all along but is `@pytest.mark.skipif(sys.platform != "win32")`,
so it silently skipped on every Ubuntu run. This job makes it actually run.

This directly closes the empirical-verification gap I flagged: from a
Mac/Linux box you can't run the Windows `ctypes.windll` path, but a
`windows-latest` runner (free for public repos) can — and now does, on
every PR and push to main, as a permanent regression guard.

## What the `test-windows` job does

1. **Verifies `_total_ram_gb()` > 0 on real Windows** — executes the
   actual `GlobalMemoryStatusEx` path (#373). Runs as a pure-Python
   step *before* any Rust build, so a flaky toolchain install can't
   mask the result.
2. **Runs the Windows-specific tests** — `tests/hardware/test_hardware_profiles.py`
   (the now-unskipped RAM test) and `tests/cli/test_cli.py` (the
   `test_windows_reconfigures_stdout_to_utf8` test from #293).
3. **Builds + imports `openjarvis_rust` on Windows** — the only CI job
   that does. The PyO3 extension is mandatory at runtime
   (`_rust_bridge.py` hard-errors without it), yet nothing previously
   verified it compiles/imports on Windows. (`desktop.yml` builds the
   Tauri app's Rust, not this extension.)
4. **Smoke-tests `jarvis --version`.**

Scoped to the platform-relevant test files (not the full 6700-test
suite) to keep the job fast; the Rust build is the slow part and
doubles as Windows-extension-build coverage.

## The real test plan

The point of this PR *is* the test plan: **watch the `test-windows`
check go green on a real Windows runner.** If it passes, #373 is
empirically verified on the platform that matters (not just mocked on
Linux). If the RAM step fails, we'd have caught a real Windows
regression that the Ubuntu suite structurally cannot.

- All `run:` steps are static commands — no `github.event.*`
  interpolation, no workflow-injection surface.
- YAML validated locally (`yaml.safe_load` → jobs: lint, test,
  test-windows, rust).

## Not included

**#331** (desktop "Jarvis server did not become healthy in time" —
the uv-sync error surfacing) is GUI-triggered Tauri boot logic. Its
only automatable surface is the error-string formatting, and running
`cargo test` on the Tauri crate pulls in the heavy webview build
deps — disproportionate for the value. Genuinely verifying #331 needs
a human running the rebuilt desktop app with a broken uv. Left as a
possible follow-up (extract `format_uv_sync_failure()` + unit test) if
you want it.

## Follow-up idea

If this job proves stable, consider promoting it to a small matrix
(`windows-latest` + `macos-latest`) so the macOS `sysctl` RAM branch
and any other platform-specific paths get the same treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)