### PR TITLE
fix(desktop): stop auto-pulling the entire Qwen3.5 model ladder

### DIFF
--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -1038,19 +1038,14 @@ async fn boot_backend(backend: SharedBackend, status: SharedStatus) {
         s.detail = "All systems ready.".into();
     }
 
-    // Phase 4: Pull remaining Qwen3.5 models in the background.
-    // The app is already usable with qwen3.5:2b; as each model finishes
-    // it appears in the model list automatically.
-    let fitting = models_that_fit();
-    tokio::spawn(async move {
-        for model in fitting {
-            if model != STARTUP_MODEL && model != FALLBACK_MODEL {
-                if !ollama_has_model(model).await {
-                    let _ = pull_model(model).await;
-                }
-            }
-        }
-    });
+    // Phase 4: done. We intentionally do NOT auto-pull the rest of the
+    // Qwen3.5 ladder here. The previous behavior walked every model that
+    // "fit" in RAM (up to qwen3.5:122b ≈ 81 GB) and pulled each one in an
+    // un-cancellable background task — so the app silently consumed tens of
+    // gigabytes with no way to stop short of deleting it. The startup model
+    // pulled in Phase 2 is enough to make the app fully usable; additional
+    // models are now opt-in (Settings → "ollama pull <model>", or the
+    // `pull_model` command invoked from the UI).
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

A user reported (via Twitter) that the macOS desktop app *"insist[s] on downloading all models from hf... started with just a tiny qwen and carries on downloading larger and larger models in the background. had to delete the app as there was no stopping it."*

This is real. The boot sequence in `frontend/src-tauri/src/lib.rs` had a **"Phase 4"** that spawned an un-cancellable background task:

```rust
let fitting = models_that_fit();   // RAM-filtered ladder, up to qwen3.5:122b ≈ 81 GB
tokio::spawn(async move {
    for model in fitting {
        if model != STARTUP_MODEL && model != FALLBACK_MODEL {
            if !ollama_has_model(model).await { let _ = pull_model(model).await; }
        }
    }
});
```

`models_that_fit()` filters the Qwen3.5 ladder only by RAM, so:
- a **32 GB** Mac silently pulled `0.8b→2b→4b→9b→27b` (~31 GB)
- a **96 GB+** machine walked all the way to `qwen3.5:122b` (≈ 81 GB)

There was no progress UI for it, no setting to disable it, and no cancellation — matching the report exactly.

## Fix

Remove the Phase 4 ladder-walk. The startup model pulled in Phase 2 already makes the app fully usable, and additional models remain opt-in through the existing `pull_model` Tauri command and the Settings → "ollama pull <model>" path. No other behavior changes; `models_that_fit()`/`preferred_model()` are still used for default-model selection.

## Notes / not in this PR

- A separate, larger gap the same user hit — **no support for OpenAI-compatible endpoints (LM Studio / custom servers)** in the desktop app — is being designed separately; the engine layer already supports it, the desktop boot path just hardwires bundled Ollama.

🤖 Generated with [Claude Code](https://claude.com/claude-code)