### PR TITLE
fix(leaderboard): filter quarantined methodology_version=0 rows

### DIFF
--- a/docs/javascripts/leaderboard.js
+++ b/docs/javascripts/leaderboard.js
@@ -116,8 +116,15 @@
     }
 
     fetch(
+      // `methodology_version=gte.1` filter excludes rows that the
+      // leaderboard-correctness migration quarantined (version 0). Rows
+      // written by current and future clients carry version >= 1, so this
+      // is forward-compatible — pre-fix corrupt rows hide at the query
+      // level (fewer bytes over the wire than client-side outlier
+      // filtering), and downstream client-side checks remain as a
+      // belt-and-suspenders second line of defence.
       SUPABASE_URL +
-        "/rest/v1/savings_entries?select=display_name,dollar_savings,energy_wh_saved,flops_saved,total_calls,total_tokens&order=dollar_savings.desc&limit=1000",
+        "/rest/v1/savings_entries?select=display_name,dollar_savings,energy_wh_saved,flops_saved,total_calls,total_tokens&methodology_version=gte.1&order=dollar_savings.desc&limit=1000",
       {
         headers: {
           apikey: SUPABASE_ANON_KEY,


### PR DESCRIPTION
## Summary

Pairs with the Supabase migration that just added `methodology_version` to `savings_entries` and quarantined 43 pre-fix corrupt rows (all from March 2026) to `methodology_version = 0`. Adds `&methodology_version=gte.1` to the public leaderboard's PostgREST fetch URL so the quarantined rows are filtered at the query level — fewer bytes over the wire, forward-compatible (new clients write `version >= 1` and remain visible), and the existing client-side outlier thresholds stay in place as a second line of defence.

## Smoke test (already verified live)

Direct `curl` against `https://mtbtgpwzrbostweaanpr.supabase.co/rest/v1/savings_entries?...&methodology_version=gte.1...` with the public anon key returns:

- **5/5 top rows are version 1** — the legitimate top-savings users
- Total response set: 291 rows (was 334 before this filter)
- Top result: "Sonny by Shadowsinthe.space", 45M tokens, v=1

A separate probe with `methodology_version=eq.0` confirms the 43 quarantined rows are still in the DB (auditable) but excluded by this filter.

## Migration provenance

Run via the Supabase Management API earlier today:

```sql
ALTER TABLE savings_entries
  ADD COLUMN IF NOT EXISTS methodology_version INTEGER DEFAULT 1;

UPDATE savings_entries
SET methodology_version = 0
WHERE total_tokens > 0
  AND (energy_wh_saved::numeric / total_tokens > 0.5
       OR flops_saved::numeric / total_tokens > 1e15);
-- Affected: 43 rows. Post-state: v=0 → 43, v=1 → 291, total 334.
```

## One observation worth knowing

The 43 quarantined rows remain readable to the anon key — there is currently no RLS policy that hides `methodology_version=0`. This PR's filter is what hides them from the public site. If you want **hard** isolation (no leak via direct API queries either), add a Supabase row-level-security policy:

```sql
CREATE POLICY anon_only_current_methodology
  ON savings_entries FOR SELECT
  TO anon
  USING (methodology_version >= 1);
```

Not blocking this PR — flagging for a follow-up decision.

## Relationship to #498

PR #498 (leaderboard pipeline correctness) prevents NEW inflated rows from being written. This PR hides the historical pre-fix rows that #498 can't reach. The two are independent — this can ship before, after, or alongside #498.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
