### PR TITLE
fix(security): detect Rust at import time + SSRF Python fallback (#225)

### DIFF
--- a/src/openjarvis/_rust_bridge.py
+++ b/src/openjarvis/_rust_bridge.py
@@ -32,7 +32,21 @@ def get_rust_module() -> _types.ModuleType:
     return openjarvis_rust
 
 
-RUST_AVAILABLE: bool = True
+def _detect_rust() -> bool:
+    """Return ``True`` if the compiled ``openjarvis_rust`` extension is importable.
+
+    Computed once at import time. Modules with a Python fallback (e.g.
+    ``security.ssrf``) consult this flag instead of hardcoding availability,
+    so the fallback is actually reachable when the extension was not built.
+    """
+    try:
+        get_rust_module()
+    except ImportError:
+        return False
+    return True
+
+
+RUST_AVAILABLE: bool = _detect_rust()
 
 
 # ---------------------------------------------------------------------------

--- a/src/openjarvis/security/ssrf.py
+++ b/src/openjarvis/security/ssrf.py
@@ -70,15 +70,23 @@ def is_private_ip(ip_str: str) -> bool:
 
 
 def check_ssrf(url: str) -> Optional[str]:
-    """Check a URL for SSRF vulnerabilities — always via Rust backend."""
-    from openjarvis._rust_bridge import get_rust_module
+    """Check a URL for SSRF vulnerabilities.
 
-    _rust = get_rust_module()
-    return _rust.check_ssrf(url)
+    Prefers the Rust backend, but falls back to the pure-Python
+    implementation when the compiled extension is unavailable. The SSRF
+    guard is security-critical, so it must never be silently skipped — or
+    crash with ``ImportError`` — merely because Rust was not built.
+    """
+    from openjarvis._rust_bridge import RUST_AVAILABLE, get_rust_module
+
+    if RUST_AVAILABLE:
+        return get_rust_module().check_ssrf(url)
+    return _check_ssrf_python(url)
 
 
 def _check_ssrf_python(url: str) -> Optional[str]:
-    """Legacy Python SSRF check — kept for reference only."""
+    """Pure-Python SSRF check — fallback used when the Rust extension is
+    unavailable (e.g. an install without the compiled backend)."""
     from urllib.parse import urlparse
 
     parsed = urlparse(url)

--- a/src/openjarvis/tools/browser.py
+++ b/src/openjarvis/tools/browser.py
@@ -101,19 +101,18 @@ class BrowserNavigateTool(BaseTool):
         if wait_for not in ("load", "domcontentloaded", "networkidle"):
             wait_for = "load"
 
-        # SSRF check
-        try:
-            from openjarvis.security.ssrf import check_ssrf
+        # SSRF check — never skipped. check_ssrf falls back to a pure-Python
+        # implementation when the Rust backend is unavailable, so an
+        # uncompiled extension must not silently disable SSRF protection.
+        from openjarvis.security.ssrf import check_ssrf
 
-            ssrf_error = check_ssrf(url)
-            if ssrf_error:
-                return ToolResult(
-                    tool_name="browser_navigate",
-                    content=f"SSRF blocked: {ssrf_error}",
-                    success=False,
-                )
-        except ImportError:
-            pass  # ssrf module not available, skip check
+        ssrf_error = check_ssrf(url)
+        if ssrf_error:
+            return ToolResult(
+                tool_name="browser_navigate",
+                content=f"SSRF blocked: {ssrf_error}",
+                success=False,
+            )
 
         try:
             page = _session.page

--- a/tests/security/test_ssrf.py
+++ b/tests/security/test_ssrf.py
@@ -220,4 +220,32 @@ class TestCheckSsrf:
         assert result is not None
 
 
-__all__ = ["TestCheckSsrf", "TestIsPrivateIp"]
+class TestCheckSsrfPythonFallback:
+    """When the Rust extension is not compiled, ``check_ssrf`` must fall back
+    to the pure-Python implementation rather than raising ``ImportError`` or
+    being silently skipped — the SSRF guard is security-critical.
+    """
+
+    def test_falls_back_to_python_when_rust_unavailable(self):
+        with patch("openjarvis._rust_bridge.RUST_AVAILABLE", False):
+            result = check_ssrf("http://169.254.169.254/latest/meta-data/")
+        assert result is not None
+        assert "cloud metadata" in result.lower() or "Blocked host" in result
+
+    def test_fallback_blocks_private_ip(self):
+        with patch("openjarvis._rust_bridge.RUST_AVAILABLE", False):
+            with patch("openjarvis.security.ssrf.socket.getaddrinfo") as mock_dns:
+                mock_dns.return_value = [(2, 1, 6, "", ("10.0.0.5", 0))]
+                result = check_ssrf("http://internal-service.local/api")
+        assert result is not None
+        assert "private IP" in result
+
+    def test_fallback_allows_public_url_without_rust(self):
+        with patch("openjarvis._rust_bridge.RUST_AVAILABLE", False):
+            with patch("openjarvis.security.ssrf.socket.getaddrinfo") as mock_dns:
+                mock_dns.return_value = [(2, 1, 6, "", ("93.184.216.34", 0))]
+                result = check_ssrf("https://example.com")
+        assert result is None
+
+
+__all__ = ["TestCheckSsrf", "TestCheckSsrfPythonFallback", "TestIsPrivateIp"]


### PR DESCRIPTION
Fixes #225.

## Problem

`src/openjarvis/_rust_bridge.py` hardcoded the exported availability flag:

```python
RUST_AVAILABLE: bool = True
```

This value was unconditional, so it never reflected whether the compiled `openjarvis_rust` extension was actually built. Two concrete consequences when the extension is **not** compiled (fresh clone without `maturin develop`, CI without a Rust toolchain, a pip install that didn't build the backend):

1. **`tools/browser.py` silently disabled SSRF protection.** The SSRF check was wrapped in `try: ... except ImportError: pass`. With no compiled backend, `check_ssrf()` raised `ImportError` (from `get_rust_module()`), which was swallowed — so the browser tool would navigate to internal/cloud-metadata endpoints (e.g. `169.254.169.254`) **with no SSRF check at all**.
2. **`tools/http_request.py` and `tools/web_search.py` crashed.** They call `check_ssrf()` unguarded, so the same `ImportError` took down those tools instead of degrading gracefully.

A complete pure-Python SSRF implementation (`_check_ssrf_python`) already existed in `ssrf.py` but was labelled "kept for reference only" and was never reachable — even though the test module already describes it as "the pure-Python implementation".

## Fix

- **`_rust_bridge.py`** — compute `RUST_AVAILABLE` dynamically by probing the extension once at import time, so the exported flag is honest. `get_rust_module()` still hard-raises `ImportError` for the modules where Rust is genuinely mandatory.
- **`security/ssrf.py`** — `check_ssrf()` now uses the Rust backend when available and falls back to `_check_ssrf_python()` otherwise, instead of raising. The SSRF guard is security-critical and must never be silently skipped or crash merely because Rust wasn't built.
- **`tools/browser.py`** — removed the `except ImportError: pass` that disabled SSRF protection; the check now always runs (Rust or Python).
- **`tests/security/test_ssrf.py`** — added `TestCheckSsrfPythonFallback` covering the fallback path (cloud-metadata IP, private IP via DNS, and a public URL) with `RUST_AVAILABLE` patched to `False`.

## Verification

- `ruff check` passes on all changed files.
- New and existing SSRF logic verified by loading `ssrf.py` with a stubbed (unavailable) Rust bridge: metadata + private IPs are blocked via the Python path, public URLs pass, and no `ImportError` escapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)