### PR TITLE
fix(install): gracefully handle host environments without Python

### DIFF
--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -202,12 +202,14 @@ need curl
 # on minimal distros that only ship the unversioned name. This is used by
 # the analytics beacon and state-file helpers below — uv installs its own
 # interpreter into the venv later, so this is only for the bootstrap shims.
-PY_CMD="python3"
-if ! command -v python3 >/dev/null 2>&1; then
-    if command -v python >/dev/null 2>&1; then
-        PY_CMD="python"
-    fi
+PY_CMD=""
+if command -v python3 >/dev/null 2>&1; then
+    PY_CMD="python3"
+elif command -v python >/dev/null 2>&1; then
+    PY_CMD="python"
 fi
+# If still not found, set to true to allow scripts to continue without crashing
+[[ -z "$PY_CMD" ]] && PY_CMD="true"
 
 # ---- env ----
 OPENJARVIS_HOME="${OPENJARVIS_HOME:-$HOME/.openjarvis}"


### PR DESCRIPTION
## What does this PR do?
This PR makes the [install.sh](cci:7://file:///e:/jarvis/scripts/install/install.sh:0:0-0:0) script more robust by gracefully handling host environments where `python3` or `python` is not yet available on the PATH.

Previously, the script would crash early at the analytics beacon or state-marking stages if no host Python was found. This change adds a fallback to `true` for the `PY_CMD` variable, allowing the script to proceed through the [install_uv](cci:1://file:///e:/jarvis/scripts/install/install.sh:404:0-413:1) and [create_venv](cci:1://file:///e:/jarvis/scripts/install/install.sh:428:0-449:1) steps where a managed Python version is eventually installed.

## Why is this important?
- Enables a smoother "cold start" experience on fresh systems.
- Prevents unnecessary script failures in minimalist environments.
- Maintainers requested smaller, focused PRs instead of large rewrites.

## How was this tested?
- Verified the logic on a system with Python installed (normal operation).
- Manually tested by temporarily mocking a missing Python to ensure the script continues without error.


## Checklist

- [x] Tests pass (`uv run pytest tests/ -v`)
- [x] Linter passes (`uv run ruff check src/ tests/`)
- [x] Formatter passes (`uv run ruff format --check src/ tests/`)
- [x] New/changed public API has docstrings
- [x] Follows registry pattern (if adding new component)
- [ ] Documentation updated (if applicable)
