### PR TITLE
fix(desktop): surface backend error frames in Deep Research stream

### DIFF
--- a/frontend/src/components/Chat/InputArea.tsx
+++ b/frontend/src/components/Chat/InputArea.tsx
@@ -308,6 +308,23 @@ export function InputArea() {
               energy_j: ev.energy_j,
               duration_s: ev.duration_s,
             });
+          } else if (ev.type === 'error') {
+            // Backend setup/worker failure (Ollama down, planner model
+            // missing, KnowledgeStore locked, etc.). Without surfacing the
+            // message, the user sees only the generic "No response was
+            // generated" fallback and has no way to self-diagnose.
+            const msg = ev.message || 'Research failed (no detail provided)';
+            accumulatedContent = accumulatedContent
+              ? `${accumulatedContent}\n\n**Research stopped:** ${msg}`
+              : `**Research failed:** ${msg}`;
+            setStreamState({ content: accumulatedContent, phase: '' });
+            useAppStore.getState().addLogEntry({
+              timestamp: Date.now(),
+              level: 'error',
+              category: 'chat',
+              message: `Deep Research error: ${msg}`,
+            });
+            toast.error(msg, { duration: 8000 });
           } else if (ev.type === 'done') {
             if (ev.usage) {
               usage = {


### PR DESCRIPTION
## Summary
Toggling Deep Research on the desktop currently shows only **"No response was generated. Please try again."** (in ~50ms) whenever the backend fails — with zero indication of *why*. The user is stranded.

## Before / After

**Before** (any backend failure — model 404, Ollama down, KnowledgeStore locked, etc.):

> No response was generated. Please try again.

That's it. Same string for every failure mode. No way to self-diagnose, no way for support to triage without server logs.

**After** (same failure surfaces the real reason in three places):

- Chat bubble: **`Research failed: RuntimeError: Ollama returned 404: {"error":"model 'gemma4:31b' not found"}`**
- Sonner toast (8s): `RuntimeError: Ollama returned 404: {"error":"model 'gemma4:31b' not found"}`
- Log panel: `[error] [chat] Deep Research error: RuntimeError: Ollama returned 404: ...`

(Repro for the example above: fresh install — `DEFAULT_PLANNER_MODEL = "gemma4:31b"` isn't pulled by the installer, so the very first Deep Research call 404s. That's how I found this bug in the first place.)

## Root cause
`research_router._stream_research` emits a clean two-frame `error` + `done` envelope on every failure path:
- Phase-1 setup crash (Ollama daemon, embedder, KnowledgeStore): [research_router.py:333](https://github.com/open-jarvis/OpenJarvis/blob/main/src/openjarvis/server/research_router.py#L333)
- Worker thread crash mid-run (planner Ollama 404, agent exception): [research_router.py:395](https://github.com/open-jarvis/OpenJarvis/blob/main/src/openjarvis/server/research_router.py#L395)
- Consumer-loop crash (rare): [research_router.py:447](https://github.com/open-jarvis/OpenJarvis/blob/main/src/openjarvis/server/research_router.py#L447)

All three produce `{"type":"error","message":"..."}` followed by `{"type":"done"}`.

The desktop SSE consumer in `InputArea.tsx` handles `search_call`, `search_result`, `synthesis`, `system_metrics`, and `done` — but has no branch for `error`. The frame is silently dropped, the `done` `break`s the loop, `accumulatedContent` is still empty, and the `finally` fallback writes the generic message.

The `ResearchEvent` discriminated union [already declares `{type:'error',message:string}`](https://github.com/open-jarvis/OpenJarvis/blob/main/frontend/src/types/index.ts#L110) — the type is there, just unused.

## Fix
One `else if` clause in the Deep Research SSE loop:
- Prepends **"Research failed: \<msg\>"** to the assistant bubble if nothing has streamed yet.
- Appends **"Research stopped: \<msg\>"** if the error arrives mid-synthesis (preserves partial output).
- Logs to the chat-category log panel.
- Raises an 8s sonner toast so the failure is visible even with the log panel collapsed.

No type or backend changes — purely surfacing what's already on the wire.

## Test plan
- [x] Reproduce on local install (planner model not pulled) → now shows backend error text in chat + toast instead of the silent fallback.
- [ ] Sanity-check mid-stream worker crash path (kill Ollama after first `search_call`) → expect partial output preserved with a "Research stopped:" note appended.
- [ ] Confirm log panel records `Deep Research error: <msg>` under chat category.