### PR TITLE
fix(channels): use conversation_id (not channel type) as Discord reply destination (#459)

### DIFF
--- a/src/openjarvis/agents/channel_agent.py
+++ b/src/openjarvis/agents/channel_agent.py
@@ -112,10 +112,15 @@ class ChannelAgent:
             friendly = (
                 f"Sorry, I ran into an error while processing your request: {exc}"
             )
+            # First positional arg is the DESTINATION (per-adapter native
+            # ID — Discord channel ID, Slack channel ID, etc.); not the
+            # channel TYPE label. The `conversation_id=` kwarg is the
+            # native message ID for reply threading (per DiscordChannel
+            # / SlackChannel / etc. send() contract — see #459).
             self._channel.send(
-                msg.channel,
+                msg.conversation_id,
                 friendly,
-                conversation_id=msg.conversation_id,
+                conversation_id=msg.message_id,
             )
             return
 
@@ -130,10 +135,11 @@ class ChannelAgent:
         else:
             reply = response_text
 
+        # Same field-mapping as the error path above (#459).
         self._channel.send(
-            msg.channel,
+            msg.conversation_id,
             reply,
-            conversation_id=msg.conversation_id,
+            conversation_id=msg.message_id,
         )
 
     # ------------------------------------------------------------------

--- a/src/openjarvis/channels/discord_channel.py
+++ b/src/openjarvis/channels/discord_channel.py
@@ -94,6 +94,16 @@ class DiscordChannel(BaseChannel):
         if not self._token:
             logger.warning("Cannot send: no Discord bot token")
             return False
+        # Defensive guard for #459 follow-up: an empty `channel` arg would
+        # produce /channels//messages and silently 404. Better to fail
+        # explicitly so the upstream bug (wrong field passed in) surfaces
+        # in the warning log instead of silently blackholing the reply.
+        if not channel:
+            logger.warning(
+                "Cannot send: no Discord channel destination "
+                "(caller passed empty channel id)"
+            )
+            return False
 
         try:
             import httpx

--- a/tests/agents/test_channel_agent.py
+++ b/tests/agents/test_channel_agent.py
@@ -134,12 +134,16 @@ def _make_msg(
     channel: str = "fake",
     sender: str = "user1",
     session_id: str = "sess-001",
+    conversation_id: str = "",
+    message_id: str = "",
 ) -> ChannelMessage:
     return ChannelMessage(
         channel=channel,
         sender=sender,
         content=content,
         session_id=session_id,
+        conversation_id=conversation_id,
+        message_id=message_id,
     )
 
 
@@ -251,3 +255,64 @@ class TestChannelAgent:
         assert len(channel._sent) == 1
         sent_content = channel._sent[0]["content"]
         assert "openjarvis://research/" in sent_content
+
+    def test_reply_uses_conversation_id_as_destination_not_channel_type(self):
+        """Regression for #459 — Discord (and every per-adapter native API)
+        wants the per-channel destination ID, not the channel TYPE label.
+
+        Pre-fix:
+          self._channel.send(msg.channel, ...)        # "discord" → 404
+          conversation_id=msg.conversation_id          # channel-id used as msg-ref-id
+
+        Post-fix:
+          self._channel.send(msg.conversation_id, ...) # numeric channel id
+          conversation_id=msg.message_id               # the message being replied to
+        """
+        channel = FakeChannel()
+        agent = _make_agent("hi back")
+        ca = ChannelAgent(channel, agent)
+
+        # The exact ChannelMessage shape DiscordChannel actually produces:
+        # channel = "discord" (TYPE label), conversation_id = numeric Discord
+        # channel id, message_id = numeric Discord message id.
+        msg = _make_msg(
+            content="hello",
+            channel="discord",
+            conversation_id="987654321098765432",
+            message_id="111122223333444455",
+        )
+        channel.simulate_message(msg)
+        ca.shutdown()
+
+        assert len(channel._sent) == 1
+        sent = channel._sent[0]
+        # The destination must be the numeric channel id, not the TYPE label.
+        assert sent["channel"] == "987654321098765432"
+        assert sent["channel"] != "discord"
+        # The conversation_id kwarg must carry the message id (for reply
+        # threading), not the channel id.
+        assert sent["conversation_id"] == "111122223333444455"
+
+    def test_error_path_also_uses_conversation_id_as_destination(self):
+        """The except-clause friendly-error path has the same field-mapping
+        bug as the success path (channel_agent.py:115-119). Verify both
+        sites are fixed."""
+        channel = FakeChannel()
+        agent = MagicMock()
+        agent.run.side_effect = RuntimeError("model unavailable")
+        ca = ChannelAgent(channel, agent)
+
+        msg = _make_msg(
+            content="hello",
+            channel="discord",
+            conversation_id="987654321098765432",
+            message_id="111122223333444455",
+        )
+        channel.simulate_message(msg)
+        ca.shutdown()
+
+        assert len(channel._sent) == 1
+        sent = channel._sent[0]
+        assert sent["channel"] == "987654321098765432"
+        assert sent["conversation_id"] == "111122223333444455"
+        assert "Sorry" in sent["content"]

--- a/tests/channels/test_discord_channel.py
+++ b/tests/channels/test_discord_channel.py
@@ -77,6 +77,17 @@ class TestSend:
             payload = mock_post.call_args[1]["json"]
             assert payload["message_reference"] == {"message_id": "msg-123"}
 
+    def test_send_refuses_empty_channel(self):
+        """Defensive guard for #459 follow-up: an empty `channel` arg
+        would build /channels//messages and silently 404. We refuse
+        fast so the upstream bug surfaces in the log instead of the
+        reply being blackholed."""
+        ch = DiscordChannel(bot_token="my-bot-token")
+        with patch("httpx.post") as mock_post:
+            result = ch.send("", "Hi there!")
+            assert result is False
+            mock_post.assert_not_called()
+
     def test_send_failure(self):
         ch = DiscordChannel(bot_token="my-bot-token")
 


### PR DESCRIPTION
## Summary

Closes #459. Reported by @jasonftl with a precise smoking gun: incoming \`ChannelMessage\` has \`channel=\"discord\"\` (TYPE label) and \`conversation_id=<numeric channel id>\`. The reply code was using \`cm.channel\` as the destination — Discord saw \`/channels/discord/messages\` and 404'd, blackholing every reply.

## What changed

**`src/openjarvis/agents/channel_agent.py`** — `_process_message` had two field-mapping bugs in both the happy path (line 133) and the exception path (line 115):

```diff
-self._channel.send(
-    msg.channel,                          # \"discord\" — the TYPE label
-    reply,
-    conversation_id=msg.conversation_id,  # channel id used as msg-ref-id
-)
+self._channel.send(
+    msg.conversation_id,                  # numeric Discord channel id
+    reply,
+    conversation_id=msg.message_id,       # message id for reply threading
+)
```

The existing `test_send_with_conversation_id` test proves the `DiscordChannel.send()` contract:
- first positional `channel` = native destination ID (Discord channel id)
- `conversation_id=` kwarg = native message ID (for reply threading)

**`src/openjarvis/channels/discord_channel.py`** — defensive guard. When `channel` is empty, refuse fast with a clear warning instead of POSTing to `/channels//messages` and silently 404'ing. The HIGH adversarial concern noted that without this guard, a future regression (someone passing the wrong field again) would silently blackhole replies just like #459 itself did.

## Other channel adapters

The verdict's audit confirmed no other channel adapters share this pattern. Slack, Telegram, Matrix, IRC, etc. each interpret `send()`'s first arg as the destination correctly. Only the `ChannelAgent` caller was passing the wrong field. Single-blast-radius fix.

## Tests

- **`test_reply_uses_conversation_id_as_destination_not_channel_type`** — builds a Discord-shaped ChannelMessage (channel=\"discord\", conversation_id=\"987654321098765432\", message_id=\"111122223333444455\"), simulates dispatch through `ChannelAgent`, asserts `send()` received the numeric channel id (not \"discord\") AND the message id as the threading kwarg.
- **`test_error_path_also_uses_conversation_id_as_destination`** — same assertion for the friendly-error path so both call sites are pinned.
- **`test_send_refuses_empty_channel`** — defensive guard.

38 affected tests pass (3 new + 35 existing).

## Credit

@jasonftl — the bug report named the exact wrong field with the exact expected field, which made this a one-prompt fix. The actual field semantics turned out to span two distinct bugs in the same call (destination + reply-threading) — the workflow audit caught the second one.

## Test plan

- [x] `uv run ruff check` on touched files — clean
- [x] `uv run pytest tests/agents/test_channel_agent.py tests/channels/test_discord_channel.py -v` — 38 passed
- [ ] CI green
- [ ] Manual: @jasonftl to confirm with a live Discord bot that replies actually appear in his channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)