### PR TITLE
fix(server): bypass agent on /v1/chat/completions when caller passes tools (#414)

### DIFF
--- a/src/openjarvis/server/routes.py
+++ b/src/openjarvis/server/routes.py
@@ -147,8 +147,23 @@ async def chat_completions(request_body: ChatCompletionRequest, request: Request
             return await _handle_agent_stream(agent, bus, model, request_body)
         return await _handle_stream(engine, model, request_body, complexity_info)
 
-    # Non-streaming: use agent if available, otherwise direct engine call
-    if agent is not None:
+    # Non-streaming: use agent if available, otherwise direct engine call.
+    #
+    # EXCEPTION: when the client explicitly passed `tools`, they're asking
+    # for raw OpenAI-compat function-calling — return the model's
+    # tool_call decision verbatim. Routing through `_handle_agent` would
+    # call `agent.run(input_text)`, which IGNORES `request_body.tools`,
+    # runs the agent's own internal tool loop with its own (different)
+    # tool spec, and returns only `result.content` — so the model's
+    # tool_calls vanish and the user sees a generic acknowledgement
+    # (e.g. "Understood. If you have another request...") that the
+    # agent's re-prompted LLM produced. See #414.
+    #
+    # If a future caller needs agent orchestration WITH client-supplied
+    # tools (e.g. injecting MCP tools through this endpoint and wanting
+    # the agent to execute them), add an explicit opt-in header rather
+    # than removing this guard — silent re-routing is what produced #414.
+    if agent is not None and not request_body.tools:
         return _handle_agent(agent, model, request_body, complexity_info)
 
     bus = getattr(request.app.state, "bus", None)

--- a/tests/server/test_routes.py
+++ b/tests/server/test_routes.py
@@ -171,6 +171,85 @@ class TestChatCompletions:
         data = resp.json()
         assert data["choices"][0]["message"]["content"] == "Hello from agent"
 
+    def test_with_tools_bypasses_agent(self):
+        """Regression for #414.
+
+        When the client passes explicit `tools` AND an agent is
+        registered, the request must go to `_handle_direct` (which
+        preserves tool_calls from the engine) rather than `_handle_agent`
+        (which calls `agent.run()` ignoring `request_body.tools` and
+        returns only `result.content`, dropping tool_calls and
+        substituting whatever generic content the agent's re-prompted
+        LLM produced).
+        """
+        engine = _make_engine()
+        engine.generate.return_value = {
+            "content": "",
+            "tool_calls": [
+                {"id": "c1", "name": "list_files", "arguments": '{"directory":"/tmp"}'},
+            ],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8},
+            "model": "test-model",
+            "finish_reason": "tool_calls",
+        }
+        agent = _make_agent(content="GENERIC AGENT FILLER")
+        app = create_app(engine, "test-model", agent=agent)
+        client = TestClient(app)
+
+        resp = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "test-model",
+                "messages": [{"role": "user", "content": "Use list_files on /tmp."}],
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "list_files",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {"directory": {"type": "string"}},
+                                "required": ["directory"],
+                            },
+                        },
+                    },
+                ],
+            },
+        )
+        assert resp.status_code == 200
+        msg = resp.json()["choices"][0]["message"]
+        # The engine's tool_calls must survive — proves we bypassed
+        # _handle_agent and reached _handle_direct.
+        assert msg["tool_calls"] is not None
+        assert msg["tool_calls"][0]["function"]["name"] == "list_files"
+        # Content must be the engine's empty string, NOT the agent's
+        # filler. If this assertion fails, the agent ran and produced
+        # filler content while dropping the real tool_calls — exactly
+        # the bug #414 reported.
+        assert msg["content"] == ""
+        assert "GENERIC AGENT FILLER" not in (msg["content"] or "")
+        # And the engine was actually called (proves we hit _handle_direct
+        # rather than short-circuiting somewhere else).
+        assert engine.generate.called
+        # And the agent was NOT called (proves the bypass worked).
+        assert not agent.run.called
+
+    def test_without_tools_still_uses_agent(self, client_with_agent):
+        """Counterpart to test_with_tools_bypasses_agent: when no tools
+        are requested, the agent path is still used (preserves existing
+        behavior for plain chat through an agent)."""
+        resp = client_with_agent.post(
+            "/v1/chat/completions",
+            json={
+                "model": "test-model",
+                "messages": [{"role": "user", "content": "Hello"}],
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        # No tools → agent path → agent's content surfaces.
+        assert data["choices"][0]["message"]["content"] == "Hello from agent"
+
     def test_agent_with_conversation(self, client_with_agent):
         resp = client_with_agent.post(
             "/v1/chat/completions",


### PR DESCRIPTION
## Summary

Closes #414.

**The reporter's symptom** (verbatim, @gilbert-barajas): same payload, two endpoints — direct curl to MLX `:8770` returns proper `{content:\"\", tool_calls:[list_files(...)]}`. Routed curl through OpenJarvis `:8000` returns `{content:\"Understood. If you have another request or need assistance with a different task, please let me know.\", tool_calls:null}`. **Tool call lost, content replaced with filler that the model never produced for this prompt.**

## Root cause

`src/openjarvis/server/routes.py:151` unconditionally routed non-streaming `/v1/chat/completions` through `_handle_agent` whenever an agent was registered. `_handle_agent`:

- takes `req.messages[-1].content` as input
- calls `agent.run(input_text, context=ctx)` — **ignoring `request_body.tools` entirely**
- the agent then runs its **own internal tool loop with its own (different) tool spec**; the user's tools never reach it
- returns only `result.content` — never `result.tool_calls`

The \"Understood. If you have another request...\" string **is not hardcoded anywhere in OpenJarvis**. (I verified with `grep` — and the workflow's first verdict pointing at `cloud_router.py:126` was wrong; that's a different, shorter `\"Understood.\"` injection in a Gemini-only code path that MLX never touches.) The filler is the agent's re-prompted LLM producing a generic acknowledgement when called with no relevant tools available — it's the model's actual output for a different prompt than the user sent.

## Fix

One conditional in `routes.py`:

```python
# Skip _handle_agent when client passed explicit tools — they're asking
# for raw OpenAI-compat function-calling, return the model's tool_call
# decision verbatim. See #414.
if agent is not None and not request_body.tools:
    return _handle_agent(agent, model, request_body, complexity_info)
```

A forward-looking comment documents this as an intentional trade-off so a future maintainer who wants \"agent orchestration + client-supplied tools\" adds an explicit opt-in header rather than silently removing the guard (silent re-routing is exactly what produced #414).

**Streaming path left intact.** Lines 143-149 in `routes.py` have an asymmetric branch (\"use agent_stream WHEN tools present\") that's intentional and documented — `_handle_agent_stream` is the word-splitting SSE bridge that exists precisely for tool-using agentic flows. The reporter's repro is non-streaming (`stream: false`); the streaming case is a separate triage if anyone hits it.

## Regression tests (`tests/server/test_routes.py`)

- **`test_with_tools_bypasses_agent`** — mocks an engine returning `tool_calls` AND an agent that would produce `\"GENERIC AGENT FILLER\"`. Asserts:
  - `tool_calls` survives to the response (function name + arguments match)
  - `content` is the engine's empty string (NOT the filler)
  - `engine.generate.called` is True
  - `agent.run.called` is False
  - This test would have caught #414 if it had existed.
- **`test_without_tools_still_uses_agent`** — counterpart pinning existing behavior: no tools + agent → agent path → agent's content surfaces.

## Adversarial review

7 interrogation points across the diff:
- Streaming-path asymmetry (justified by existing comment — non-issue)
- `tools=[]` truthiness (Pydantic preserves `[]`, `not []` is True → agent fires — correct)
- `tool_choice` (not in `ChatCompletionRequest` model — out of scope for this fix)
- Field type validation (confirmed correct)
- Agent-path regression risk (no current caller depends on \"tools + agent\" through this endpoint; MCP injection goes through `agent_manager_routes.py` separately)
- `MagicMock` semantics for `agent.run.called` (correct)
- `content: None` edge case (pre-existing latent in `_handle_direct`, not made worse by this fix)

Six were non-issues; the seventh prompted the forward-looking comment.

## Test plan

- [x] `uv run ruff check src/openjarvis/server/routes.py tests/server/test_routes.py` — clean
- [x] `uv run pytest tests/server/test_routes.py::TestChatCompletions -v` — 13 passed (including 2 new)
- [ ] CI green (lint / rust / test / test-windows)
- [ ] Manual: @gilbert-barajas's exact repro on a host with an agent registered + MLX backend at `:8770` → expect tool_calls round-trip, empty content, no filler

## Credit

Reported by @gilbert-barajas in #414. The careful side-by-side curls against the backend (`:8770`) vs the router (`:8000`) — same payload, two different responses — made this triage tractable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)