### PR TITLE
fix(packaging): cap requires-python to <3.14 for Windows numpy wheels (#350)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,13 +90,20 @@ jobs:
   # interpolation), so there is no workflow-injection surface here.
   test-windows:
     runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # 3.12 = common; 3.13 = the supported ceiling — installing there guards
+        # against a numpy/native wheel gap at the top of the range (#350), which
+        # is exactly how the source-build failure slips in on Windows.
+        python-version: ["3.12", "3.13"]
     steps:
       - uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.0.0

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -94,7 +94,7 @@ cd OpenJarvis
 
 The script handles everything:
 
-1. Checks for Python 3.10+ and Node.js 18+
+1. Checks for Python 3.10–3.13 and Node.js 18+
 2. Installs Ollama if not present and pulls a starter model
 3. Installs Python and frontend dependencies
 4. Starts the backend API server and frontend dev server

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -238,7 +238,7 @@ See the [Python SDK guide](../user-guide/python-sdk.md) for the full API referen
 
 | Requirement | Version | Install | Notes |
 |-------------|---------|---------|-------|
-| Python | 3.10+ | [python.org](https://www.python.org/downloads/) | Required |
+| Python | 3.10–3.13 | [python.org](https://www.python.org/downloads/) | Required. 3.14+ not yet supported (a core dependency lacks 3.14 wheels). |
 | uv | latest | `curl -LsSf https://astral.sh/uv/install.sh \| sh` or `brew install uv` (macOS) | Python package & project manager |
 | Git | any | [git-scm.com](https://git-scm.com/) or `brew install git` (macOS) | Required |
 | Rust | stable | `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \| sh` | Required for the Rust extension |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,11 @@ name = "OpenJarvis"
 version = "0.1.1"
 description = "OpenJarvis — modular AI assistant backend with composable intelligence primitives"
 readme = "README.md"
-requires-python = ">=3.10"
+# Upper bound: numpy 2.2.x (pinned transitively via datasets/pandas) ships no
+# cp314 Windows wheel, so under Python 3.14 uv would compile numpy from source
+# (Meson) and fail on Windows boxes without a C toolchain (#350). Cap to the
+# range that has prebuilt wheels; matches the classifiers (3.10–3.13).
+requires-python = ">=3.10,<3.14"
 license = {text = "Apache-2.0"}
 authors = [
     {name = "Open Jarvis Contributors"},


### PR DESCRIPTION
Closes #350.

## Problem (verified)
On Windows under **Python 3.14**, `uv sync` (run by `jarvis serve` and the desktop launcher's preflight) tries to **compile numpy from source** via Meson and fails — `Failed to build numpy==2.2.6 … mesonpy.build_wheel failed` — because numpy 2.2.x (pulled in transitively by `datasets`/`pandas`, so it's on *every* install path) ships **no cp314 Windows wheel**, and `requires-python = ">=3.10"` had no upper bound. The desktop shell surfaces this as "Server failed to start".

The project already targets 3.10–3.13 (classifiers) and documents native Windows as unsupported — the missing ceiling is the bug.

## Fix (minimal, low-risk)
- `pyproject.toml`: `requires-python = ">=3.10,<3.14"` → uv now **rejects 3.14 with a clear message** instead of attempting a C-toolchain build. Enforced at resolve time, so it works regardless of the lockfile.
- `.github/workflows/ci.yml`: add **Python 3.13** (the supported ceiling) to the `test-windows` matrix, so a future numpy/native-wheel gap at the top of the range is caught (today it only ran 3.12, which has a wheel and was blind to this).
- docs: supported Python stated as **3.10–3.13**.

The numpy-floor bump (an alternative) was evaluated and **dropped** — low confidence (CI already proves 2.2.6 works on Win 3.12; the gap is specifically the 3.14 wheel, not the version).

## Note on uv.lock
Deliberately **not** regenerated here: the committed lock is already stale on `main` (pins `openjarvis 1.0.2` while `pyproject` is `0.1.1`), so `uv lock` re-resolves a large amount of unrelated drift (drops `ray`, re-collapses vllm/transformers). The pyproject ceiling is the functional fix; a controlled lockfile refresh belongs in its own PR.

> Verified via the diagnose→adversarial-verify workflow; validated by the `windows-latest` CI job (now incl. 3.13). I cannot reproduce on Linux, but the failure mode and fix are code-confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)