### PR TITLE
fix(engine): retry without temperature on unsupported_value 400 (#426)

### DIFF
--- a/src/openjarvis/engine/cloud.py
+++ b/src/openjarvis/engine/cloud.py
@@ -136,6 +136,25 @@ def _is_openai_reasoning_model(model: str) -> bool:
     return m == "gpt-5-mini" or m.startswith("gpt-5-mini-")
 
 
+def _is_unsupported_temperature_error(exc: Exception) -> bool:
+    """True if an OpenAI 400 says the model rejects a non-default temperature.
+
+    Some models (e.g. gpt-5) only accept the default temperature and return
+    ``code: unsupported_value`` for ``param: temperature`` (see #426). We
+    can't enumerate every such model up front, so detect the error and retry
+    without temperature — mirroring the tools-400 retry in the local engines.
+    """
+    message = str(exc).lower()
+    if "temperature" not in message:
+        return False
+    return (
+        "unsupported_value" in message
+        or "unsupported value" in message
+        or "only the default" in message
+        or "does not support" in message
+    )
+
+
 def estimate_cost(model: str, prompt_tokens: int, completion_tokens: int) -> float:
     """Estimate USD cost based on the hardcoded pricing table."""
     # Try exact match first, then prefix match
@@ -165,8 +184,14 @@ def _serialize_anthropic_block(block: Any) -> Dict[str, Any]:
         "type": getattr(block, "type", None) or type(block).__name__,
     }
     for attr in (
-        "id", "name", "input", "text", "thinking", "signature",
-        "tool_use_id", "content",
+        "id",
+        "name",
+        "input",
+        "text",
+        "thinking",
+        "signature",
+        "tool_use_id",
+        "content",
     ):
         if not hasattr(block, attr):
             continue
@@ -521,7 +546,19 @@ class CloudEngine(InferenceEngine):
                 create_kwargs["response_format"] = response_format
 
         t0 = time.monotonic()
-        resp = self._openai_client.chat.completions.create(**create_kwargs)
+        try:
+            resp = self._openai_client.chat.completions.create(**create_kwargs)
+        except Exception as exc:
+            # Some models reject a non-default temperature with a 400
+            # unsupported_value (see #426). Retry once without it rather
+            # than failing the user's first prompt.
+            if "temperature" in create_kwargs and _is_unsupported_temperature_error(
+                exc
+            ):
+                create_kwargs.pop("temperature", None)
+                resp = self._openai_client.chat.completions.create(**create_kwargs)
+            else:
+                raise
         elapsed = time.monotonic() - t0
         choice = resp.choices[0]
         usage = resp.usage

--- a/tests/engine/test_cloud.py
+++ b/tests/engine/test_cloud.py
@@ -114,6 +114,97 @@ class TestCloudEngineGenerate:
         assert result["usage"]["completion_tokens"] == 8
 
 
+class TestOpenAIUnsupportedTemperatureRetry:
+    """Regression for #426.
+
+    Some OpenAI models (e.g. gpt-5) reject a non-default ``temperature``
+    with HTTP 400 ``unsupported_value``. A brand-new install defaults to
+    such a model, so the very first prompt 400s. The engine must detect
+    this specific error and retry once without ``temperature``.
+    """
+
+    def _fake_resp(self):
+        return SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content="ok"),
+                    finish_reason="stop",
+                )
+            ],
+            usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+            model="gpt-5",
+        )
+
+    def test_retries_without_temperature_on_unsupported_value(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+        calls: list[dict] = []
+        err = Exception(
+            "Error code: 400 - {'error': {'message': \"Unsupported value: "
+            "'temperature' does not support 0.7 with this model. Only the "
+            "default (1) value is supported.\", 'type': "
+            "'invalid_request_error', 'param': 'temperature', 'code': "
+            "'unsupported_value'}}"
+        )
+
+        def create(**kwargs):
+            calls.append(kwargs)
+            if "temperature" in kwargs:
+                raise err
+            return self._fake_resp()
+
+        fake_client = mock.MagicMock()
+        fake_client.chat.completions.create.side_effect = create
+
+        EngineRegistry.register_value("cloud", CloudEngine)
+        engine = CloudEngine()
+        engine._openai_client = fake_client
+
+        result = engine.generate(
+            [Message(role=Role.USER, content="Hi")],
+            model="gpt-5",
+            temperature=0.7,
+        )
+        # The call succeeded via the retry.
+        assert result["content"] == "ok"
+        # First attempt sent temperature, retry dropped it.
+        assert len(calls) == 2
+        assert "temperature" in calls[0]
+        assert "temperature" not in calls[1]
+
+    def test_unrelated_400_is_not_retried(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+        calls: list[dict] = []
+        err = Exception("Error code: 400 - context_length_exceeded")
+
+        def create(**kwargs):
+            calls.append(kwargs)
+            raise err
+
+        fake_client = mock.MagicMock()
+        fake_client.chat.completions.create.side_effect = create
+
+        EngineRegistry.register_value("cloud", CloudEngine)
+        engine = CloudEngine()
+        engine._openai_client = fake_client
+
+        with pytest.raises(Exception):  # noqa: B017 - re-raised unchanged
+            engine.generate(
+                [Message(role=Role.USER, content="Hi")],
+                model="gpt-4o",
+                temperature=0.7,
+            )
+        # No temperature-retry for an unrelated 400 — exactly one attempt.
+        assert len(calls) == 1
+
+
 # ---------------------------------------------------------------------------
 # Codex provider support (OpenAI Responses API)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

A brand-new cloud install defaults to a model (e.g. `gpt-5`) that only accepts the **default** temperature. The first prompt sends `temperature=0.7` and the API returns:

```
400 - Unsupported value: 'temperature' does not support 0.7 with this model.
Only the default (1) value is supported. (param: temperature, code: unsupported_value)
```

So `jarvis` fails on the user's very first message (#426).

## Fix

Add `_is_unsupported_temperature_error()` and wrap the OpenAI `chat.completions.create()` call in `_generate_openai`: on a 400 that names `temperature` as unsupported, drop `temperature` from the kwargs and retry once. This mirrors the existing tools-400 retry idiom in `ollama.py` and `_openai_compat.py`. Unrelated 400s re-raise unchanged.

We detect-and-retry rather than maintain a model allowlist because the set of restricted models changes over time and can't be enumerated up front.

## Verification

- **TDD**, two tests (fail-before / pass-after):
  - `test_retries_without_temperature_on_unsupported_value` — mock raises the real 400 shape when `temperature` is present, succeeds without it; asserts exactly 2 calls, temperature present then absent.
  - `test_unrelated_400_is_not_retried` — a non-temperature 400 raises with exactly 1 attempt (no spurious retry).
- Full `tests/engine/test_cloud.py` (20 tests) passes; `ruff check` clean.

**Scope note:** fixes the standard OpenAI path (the one in the report). The streaming OpenAI path and other providers (OpenRouter/MiniMax) aren't touched here; can follow up if the same 400 surfaces there.

Closes #426.

🤖 Generated with [Claude Code](https://claude.com/claude-code)