### PR TITLE
docs(test): use canonical github.io install URL in run-as-root case (#337)

### DIFF
--- a/tests/install/cases/run-as-root.md
+++ b/tests/install/cases/run-as-root.md
@@ -15,7 +15,7 @@ User runs `sudo bash install.sh` or invokes the installer from a root shell.
 Re-run as the regular user (without sudo):
 
 ```bash
-curl -fsSL https://openjarvis.ai/install.sh | bash
+curl -fsSL https://open-jarvis.github.io/OpenJarvis/install.sh | bash
 ```
 
 ## Test


### PR DESCRIPTION
## What

The `run-as-root` install case doc (`tests/install/cases/run-as-root.md`) still showed its retry command using `https://openjarvis.ai/install.sh` — the community-operated domain whose TLS is broken and which the project does **not** control (#337). Point it at the canonical, project-controlled GitHub Pages URL, matching README and the install docs.

## Why this is the only repo change needed for #337

`openjarvis.ai` appears **nowhere in shipped `src/`** — only in docs, deploy examples, a changelog (historical), and this one test fixture. The user-facing install path was already fixed in #402 (canonical URL `https://open-jarvis.github.io/OpenJarvis/install.sh`, verified serving HTTP 200). This was the last stale install reference pointing at the dead domain.

## Scope / safety

- Documentation only. The case `.md` describes the bats test `tests/install/bash/test_install.bats::"refuses to run as root"`, which stubs `id` to fake uid 0 and asserts non-zero exit + "root" in stderr — **no URL dependency**, so test behavior is unchanged.
- Mining-pool (`pool.openjarvis.ai`) and analytics (`analytics.openjarvis.ai`) references are left as-is: they're illustrative examples in design docs / deploy scripts, not runtime defaults, and are out of scope for the install issue.

Refs #337.

🤖 Generated with [Claude Code](https://claude.com/claude-code)