### PR TITLE
Improve local engine model resolution

### DIFF
--- a/src/openjarvis/cli/serve.py
+++ b/src/openjarvis/cli/serve.py
@@ -24,6 +24,61 @@ from openjarvis.intelligence import (
 logger = logging.getLogger(__name__)
 
 
+def _unique_model_ids(model_ids: list[str]) -> list[str]:
+    """Return model ids in first-seen order without duplicates."""
+    unique: list[str] = []
+    seen: set[str] = set()
+    for model_id in model_ids:
+        if model_id and model_id not in seen:
+            seen.add(model_id)
+            unique.append(model_id)
+    return unique
+
+
+def _safe_list_models(engine: object) -> list[str]:
+    try:
+        list_models = getattr(engine, "list_models")
+        return list(list_models())
+    except Exception as exc:
+        logger.debug("Failed to list models for selected server engine: %s", exc)
+        return []
+
+
+def _resolve_server_model(
+    requested_model: str | None,
+    *,
+    config: object,
+    engine_name: str,
+    engine: object,
+    all_models: dict[str, list[str]],
+) -> str:
+    """Pick a startup model that is present on the active server engine.
+
+    CLI ``--model`` remains authoritative. For config-driven startup, prefer the
+    configured server/default model only when the active engine can actually
+    serve it; otherwise use ``intelligence.fallback_model`` or the first
+    reachable model. This prevents MLX-preferred configs from hiding a healthy
+    Ollama fallback behind an empty/incorrect model map.
+    """
+    if requested_model:
+        return requested_model
+
+    candidates = [
+        getattr(config.server, "model", ""),
+        getattr(config.intelligence, "default_model", ""),
+        getattr(config.intelligence, "fallback_model", ""),
+    ]
+    available = _unique_model_ids(
+        _safe_list_models(engine) + list(all_models.get(engine_name, []))
+    )
+
+    for candidate in candidates:
+        if candidate and (not available or candidate in available):
+            return candidate
+
+    return available[0] if available else ""
+
+
 @click.command()
 @click.option("--host", default=None, help="Bind address (default: config).")
 @click.option(
@@ -107,10 +162,12 @@ def serve(
     sec = setup_security(config, engine, bus)
     engine = sec.engine
 
-    # If cloud API keys are set, wrap with MultiEngine so both local
-    # and cloud models appear in the model list and can be used.
+    # If cloud API keys are set, prepare a cloud engine. We build the
+    # MultiEngine after local discovery so healthy local fallbacks such as
+    # Ollama stay visible even when the configured preferred engine is MLX.
     import os
 
+    cloud_engine = None
     _has_cloud = (
         os.environ.get("OPENAI_API_KEY")
         or os.environ.get("ANTHROPIC_API_KEY")
@@ -121,12 +178,9 @@ def serve(
     if _has_cloud and engine_name != "cloud":
         try:
             from openjarvis.engine.cloud import CloudEngine
-            from openjarvis.engine.multi import MultiEngine
 
-            cloud = CloudEngine()
-            engine = MultiEngine([(engine_name, engine), ("cloud", cloud)])
-            engine_name = "multi"
-            if cloud.health():
+            cloud_engine = CloudEngine()
+            if cloud_engine.health():
                 console.print("  Cloud:  [cyan]enabled[/cyan] (API keys detected)")
             else:
                 console.print(
@@ -163,16 +217,46 @@ def serve(
     for ek, model_ids in all_models.items():
         merge_discovered_models(ek, model_ids)
 
+    multi_entries = [(engine_name, engine)]
+    for discovered_name, discovered_engine in all_engines:
+        if discovered_name != engine_name:
+            multi_entries.append((discovered_name, discovered_engine))
+    if cloud_engine is not None:
+        multi_entries.append(("cloud", cloud_engine))
+
+    if len(multi_entries) > 1:
+        from openjarvis.engine.multi import MultiEngine
+
+        engine = MultiEngine(multi_entries)
+        engine_name = "multi"
+        all_models[engine_name] = engine.list_models()
+        merge_discovered_models(engine_name, all_models[engine_name])
+
     # Resolve model
-    if model_name is None:
-        model_name = config.server.model or config.intelligence.default_model
+    configured_model = (
+        model_name or config.server.model or config.intelligence.default_model
+    )
+    model_name = _resolve_server_model(
+        model_name,
+        config=config,
+        engine_name=engine_name,
+        engine=engine,
+        all_models=all_models,
+    )
+    if configured_model and model_name and model_name != configured_model:
+        console.print(
+            "[yellow]Configured model "
+            f"{configured_model!r} is not reachable; using {model_name!r}.[/yellow]"
+        )
     if not model_name:
-        engine_models = all_models.get(engine_name, [])
-        if engine_models:
-            model_name = engine_models[0]
-        else:
-            console.print("[red]No model available on engine.[/red]")
-            sys.exit(1)
+        console.print(
+            "[red]No model available on any reachable engine.[/red]\n\n"
+            "Start an inference backend and make sure it lists at least one model.\n"
+            "For Ollama: [cyan]ollama serve[/cyan] and "
+            "[cyan]ollama pull qwen3.5:9b[/cyan].\n"
+            "For MLX: start the MLX OpenAI-compatible server on the configured host."
+        )
+        sys.exit(1)
 
     # Resolve agent
     agent = None

--- a/src/openjarvis/engine/_openai_compat.py
+++ b/src/openjarvis/engine/_openai_compat.py
@@ -69,6 +69,23 @@ class _OpenAICompatibleEngine(InferenceEngine):
             raise EngineConnectionError(
                 f"{self.engine_id} engine not reachable at {self._host}"
             ) from exc
+        except httpx.HTTPStatusError as exc:
+            error_detail = exc.response.text.strip()
+            if exc.response.status_code == 404:
+                detail_suffix = (
+                    f" Response body: {error_detail}" if error_detail else ""
+                )
+                raise EngineConnectionError(
+                    f"{self.engine_id} engine at {self._host} returned 404 for "
+                    f"{self._api_prefix}/chat/completions. Make sure this port "
+                    "is running an OpenAI-compatible chat server, not another "
+                    f"local web service.{detail_suffix}"
+                ) from exc
+            detail_suffix = f": {error_detail}" if error_detail else ""
+            raise EngineConnectionError(
+                f"{self.engine_id} engine at {self._host} returned HTTP "
+                f"{exc.response.status_code}{detail_suffix}"
+            ) from exc
         data = resp.json()
         choices = data.get("choices", [])
         if not choices:

--- a/tests/cli/test_serve_model_resolution.py
+++ b/tests/cli/test_serve_model_resolution.py
@@ -1,0 +1,67 @@
+"""Tests for API server model selection."""
+
+from __future__ import annotations
+
+from openjarvis.cli.serve import _resolve_server_model
+from openjarvis.core.config import JarvisConfig
+
+
+class _FakeEngine:
+    def __init__(self, models: list[str]) -> None:
+        self._models = models
+
+    def list_models(self) -> list[str]:
+        return self._models
+
+
+def test_server_model_falls_back_to_reachable_ollama_model() -> None:
+    cfg = JarvisConfig()
+    cfg.server.model = "mlx-community/Qwen2.5-7B-Instruct-4bit"
+    cfg.intelligence.default_model = "mlx-community/Qwen2.5-7B-Instruct-4bit"
+    cfg.intelligence.fallback_model = "qwen3.5:9b"
+
+    model = _resolve_server_model(
+        None,
+        config=cfg,
+        engine_name="multi",
+        engine=_FakeEngine(["qwen3.5:9b"]),
+        all_models={"multi": ["qwen3.5:9b"]},
+    )
+
+    assert model == "qwen3.5:9b"
+
+
+def test_server_model_prefers_reachable_configured_model() -> None:
+    cfg = JarvisConfig()
+    cfg.server.model = "mlx-community/Qwen2.5-7B-Instruct-4bit"
+    cfg.intelligence.default_model = "qwen3.5:9b"
+    cfg.intelligence.fallback_model = "qwen3.5:9b"
+
+    model = _resolve_server_model(
+        None,
+        config=cfg,
+        engine_name="multi",
+        engine=_FakeEngine(
+            ["mlx-community/Qwen2.5-7B-Instruct-4bit", "qwen3.5:9b"]
+        ),
+        all_models={"multi": ["mlx-community/Qwen2.5-7B-Instruct-4bit"]},
+    )
+
+    assert model == "mlx-community/Qwen2.5-7B-Instruct-4bit"
+
+
+def test_server_model_keeps_explicit_cli_model() -> None:
+    cfg = JarvisConfig()
+    cfg.server.model = "configured-model"
+    cfg.intelligence.fallback_model = "fallback-model"
+
+    model = _resolve_server_model(
+        "explicit-model",
+        config=cfg,
+        engine_name="multi",
+        engine=_FakeEngine(["fallback-model"]),
+        all_models={"multi": ["fallback-model"]},
+    )
+
+    assert model == "explicit-model"
+


### PR DESCRIPTION
## What does this PR do?

Improves local inference startup behavior when the configured model is not actually available on the active/reachable engine.

This PR:

- Keeps explicit CLI `--model` behavior authoritative.
- Resolves config-driven startup models against models available from the selected engine or discovered multi-engine fallback.
- Allows healthy local fallbacks, such as Ollama, to remain usable even when a preferred/configured MLX model is unavailable.
- Includes all discovered healthy engines in `MultiEngine`.
- Improves OpenAI-compatible engine errors for HTTP failures, especially 404 responses from local services that are reachable but not serving `/v1/chat/completions`.
- Adds focused tests for server model resolution.

## How was this tested?

```bash
uv run --extra dev --extra server python -m pytest tests/cli/test_serve_model_resolution.py -q
```

Result:

```text
3 passed in 0.36s
```

## Checklist

- [ ] Tests pass (`uv run pytest tests/ -v`)
- [ ] Linter passes (`uv run ruff check src/ tests/`)
- [ ] Formatter passes (`uv run ruff format --check src/ tests/`)
- [x] New/changed public API has docstrings
- [x] Follows registry pattern (if adding new component)
- [ ] Documentation updated (if applicable)

Notes:

- This is intentionally a small upstream PR containing only the engine/model-resolution change and focused tests.
- No lockfile changes are included.