### PR TITLE
fix: copy package includes in Docker build

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -13,6 +13,8 @@ FROM python:3.12-slim-bookworm AS builder
 WORKDIR /app
 COPY pyproject.toml README.md ./
 COPY src/ src/
+COPY scripts/install scripts/install
+COPY deploy/windows deploy/windows
 
 # Copy built frontend into the server static directory
 COPY --from=frontend /src/openjarvis/server/static src/openjarvis/server/static/

--- a/deploy/docker/Dockerfile.gpu
+++ b/deploy/docker/Dockerfile.gpu
@@ -17,6 +17,8 @@ RUN apt-get update && \
 WORKDIR /app
 COPY pyproject.toml README.md ./
 COPY src/ src/
+COPY scripts/install scripts/install
+COPY deploy/windows deploy/windows
 
 COPY --from=frontend /src/openjarvis/server/static src/openjarvis/server/static/
 

--- a/deploy/docker/Dockerfile.gpu.rocm
+++ b/deploy/docker/Dockerfile.gpu.rocm
@@ -17,6 +17,8 @@ RUN apt-get update && \
 WORKDIR /app
 COPY pyproject.toml README.md ./
 COPY src/ src/
+COPY scripts/install scripts/install
+COPY deploy/windows deploy/windows
 
 COPY --from=frontend /src/openjarvis/server/static src/openjarvis/server/static/
 

--- a/tests/deployment/test_docker.py
+++ b/tests/deployment/test_docker.py
@@ -26,17 +26,38 @@ class TestDockerFiles:
         assert "jarvis" in content
 
     def test_dockerfile_copies_forced_package_includes(self):
-        content = (DOCKER_DIR / "Dockerfile").read_text()
-        install_step = content.index('uv pip install --system ".[server]"')
+        # Every Dockerfile that builds the wheel from an explicit `COPY src/`
+        # context (rather than `COPY . .`) must also copy the non-src
+        # force-include paths before installing, or hatchling's wheel build
+        # fails (see #447). Guard ALL such Dockerfiles, not just the CPU one,
+        # so the GPU variants can't silently regress.
         project = tomllib.loads((ROOT / "pyproject.toml").read_text())
         force_include = project["tool"]["hatch"]["build"]["targets"]["wheel"][
             "force-include"
         ]
+        non_src_includes = [s for s in force_include if not s.startswith("src/")]
 
-        for source in force_include:
-            if source.startswith("src/"):
-                continue
-            assert content.index(f"COPY {source} ") < install_step
+        install_marker = 'uv pip install --system ".[server]"'
+        wheel_dockerfiles = [
+            p
+            for p in sorted(DOCKER_DIR.glob("Dockerfile*"))
+            if install_marker in p.read_text() and "COPY src/ src/" in p.read_text()
+        ]
+        # Sanity: we actually found the wheel-building Dockerfiles to guard.
+        assert wheel_dockerfiles, "no wheel-building Dockerfiles found to check"
+
+        for dockerfile in wheel_dockerfiles:
+            content = dockerfile.read_text()
+            install_step = content.index(install_marker)
+            for source in non_src_includes:
+                copy_marker = f"COPY {source} "
+                assert copy_marker in content, (
+                    f"{dockerfile.name} is missing '{copy_marker.strip()}' "
+                    f"(a non-src force-include path)"
+                )
+                assert content.index(copy_marker) < install_step, (
+                    f"{dockerfile.name} copies '{source}' after the install step"
+                )
 
     def test_docker_compose_valid_yaml(self):
         import importlib

--- a/tests/deployment/test_docker.py
+++ b/tests/deployment/test_docker.py
@@ -4,6 +4,11 @@ from __future__ import annotations
 
 from pathlib import Path
 
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python < 3.11
+    import tomli as tomllib
+
 ROOT = Path(__file__).resolve().parent.parent.parent
 DOCKER_DIR = ROOT / "deploy" / "docker"
 
@@ -19,6 +24,19 @@ class TestDockerFiles:
         content = (DOCKER_DIR / "Dockerfile").read_text()
         assert "ENTRYPOINT" in content
         assert "jarvis" in content
+
+    def test_dockerfile_copies_forced_package_includes(self):
+        content = (DOCKER_DIR / "Dockerfile").read_text()
+        install_step = content.index('uv pip install --system ".[server]"')
+        project = tomllib.loads((ROOT / "pyproject.toml").read_text())
+        force_include = project["tool"]["hatch"]["build"]["targets"]["wheel"][
+            "force-include"
+        ]
+
+        for source in force_include:
+            if source.startswith("src/"):
+                continue
+            assert content.index(f"COPY {source} ") < install_step
 
     def test_docker_compose_valid_yaml(self):
         import importlib


### PR DESCRIPTION
## What does this PR do?

Fixes #447.

Copies the package `force-include` paths into the CPU Docker builder before
`uv pip install`, and adds a regression test so future packaging includes stay
aligned with the Dockerfile.

## How was this tested?

- `OPENJARVIS_API_KEY=test docker compose -f deploy/docker/docker-compose.yml build jarvis`
- `docker run --rm docker-jarvis:latest --help`
- `env UV_CACHE_DIR=/private/tmp/uv-cache uv run --frozen --with pytest --with-editable . pytest tests/deployment/test_docker.py`
- `env UV_CACHE_DIR=/private/tmp/uv-cache uv run --frozen --with ruff ruff check src/ tests/`
- `env UV_CACHE_DIR=/private/tmp/uv-cache uv run --frozen --with ruff ruff format --check tests/deployment/test_docker.py`

## Checklist

- [ ] Tests pass (`uv run pytest tests/ -v`) — not run; targeted deployment tests passed
- [x] Linter passes (`uv run ruff check src/ tests/`)
- [ ] Formatter passes (`uv run ruff format --check src/ tests/`) — full repo check reports existing unrelated formatting drift; changed test file passes
- [x] New/changed public API has docstrings — N/A
- [x] Follows registry pattern (if adding new component) — N/A
- [x] Documentation updated (if applicable) — N/A
