### PR TITLE
docs(readme): replace stripped <video> with animated WebP demo reel

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 ---
 
 <div align="center">
-  <video src="https://github.com/open-jarvis/OpenJarvis/releases/download/readme-media/openjarvis_demo_reel_v2.mp4" controls width="100%"></video>
+  <img alt="OpenJarvis demo reel" src="assets/openjarvis_demo_reel.webp" width="100%">
 </div>
 
 ---


### PR DESCRIPTION
## Summary

- GitHub's README sanitizer was stripping the previous \`<video>\` tag (release-asset URLs aren't in the README's allowed source list), so the embed was invisible on the rendered page.
- Replaces it with an animated WebP committed to \`assets/openjarvis_demo_reel.webp\` — renders inline on every Markdown viewer.
- Source video has no audio, so animated WebP is functionally equivalent to inline video (auto-loop, no controls needed).

## Encoding

| Param | Value |
|---|---|
| Width | 960px |
| Frame rate | 15 fps |
| Encoder | libwebp, lossy, q=60, m=4 |
| Frames | 1101 |
| Duration | 73s |
| Output size | 4.5 MB |

Source: \`openjarvis_demo_reel_v2.mp4\` (1920×1200, 30fps, 73s, ~11MB).

## Test plan

- [ ] Confirm the WebP renders inline at the top of the rendered README (between the badges and the Documentation links, framed by horizontal rules).
- [ ] Confirm it auto-loops without click-through.
- [ ] After merge: delete the now-unused \`readme-media\` prerelease + asset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)