### PR TITLE
fix(install): PowerShell entry point for Windows users (#334)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,12 @@ curl -fsSL https://open-jarvis.github.io/OpenJarvis/install.sh | bash
 
 The installer handles everything for you — including [uv](https://docs.astral.sh/uv/), the Python venv, Ollama, and a small starter model. You don't need to install anything first.
 
-**Windows:** the installer is a `bash` script and won't run in PowerShell or `cmd`. Pick one of:
+**Windows:** the `curl … | bash` installer won't run in PowerShell or `cmd` (you'll see `bash: not recognized`). Run this in PowerShell for guidance — or pick one of the options below:
+
+```powershell
+irm https://open-jarvis.github.io/OpenJarvis/install.ps1 | iex
+```
+
 
 - **WSL2 (recommended for the CLI / Python SDK)** — one-time setup in an admin PowerShell, then run the same `curl … | bash` inside Ubuntu:
   ```powershell

--- a/docs/gen_install_script.py
+++ b/docs/gen_install_script.py
@@ -1,21 +1,24 @@
-"""Publish the canonical install.sh into the docs site.
+"""Publish the canonical install scripts into the docs site.
 
-Serves the installer at ``https://open-jarvis.github.io/OpenJarvis/install.sh``
-so users have an HTTPS-valid, project-controlled install URL that does not
-depend on the externally-hosted ``openjarvis.ai`` domain — whose TLS config
-broke and which the project does not control (issue #337).
+Serves the installers at ``https://open-jarvis.github.io/OpenJarvis/install.sh``
+and ``…/install.ps1`` so users have HTTPS-valid, project-controlled install
+URLs that do not depend on the externally-hosted ``openjarvis.ai`` domain —
+whose TLS config broke and which the project does not control (issue #337).
 
-Single source of truth: the script lives at ``scripts/install/install.sh``
-(also bundled into the wheel as ``_install_scripts/``). This copies it
-verbatim into the built site at ``install.sh`` on every ``mkdocs build``,
-so the published copy can never drift from the canonical one.
+Single source of truth: the scripts live at ``scripts/install/`` (also bundled
+into the wheel as ``_install_scripts/``). This copies them verbatim into the
+built site on every ``mkdocs build`` so the published copies can never drift.
+
+``install.ps1`` is guidance-only — it points Windows users at WSL2 or the
+desktop app rather than installing the native CLI (which is unsupported), so
+PowerShell users who ran ``curl … | bash`` get the right path instead of
+``bash: not recognized`` (#334).
 """
 
 from pathlib import Path
 
 import mkdocs_gen_files
 
-_SRC = Path("scripts/install/install.sh")
-
-with mkdocs_gen_files.open("install.sh", "wb") as dst:
-    dst.write(_SRC.read_bytes())
+for _name in ("install.sh", "install.ps1"):
+    with mkdocs_gen_files.open(_name, "wb") as dst:
+        dst.write(Path("scripts/install", _name).read_bytes())

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -147,6 +147,7 @@ nav:
   - Getting Started:
       - Installation: getting-started/installation.md
       - macOS Guide: getting-started/macos.md
+      - Windows (WSL2): getting-started/wsl2.md
       - Quick Start: getting-started/quickstart.md
       - Code Snippets: getting-started/snippets.md
       - Configuration: getting-started/configuration.md

--- a/scripts/install/install.ps1
+++ b/scripts/install/install.ps1
@@ -1,0 +1,45 @@
+# OpenJarvis — Windows (PowerShell) install entry point.
+#
+# Native Windows CLI install is NOT supported. OpenJarvis runs on Windows via
+# WSL2 or the desktop app. This script intentionally does NOT install the CLI;
+# it prints the two supported paths and exits non-zero — mirroring the
+# MINGW/MSYS/CYGWIN refusal in install.sh — so PowerShell/cmd users who tried
+#   curl -fsSL https://open-jarvis.github.io/OpenJarvis/install.sh | bash
+# (and hit "bash: not recognized") get the right guidance instead (#334).
+#
+# Published at https://open-jarvis.github.io/OpenJarvis/install.ps1 so the
+# PowerShell one-liner works:
+#   irm https://open-jarvis.github.io/OpenJarvis/install.ps1 | iex
+#
+# Kept to plain Write-Host / exit so it runs under Constrained Language Mode.
+
+Write-Host ''
+Write-Host 'OpenJarvis on Windows' -ForegroundColor Cyan
+Write-Host '====================='
+Write-Host ''
+Write-Host 'The native Windows (PowerShell/cmd) CLI is not supported.'
+Write-Host 'OpenJarvis runs on Windows two ways:'
+Write-Host ''
+Write-Host '  1. WSL2 (recommended for the CLI / Python SDK).'
+Write-Host '     One-time setup in an ADMIN PowerShell:'
+Write-Host ''
+Write-Host '         wsl --install -d Ubuntu-24.04'
+Write-Host ''
+Write-Host '     Then open the Ubuntu shell that gets installed and run:'
+Write-Host ''
+Write-Host '         curl -fsSL https://open-jarvis.github.io/OpenJarvis/install.sh | bash'
+Write-Host ''
+Write-Host '  2. Desktop app (no terminal needed). Download the .exe from Releases:'
+Write-Host '         https://github.com/open-jarvis/OpenJarvis/releases'
+Write-Host ''
+Write-Host 'Full WSL2 walkthrough:'
+Write-Host '         https://open-jarvis.github.io/OpenJarvis/getting-started/wsl2/'
+Write-Host ''
+
+# If WSL is already installed, point at option 1 explicitly.
+if (Get-Command wsl -ErrorAction SilentlyContinue) {
+    Write-Host 'Detected WSL on this machine - option 1 is your fastest path.' -ForegroundColor Green
+    Write-Host ''
+}
+
+exit 1

--- a/tests/install/cases/README.md
+++ b/tests/install/cases/README.md
@@ -13,5 +13,6 @@ When a real-world bug report uncovers a new failure mode, add an entry here at t
 
 - [run-as-root.md](run-as-root.md) — installer refuses to run as root
 - [missing-git.md](missing-git.md) — installer refuses without `git` on PATH
+- [windows-powershell.md](windows-powershell.md) — PowerShell users get `install.ps1` guidance instead of `bash: not recognized`
 
 (Add new entries as the catalog grows.)

--- a/tests/install/cases/windows-powershell.md
+++ b/tests/install/cases/windows-powershell.md
@@ -1,0 +1,46 @@
+# Case: PowerShell user runs the bash one-liner
+
+**Reported:** #334 — *"The term 'bash' is not recognized as the name of a cmdlet…"*
+
+## Symptom
+
+A Windows user pastes the documented install command into **PowerShell** (or
+`cmd`):
+
+```powershell
+curl -fsSL https://open-jarvis.github.io/OpenJarvis/install.sh | bash
+```
+
+and gets:
+
+```
+bash : The term 'bash' is not recognized as the name of a cmdlet, function,
+script file, or operable program.
+```
+
+## Why
+
+`install.sh` is a bash script. PowerShell/cmd have no `bash`, so the pipe
+fails before any installer code runs. The script's own native-Windows refusal
+(`uname -s` = `MINGW*/MSYS*/CYGWIN*`) cannot help here — that branch requires
+bash to already exist.
+
+## Expected behavior
+
+There is a PowerShell entry point published alongside `install.sh`:
+
+```powershell
+irm https://open-jarvis.github.io/OpenJarvis/install.ps1 | iex
+```
+
+`install.ps1` is **guidance-only** (native Windows CLI is unsupported): it
+prints the two supported paths — WSL2 (`wsl --install -d Ubuntu-24.04`, then
+re-run the bash one-liner inside Ubuntu) and the desktop app — links the WSL2
+walkthrough, and exits non-zero. It never attempts a native install.
+
+## Regression guard
+
+- `scripts/install/install.ps1` exists and exits non-zero with the WSL2 /
+  desktop guidance.
+- `docs/gen_install_script.py` publishes it to the site (`install.ps1`).
+- `install.sh` still refuses on MINGW/MSYS/CYGWIN (bash-on-Windows) shells.


### PR DESCRIPTION
Closes #334.

## Problem
Windows users paste the documented one-liner into **PowerShell/cmd**:
```powershell
curl -fsSL https://open-jarvis.github.io/OpenJarvis/install.sh | bash
```
and get **"The term 'bash' is not recognized"** — there's no `bash`, so the pipe fails before any installer code runs. install.sh's own MINGW/MSYS/CYGWIN refusal can't help (that branch requires bash to already exist).

## Fix (guidance-only — consistent with "native Windows CLI unsupported")
- **`scripts/install/install.ps1`** (new): prints the two supported paths — **WSL2** (`wsl --install -d Ubuntu-24.04`, then re-run the bash one-liner inside Ubuntu) and the **desktop app** — links the WSL2 walkthrough, and `exit 1`. It does **not** install the native CLI. Plain `Write-Host`/`exit` (Constrained-Language-Mode safe). Already bundled into the wheel via the existing `scripts/install → _install_scripts` force-include.
- **`docs/gen_install_script.py`**: publishes it to the site, so the answer is a clean one-liner:
  ```powershell
  irm https://open-jarvis.github.io/OpenJarvis/install.ps1 | iex
  ```
- **README**: surfaces that one-liner as the explicit "ran the curl line in PowerShell? do this" answer.
- **mkdocs.yml**: adds the previously-**orphaned** WSL2 page to the nav so it's reachable on the docs site (the higher-leverage half — verified `docs/getting-started/wsl2.md` exists).
- **tests/install/cases/windows-powershell.md**: regression catalog entry.

Verifier corrections applied: target `installation.md`/nav (not a phantom `install.md`); no `pyproject` edit needed (force-include already bundles the ps1).

> Diagnosed + adversarially verified via workflow. The published `.ps1` build is exercised by the docs CI; `install.ps1` is guidance-only so there's no native-install surface to regress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)