### PR TITLE
release: v1.0.2 — fix broken PyPI wheel (#372) + pynvml/Windows/install fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,61 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.0.2] - 2026-05-24
+
+A patch release that fixes a packaging bug which broke the v1.0.1
+wheel on PyPI, silences a noisy startup warning, restores a working
+install path while `openjarvis.ai` is down, improves desktop
+first-boot diagnostics on Windows, and ships the RAM-detection fix
+for Windows that missed the v1.0.1 cutoff.
+
+### Fixed
+
+**`openjarvis/traces/` missing from the v1.0.1 PyPI wheel** (#372).
+The `.gitignore` carried an unanchored `traces/` pattern, which
+hatchling honored at wheel-build time and matched the runtime module
+`src/openjarvis/traces/` — silently dropping the whole package. Every
+fresh `pip install openjarvis==1.0.1` then failed at import with
+`ModuleNotFoundError: No module named 'openjarvis.traces'` on the
+first `jarvis ask`, learning, or server call. Anchored the pattern to
+`/traces/`. Verified: a clean `uv build` now produces a wheel
+containing all four `traces/` files.
+
+**`pynvml` deprecation `FutureWarning` on every command** (#389).
+Switched the dependency from the legacy `pynvml` package to NVIDIA's
+official `nvidia-ml-py` (same `pynvml` module name, no warning shim),
+and added defensive `warnings.filterwarnings` at every `import pynvml`
+site to suppress the warning even when `pynvml` is pulled in
+transitively.
+
+**Windows RAM detection returning `0.0 GB`** (#373). The Windows
+branch of `_total_ram_gb()` (via `GlobalMemoryStatusEx`) landed after
+the v1.0.1 cutoff, so v1.0.1 users still saw `0.0 GB` from `jarvis
+init`. Now shipping in the wheel. A new `windows-latest` CI job runs
+the real `GlobalMemoryStatusEx` path on every PR as a regression
+guard.
+
+**Desktop first-boot hung on "did not become healthy in time"**
+(#331). The Tauri boot path ran `uv sync` with stderr discarded and
+the exit code ignored, so a failed dependency install surfaced only
+as a generic 600-second health-check timeout. Now captures stderr,
+checks the exit status, and surfaces the actual `uv sync` error
+(with the diagnostic tail) before the long wait. The error-formatting
+logic is covered by unit tests.
+
+### Changed
+
+**Install URL moved to GitHub Pages** (#337, #352). The documented
+`openjarvis.ai/install.sh` URL was failing with `sslv3 alert
+handshake failure` (the domain is community-operated and had a broken
+TLS config). The canonical installer is now served from the
+project-controlled GitHub Pages site at
+`https://open-jarvis.github.io/OpenJarvis/install.sh`, generated from
+the same `scripts/install/install.sh` at docs-build time. The README
+also documents the WSL2 path for Windows and the `uv` prerequisite
+for the desktop binary, and the installer bails early with a clear
+message when run under Git Bash / MSYS2 / Cygwin.
+
 ## [1.0.1] - 2026-05-17
 
 A patch release that closes the auto-update gap so the analytics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "OpenJarvis"
-version = "1.0.1"
+version = "1.0.2"
 description = "OpenJarvis — modular AI assistant backend with composable intelligence primitives"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Bumps the version **1.0.1 → 1.0.2** and adds the CHANGELOG entry, so
the fixes merged since v1.0.1 can actually ship to PyPI.

**Why a new version is required:** the headline fix is #372 — the
v1.0.1 wheel on PyPI is missing `openjarvis/traces/`, so every
`pip install openjarvis==1.0.1` breaks at import. PyPI filenames are
immutable; you can't re-upload `1.0.1`, so the fix must ship as `1.0.2`.

## What's in 1.0.2 (all already merged to `main`)

- **#372** — `openjarvis/traces/` missing from the wheel (the
  `.gitignore` `traces/` pattern matched the runtime module). Anchored
  to `/traces/`.
- **#389** — `pynvml` deprecation `FutureWarning` on every command.
  Switched to `nvidia-ml-py` + defensive warning filters.
- **#373** — Windows RAM detection returning `0.0 GB`. The
  `GlobalMemoryStatusEx` fix now ships in the wheel; a `windows-latest`
  CI job guards it.
- **#331** — desktop first-boot "did not become healthy in time".
  `uv sync` errors now surface before the long health-check wait.
- **#337 / #352** — install URL moved to the project-controlled
  GitHub Pages site (`openjarvis.ai` SSL is broken and community-operated).

## This PR

Two-line functional change (`pyproject.toml` version) plus the
CHANGELOG entry. No code changes — everything it documents is already
on `main`.

## Release steps after merge

```bash
uv build
unzip -l dist/openjarvis-1.0.2-py3-none-any.whl | grep traces   # expect 4 files
twine upload dist/openjarvis-1.0.2-*
```

Recommend also tagging `v1.0.2` and cutting a GitHub Release with the
wheel attached — v1.0.1 has no GitHub Release, only a PyPI artifact,
which is part of what made #372 hard to diagnose. (Do **not** use
`git clean -fdx` to clean before building — `-x` wipes `.venv`; `uv
build` already builds in isolation.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)