### PR TITLE
docs(readme): scale demo reel to 75% width, add dark grey frame

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 ---
 
 <div align="center">
-  <img alt="OpenJarvis demo reel" src="assets/openjarvis_demo_reel.webp" width="100%">
+  <img alt="OpenJarvis demo reel" src="assets/openjarvis_demo_reel.webp" width="75%">
 </div>
 
 ---


### PR DESCRIPTION
## Summary

- Embed width: \`width="100%"\` → \`width="75%"\` to size down the hero a touch.
- Re-encoded the WebP with a **4px #3a3a3a border** baked in via ffmpeg's \`pad\` filter. GitHub's README sanitizer doesn't reliably honor CSS borders on \`<img>\`, so the frame has to live in the asset itself.

Final asset: 4.5 MB animated WebP, 968×608 (960×600 content + 4px border on all sides), 15 fps, 73 s loop.

## Test plan

- [ ] Confirm the demo reel renders narrower than before.
- [ ] Confirm the subtle dark grey frame is visible around the video.
- [ ] Confirm it still auto-loops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)