### PR TITLE
fix: resolve TOML parser dropping system_prompt and memory config (fixes #401)

### DIFF
--- a/src/openjarvis/core/config.py
+++ b/src/openjarvis/core/config.py
@@ -1434,6 +1434,7 @@ class MemoryFilesConfig:
 class SystemPromptConfig:
     """Limits and strategy for system-prompt assembly."""
 
+    prefix: str = ""
     soul_max_chars: int = 4000
     memory_max_chars: int = 2500
     user_max_chars: int = 1500
@@ -1810,6 +1811,10 @@ def load_config(path: Optional[Path] = None) -> JarvisConfig:
             "agent_manager",
             "digest",
             "proactive",
+            "memory_files",
+            "system_prompt",
+            "compression",
+            "skills",
         )
         for section_name in top_sections:
             if section_name in data:

--- a/src/openjarvis/prompt/builder.py
+++ b/src/openjarvis/prompt/builder.py
@@ -80,7 +80,7 @@ class SystemPromptBuilder:
 
     def _build_frozen_prefix(self) -> str:
         sections: list[str] = []
-        if getattr(self._sp_config, "prefix", ""):
+        if self._sp_config.prefix:
             sections.append(self._sp_config.prefix)
         if self._agent_template:
             sections.append(self._agent_template)

--- a/src/openjarvis/prompt/builder.py
+++ b/src/openjarvis/prompt/builder.py
@@ -80,7 +80,10 @@ class SystemPromptBuilder:
 
     def _build_frozen_prefix(self) -> str:
         sections: list[str] = []
-        sections.append(self._agent_template)
+        if getattr(self._sp_config, "prefix", ""):
+            sections.append(self._sp_config.prefix)
+        if self._agent_template:
+            sections.append(self._agent_template)
         sections.extend(self._persona_sections())
         # XML skill catalog (preferred over legacy markdown list)
         if self._skill_catalog_xml:


### PR DESCRIPTION
## Summary

Resolves a parser bug where the `[system_prompt]`, `[memory_files]`, `[compression]`, and `[skills]` config blocks were being silently dropped by `load_config()`. 

This fixes Issue #401 by finally allowing `system_prompt.prefix` to be parsed from `config.toml`. The `SOUL.md` loading issue also mentioned in #401 is tracked separately in #376 and is out of scope for this fix.

## What changed in `src/openjarvis/core/config.py` & `src/openjarvis/prompt/builder.py`

1. **Fixed `load_config` allowlist:** Added the missing 4 sections (`system_prompt`, `memory_files`, `compression`, `skills`) to `top_sections`.
2. **Added `prefix` to `SystemPromptConfig`:** Enabled the dataclass to store the newly-parsed TOML property.
3. **Prepended prefix in `SystemPromptBuilder._build_frozen_prefix`:** Injected the configured prefix ahead of the default agent template to ensure the LLM honors it.

## Test plan

- [x] Verified `tests/core/test_config.py` passes cleanly (parser now properly loads all missing sections).
- [x] Verified `tests/prompt/test_builder.py` passes cleanly (proper prefix building).
- [x] Ran full `ruff` formatter and linter checks cleanly.
