### PR TITLE
perf(serve): parallelize engine discovery + async version check (#263)

### DIFF
--- a/src/openjarvis/cli/__init__.py
+++ b/src/openjarvis/cli/__init__.py
@@ -68,9 +68,21 @@ def cli(ctx: click.Context, verbose: bool, quiet: bool) -> None:
 
     research_mode_active = "--research" in sys.argv
     if not quiet and ctx.invoked_subcommand and not research_mode_active:
+        import threading
+
         from openjarvis.cli._version_check import check_for_updates
 
-        check_for_updates(ctx.invoked_subcommand)
+        # Run the PyPI version poll off the hot path: on a cache miss it does
+        # a blocking urlopen (up to 3s) that otherwise delays every command,
+        # notably `jarvis serve` startup (#263). It's best-effort and never
+        # raises, and the nudge prints to stderr, so a daemon thread is safe —
+        # for long-lived commands (serve) it finishes; for short commands that
+        # exit first, the check is simply skipped this run (same as a miss).
+        threading.Thread(
+            target=check_for_updates,
+            args=(ctx.invoked_subcommand,),
+            daemon=True,
+        ).start()
 
     # First-run guard — routes bare `jarvis` to chat or init.
     if ctx.invoked_subcommand is None:
@@ -129,9 +141,7 @@ try:
 except Exception as _dr_exc:
     import logging as _logging
 
-    _logging.getLogger(__name__).debug(
-        "deep-research command unavailable: %s", _dr_exc
-    )
+    _logging.getLogger(__name__).debug("deep-research command unavailable: %s", _dr_exc)
 cli.add_command(self_update, "self-update")
 cli.add_command(bootstrap_cmd, "_bootstrap")
 

--- a/src/openjarvis/engine/_discovery.py
+++ b/src/openjarvis/engine/_discovery.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Dict, List, Tuple
 
 from openjarvis.core.config import JarvisConfig
@@ -106,15 +107,30 @@ def discover_engines(config: JarvisConfig) -> List[Tuple[str, InferenceEngine]]:
     Results are sorted with the config default engine first.
     """
     _maybe_register_mining_sidecar_engine()
-    healthy: List[Tuple[str, InferenceEngine]] = []
-    for key in EngineRegistry.keys():
+
+    # Probe engines concurrently: each health() does a blocking network
+    # check with its own timeout, so a serial loop costs the SUM of all
+    # probe timeouts (dead localhost ports especially). Running them in
+    # threads collapses that to roughly the slowest single probe. The
+    # healthy.sort() below normalizes order, so completion order is
+    # irrelevant and the result is identical to the serial version (#263).
+    keys = list(EngineRegistry.keys())
+
+    def _probe(key: str) -> Tuple[str, InferenceEngine] | None:
         try:
             engine = _make_engine(key, config)
             if engine.health():
-                healthy.append((key, engine))
+                return (key, engine)
         except Exception as exc:
             logger.debug("Engine %r failed during discovery: %s", key, exc)
-            continue
+        return None
+
+    healthy: List[Tuple[str, InferenceEngine]] = []
+    if keys:
+        with ThreadPoolExecutor(max_workers=len(keys)) as pool:
+            for result in pool.map(_probe, keys):
+                if result is not None:
+                    healthy.append(result)
 
     default_key = config.engine.default
 

--- a/tests/engine/test_discovery.py
+++ b/tests/engine/test_discovery.py
@@ -73,6 +73,55 @@ class TestDiscoverEngines:
             result = discover_engines(cfg)
         assert result[0][0] == "b"
 
+    def test_health_checks_run_concurrently(self) -> None:
+        """Regression for #263 — discovery must probe engines in parallel.
+
+        Each engine's health() does a blocking network probe with its own
+        timeout, so serial discovery cost = sum of probe times. With N
+        engines each sleeping S, parallel discovery wall-time must stay far
+        below N*S (closer to S). We don't measure real time precisely (CI is
+        noisy); instead we record concurrency: the max number of health()
+        calls in flight simultaneously must exceed 1.
+        """
+        import threading
+        import time
+
+        n_engines = 6
+        sleep_s = 0.15
+        for i in range(n_engines):
+            _reg(f"slow{i}", f"slow{i}")
+
+        lock = threading.Lock()
+        in_flight = 0
+        max_in_flight = 0
+
+        class _SlowEngine(_FakeEngine):
+            def health(self) -> bool:
+                nonlocal in_flight, max_in_flight
+                with lock:
+                    in_flight += 1
+                    max_in_flight = max(max_in_flight, in_flight)
+                time.sleep(sleep_s)
+                with lock:
+                    in_flight -= 1
+                return True
+
+        cfg = JarvisConfig()
+        with mock.patch(
+            "openjarvis.engine._discovery._make_engine",
+            side_effect=lambda k, c: _SlowEngine(healthy=True),
+        ):
+            start = time.monotonic()
+            result = discover_engines(cfg)
+            elapsed = time.monotonic() - start
+
+        # All slow engines were discovered (plus any real registered ones).
+        assert len([r for r in result if r[0].startswith("slow")]) == n_engines
+        # Concurrency actually happened — more than one probe overlapped.
+        assert max_in_flight > 1, f"probes ran serially (max_in_flight={max_in_flight})"
+        # Wall-time is well under the serial sum (n*sleep), allowing slack.
+        assert elapsed < n_engines * sleep_s * 0.7
+
 
 class TestDiscoverModels:
     def test_aggregate_models(self) -> None:


### PR DESCRIPTION
## Problem (#263)

`jarvis serve` takes 70+s to start on a fast machine. Two of the three root causes are addressed here (the third is deferred — see below).

## Fixes

**1. Parallelize `discover_engines`** (`_discovery.py`)
The serial loop called each registered engine's `health()` one at a time, and every probe is a blocking network check with its own ~2s timeout — so N dead/slow localhost ports cost N×2s (≈10–28s). Now probes run concurrently in a `ThreadPoolExecutor`. The existing `healthy.sort()` normalizes order, so **output is identical** to the serial version. `health()` impls are read-only on per-instance HTTP clients with no shared mutable state.

**2. Async version check** (`cli/__init__.py`)
The PyPI update poll did a blocking `urlopen` (up to 3s on a cache miss) inline before command dispatch, delaying every command. Moved to a daemon thread — it's best-effort, never raises, and prints to stderr.

Together: ~13–31s off cold startup.

## Verification
- New regression test `test_health_checks_run_concurrently` records max concurrent `health()` calls — fails on the serial impl (`max_in_flight=1`), passes after (proves real overlap, not just unchanged output).
- Existing discovery tests (healthy-only, default-first, fallback, sidecar) still pass — output unchanged. Version-check + CLI tests unaffected. 57 tests green; ruff clean.

## Deferred (not in scope)
The headline ~30–40s win — the duplicate `SystemBuilder.build()` in `serve.py` — is **not** addressed. It's not actually redundant: `executor.set_system()` consumes a fully-wired `JarvisSystem` (tool_executor, session_store, skill_manager) that serve.py's inline path never constructs, so de-duping risks silently breaking scheduled agents. Needs a design pass (touches core abstractions).

Refs #263.

🤖 Generated with [Claude Code](https://claude.com/claude-code)