### PR TITLE
fix(cli): escape exception text in agents-list error handler (#297)

### DIFF
--- a/src/openjarvis/cli/agent_cmd.py
+++ b/src/openjarvis/cli/agent_cmd.py
@@ -88,7 +88,13 @@ def list_agents() -> None:
             )
         console.print(table)
     except Exception as exc:
-        console.print(f"[red]Error: {exc}[/red]")
+        # Escape the dynamic exception text: Rich re-parses console.print
+        # arguments as markup, so an exception message containing "[...]"
+        # raises a secondary MarkupError (see #297). Keep the static
+        # "Error:" label styled; render the message literally.
+        from rich.markup import escape
+
+        console.print(f"[red]Error:[/red] {escape(str(exc))}")
 
 
 @agent.command("create")

--- a/tests/cli/test_agent_cmd.py
+++ b/tests/cli/test_agent_cmd.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 from click.testing import CliRunner
 
 from openjarvis.cli import cli
@@ -11,6 +13,25 @@ class TestAgentCmd:
     def test_agent_list_help(self) -> None:
         result = CliRunner().invoke(cli, ["agents", "list", "--help"])
         assert result.exit_code == 0
+
+    def test_agent_list_error_with_markup_chars_does_not_crash(self) -> None:
+        """Regression for #297.
+
+        When ``_get_manager()`` (or anything in the body) raises an
+        exception whose message contains Rich markup metacharacters like
+        ``[...]``, the error handler must not re-parse that text as markup
+        and blow up with a secondary MarkupError traceback. The command
+        should print a clean one-line error instead.
+        """
+        # A message with bracketed text is what triggers the MarkupError
+        # when fed to console.print() unescaped.
+        boom = RuntimeError("DB locked at [/var/run/x] not a [valid] tag")
+        with patch("openjarvis.cli.agent_cmd._get_manager", side_effect=boom):
+            result = CliRunner().invoke(cli, ["agents", "list"])
+        # No traceback / unhandled exception leaked through.
+        assert result.exception is None, result.output
+        # The raw message (brackets intact) is surfaced to the user.
+        assert "DB locked at [/var/run/x] not a [valid] tag" in result.output
 
     def test_agent_info_help(self) -> None:
         result = CliRunner().invoke(cli, ["agents", "info", "--help"])


### PR DESCRIPTION
## Problem

`jarvis agents list` crashed with a secondary traceback when the underlying operation raised an exception whose message contained Rich markup metacharacters (e.g. a path like `[/var/run/x]`). The error handler did:

```python
except Exception as exc:
    console.print(f"[red]Error: {exc}[/red]")
```

Rich treats `console.print` arguments as console markup, so the interpolated `{exc}` was re-parsed as markup and raised a `MarkupError` ("closing tag '...' doesn't match any open tag") — burying the real error under a Rich traceback. This matches the #297 report (intermittent on Windows/WSL2 during a model-unload window: the *first* exception is transient, but the handler meant to display it crashes instead).

## Fix

Escape the dynamic exception text with `rich.markup.escape`, keeping only the static `Error:` label styled:

```python
except Exception as exc:
    from rich.markup import escape
    console.print(f"[red]Error:[/red] {escape(str(exc))}")
```

The original error now surfaces cleanly as a one-line message with brackets rendered literally. Control flow is unchanged (print, then return; exit code stays 0).

## Verification

- **TDD**: new `test_agent_list_error_with_markup_chars_does_not_crash` patches `_get_manager` to raise `RuntimeError("DB locked at [/var/run/x] not a [valid] tag")`. It fails before the fix with the exact `MarkupError`, and passes after — asserting no exception leaks and the raw message (brackets intact) reaches the user.
- Full `tests/cli/test_agent_cmd.py` (18 tests) passes; `ruff check` clean.

Closes #297.

🤖 Generated with [Claude Code](https://claude.com/claude-code)