### PR TITLE
docs(readme): embed demo reel video in hero section

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@
 
 ---
 
+<div align="center">
+
+https://github.com/user-attachments/assets/REPLACE-WITH-UPLOADED-VIDEO-URL
+
+</div>
+
+---
+
 > **[Documentation](https://open-jarvis.github.io/OpenJarvis/)**
 >
 > **[Project Site](https://scalingintelligence.stanford.edu/blogs/openjarvis/)**

--- a/README.md
+++ b/README.md
@@ -16,9 +16,7 @@
 ---
 
 <div align="center">
-
-https://github.com/user-attachments/assets/REPLACE-WITH-UPLOADED-VIDEO-URL
-
+  <video src="https://github.com/open-jarvis/OpenJarvis/releases/download/readme-media/openjarvis_demo_reel_v2.mp4" controls width="100%"></video>
 </div>
 
 ---


### PR DESCRIPTION
## Summary

- Adds a centered video block in the README hero, between the badges and the Documentation links, framed by horizontal rules above and below.
- The URL is currently a placeholder (`REPLACE-WITH-UPLOADED-VIDEO-URL`) — see the next step below.

## Next step (required before merge)

To make the mp4 render inline as a real `<video>` player on the rendered README, the file needs to live on GitHub's `user-attachments` CDN:

1. Drag \`openjarvis_demo_reel_v2.mp4\` into the comment box on this PR (don't post — just wait for the upload to finish).
2. GitHub will replace the dropzone with a \`https://github.com/user-attachments/assets/<uuid>\` URL.
3. Copy that URL and paste it in a comment here so the placeholder can be swapped, or edit the README directly on this branch.
4. Discard the unsent comment.

The bare URL on its own line is what triggers GitHub's auto-embed — don't wrap it in markdown link syntax or `<video>` tags.

## Test plan

- [ ] Drag the mp4 into a PR comment to get the user-attachments URL
- [ ] Swap the placeholder in \`README.md\` for the real URL
- [ ] Confirm the video renders inline (with playback controls) in the rendered PR diff
- [ ] Confirm the horizontal rules sit flush above and below the video block

🤖 Generated with [Claude Code](https://claude.com/claude-code)