### PR TITLE
fix(tools): return labeled page content from web_search (#390)

### DIFF
--- a/src/openjarvis/tools/web_search.py
+++ b/src/openjarvis/tools/web_search.py
@@ -120,12 +120,15 @@ class WebSearchTool(BaseTool):
         from ddgs import DDGS
 
         ddgs = DDGS()
-        results = list(ddgs.text(query, max_results=max_results))
-        formatted = "\n\n".join(
-            f"**{r.get('title', 'Untitled')}**\n"
-            f"{r.get('href', '')}\n{r.get('body', '')}"
-            for r in results
-        )
+        raw_results = list(ddgs.text(query, max_results=max_results))
+        results = []
+        for r in raw_results:
+            title = r.get("title", "Untitled")
+            url = r.get("href", "")
+            snippet = r.get("body", "")
+            results.append(f"### {title}\nSource: {url}\nSummary: {snippet}")
+
+        formatted = "\n\n---\n\n".join(results)
         return formatted
 
     def execute(self, **params: Any) -> ToolResult:
@@ -161,13 +164,20 @@ class WebSearchTool(BaseTool):
             from tavily import TavilyClient
 
             client = TavilyClient(api_key=self._api_key)
-            response = client.search(query, max_results=max_results)
-            results = response.get("results", [])
-            formatted = "\n\n".join(
-                f"**{r.get('title', 'Untitled')}**\n"
-                f"{r.get('url', '')}\n{r.get('content', '')}"
-                for r in results
+            response = client.search(
+                query, max_results=max_results, search_depth="advanced"
             )
+            results = response.get("results", [])
+            formatted_parts = []
+            for r in results:
+                title = r.get("title", "Untitled")
+                url = r.get("url", "")
+                content = r.get("content", "") or r.get("snippet", "")
+                formatted_parts.append(
+                    f"### {title}\nSource: {url}\nSummary: {content}"
+                )
+
+            formatted = "\n\n---\n\n".join(formatted_parts)
             return ToolResult(
                 tool_name="web_search",
                 content=formatted or "No results found.",

--- a/tests/tools/test_web_search.py
+++ b/tests/tools/test_web_search.py
@@ -170,7 +170,9 @@ class TestWebSearchTool:
 
         tool = WebSearchTool(api_key="test-key", max_results=3)
         tool.execute(query="test", max_results=7)
-        mock_client.search.assert_called_once_with("test", max_results=7)
+        mock_client.search.assert_called_once_with(
+            "test", max_results=7, search_depth="advanced"
+        )
 
     def test_to_openai_function(self):
         tool = WebSearchTool(api_key="test-key")
@@ -230,6 +232,82 @@ class TestWebSearchTool:
     def test_registry_registration(self):
         ToolRegistry.register_value("web_search", WebSearchTool)
         assert ToolRegistry.contains("web_search")
+
+    def test_tavily_results_use_labeled_content_format(self, monkeypatch):
+        """Regression for #390: results expose page CONTENT under labeled
+        Source/Summary headings (so agents synthesize content, not echo
+        URLs), and Tavily is queried with search_depth='advanced'."""
+        import builtins
+
+        mock_client = MagicMock()
+        mock_client.search.return_value = {
+            "results": [
+                {
+                    "title": "Result 1",
+                    "url": "https://example.com/1",
+                    "content": "Content about test.",
+                },
+            ]
+        }
+        mock_tavily_module = MagicMock()
+        mock_tavily_module.TavilyClient.return_value = mock_client
+        original_import = builtins.__import__
+
+        def _mock_import(name, *args, **kwargs):
+            if name == "tavily":
+                return mock_tavily_module
+            if name == "tavily.errors":
+                mock_errors = MagicMock()
+                mock_errors.UsageLimitExceededError = Exception
+                return mock_errors
+            return original_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _mock_import)
+
+        tool = WebSearchTool(api_key="test-key")
+        result = tool.execute(query="test query")
+        assert result.success is True
+        # Labeled structure with the page content surfaced.
+        assert "### Result 1" in result.content
+        assert "Source: https://example.com/1" in result.content
+        assert "Summary: Content about test." in result.content
+        # search_depth='advanced' is what pulls richer content from Tavily.
+        _, kwargs = mock_client.search.call_args
+        assert kwargs.get("search_depth") == "advanced"
+
+    def test_tavily_falls_back_to_snippet_when_no_content(self, monkeypatch):
+        """When a Tavily result lacks 'content', the 'snippet' field is used
+        for the Summary rather than rendering an empty summary."""
+        import builtins
+
+        mock_client = MagicMock()
+        mock_client.search.return_value = {
+            "results": [
+                {
+                    "title": "Snippet Only",
+                    "url": "https://example.com/s",
+                    "snippet": "Fallback snippet text.",
+                },
+            ]
+        }
+        mock_tavily_module = MagicMock()
+        mock_tavily_module.TavilyClient.return_value = mock_client
+        original_import = builtins.__import__
+
+        def _mock_import(name, *args, **kwargs):
+            if name == "tavily":
+                return mock_tavily_module
+            if name == "tavily.errors":
+                mock_errors = MagicMock()
+                mock_errors.UsageLimitExceededError = Exception
+                return mock_errors
+            return original_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _mock_import)
+
+        tool = WebSearchTool(api_key="test-key")
+        result = tool.execute(query="test query")
+        assert "Summary: Fallback snippet text." in result.content
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem (#390)

`web_search` returned thin, unlabeled results — Tavily's default `search_depth` plus a `**title**` / url / content blob. Small local models in the `native_react` loop tended to **echo the URLs** instead of synthesizing page content; only the orchestrator (which post-processes) coped.

## Fix

- Query Tavily with **`search_depth="advanced"`** (richer page content).
- Format each result as a labeled block so the content is unambiguous to the model:
  ```
  ### {title}
  Source: {url}
  Summary: {content or snippet}
  ```
  joined with `---` separators. DuckDuckGo fallback uses the same shape.
- Fall back to a result's `snippet` when `content` is absent.

## Provenance

Extracted from #448 by @sanjayravit — **the web_search portion only**. That PR also bundled an unrelated 239-line `install.sh` rewrite (git/curl auto-bootstrap, venv creation) under a "web_search" title; that part is out of scope here and left for separate review. Full credit to @sanjayravit for the web_search fix.

## Verification

- Added tests asserting the labeled `### / Source: / Summary:` format, the `snippet` fallback, and that Tavily is called with `search_depth="advanced"`.
- Updated `test_max_results_parameter` for the new call signature (it asserted the exact `search()` kwargs).
- Existing title-substring assertions still pass (the new `### {title}` contains the title). Full `tests/tools/test_web_search.py`: **38 passed**; ruff clean.

Closes #390.

🤖 Generated with [Claude Code](https://claude.com/claude-code)