### PR TITLE
fix(ci): gate live HuggingFace Hub download tests behind `hub` marker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Run tests
         run: |
-          uv run pytest tests/ -v --tb=short -m "not live and not cloud" \
+          uv run pytest tests/ -v --tb=short -m "not live and not cloud and not hub" \
             --cov=openjarvis \
             --cov-report=term-missing \
             --cov-report=xml \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,6 +174,7 @@ markers = [
     "live_channel: requires real channel credentials (env vars)",
     "nvidia: requires NVIDIA GPU",
     "slow: long-running test",
+    "hub: downloads real datasets from the HuggingFace Hub at runtime; excluded from the default CI lane (run with -m hub)",
     "live_external: requires HERMES_AGENT_PATH and OPENCLAW_PATH; spawns real foreign-framework subprocesses",
     "modal: requires Modal token + network; runs real swebench harness on Modal",
 ]

--- a/tests/evals/datasets/test_external_agent_datasets.py
+++ b/tests/evals/datasets/test_external_agent_datasets.py
@@ -10,6 +10,14 @@ These tests download each dataset once to ~/.cache/huggingface and
 verify the provider loads, iterates, and honours the split kwarg.
 The ModuleNotFoundError skip branch is defensive — currently
 unreachable since all three provider modules exist.
+
+Marked ``hub``: they hit the live HuggingFace Hub, so they are excluded
+from the default CI lane (which runs ``-m "not live and not cloud and not
+hub"``) — a transient Hub outage or rate-limit must not redden ``main``.
+Run them on demand with ``pytest -m hub``. The ADP provider swallows
+per-config download errors and returns 0 records on a network failure
+(see ``adp.py``), so a Hub outage surfaces here as ``assert 1 <= 0``
+rather than an exception — another reason these can't run unguarded in CI.
 """
 
 from __future__ import annotations
@@ -17,6 +25,8 @@ from __future__ import annotations
 import importlib
 
 import pytest
+
+pytestmark = pytest.mark.hub
 
 PROVIDERS = [
     ("openjarvis.evals.datasets.adp", "ADPDataset"),

--- a/tests/evals/test_dataset_splits_integration.py
+++ b/tests/evals/test_dataset_splits_integration.py
@@ -1,10 +1,21 @@
-"""Integration test: each provider's split kwarg produces disjoint train/test slices."""
+"""Integration test: each provider's split kwarg produces disjoint train/test slices.
+
+Marked ``hub``: every provider here downloads a real corpus from the
+HuggingFace Hub, so the module is excluded from the default CI lane (which
+runs ``-m "not live and not cloud and not hub"``). A transient Hub outage
+or rate-limit raises connectivity errors (``LocalEntryNotFoundError``,
+``HfHubHTTPError``) that the gated/not-found skip branch below does not
+catch — so running these unguarded made ``main`` flaky-red. Run on demand
+with ``pytest -m hub``.
+"""
 
 from __future__ import annotations
 
 import importlib
 
 import pytest
+
+pytestmark = pytest.mark.hub
 
 PROVIDERS = [
     ("openjarvis.evals.datasets.pinchbench", "PinchBenchDataset"),


### PR DESCRIPTION
## Problem

The latest `main` CI run ([27071290722](https://github.com/open-jarvis/OpenJarvis/actions/runs/27071290722)) is **red**, but it's flaky-network noise, not a code regression. 8 tests failed (6883 passed); all 8 are eval-dataset tests that **download real corpora from the HuggingFace Hub at runtime** and hit connectivity failures:

| Test | Error |
|------|-------|
| `test_external_agent_datasets` → ADP / ToolOrchestra / GeneralThoughts | `assert 1 <= 0` / `LocalEntryNotFoundError` ("check your connection") |
| `test_dataset_splits_integration` → GAIA | `HfHubHTTPError` (CloudFront 5xx/429) |
| ...→ LiveResearchBench / LiveCodeBench | `LocalEntryNotFoundError` / network `RuntimeError` |

Two signals confirm it's transient Hub flakiness, not a regression:

1. The merged change (#506) was **docs-only**, and its **PR run passed 4h before** the merge run failed.
2. The errors are all offline-fallback / CloudFront errors ("Please check your connection"), not 404s.

These tests are marked only `@pytest.mark.slow`, which CI's `-m "not live and not cloud"` filter does **not** exclude — so any Hub blip reddens `main`. They also **dominated CI wall-time** (~33 min of downloads + retry backoff on the failing run).

## Fix

- Register a dedicated `hub` pytest marker.
- Apply it (module-level `pytestmark`) to the two suites that do live Hub downloads.
- Exclude it from the default CI lane: `-m "not live and not cloud and not hub"`.

Tests remain runnable on demand with `uv run pytest -m hub`.

The ADP provider swallows per-config download errors and returns 0 records on a network failure (`adp.py`), so a Hub outage surfaces as `assert 1 <= 0` rather than an exception — it can't be made non-flaky by exception handling alone, only by gating.

## Verification

- `-m "not live and not cloud and not hub"` → **14 hub tests deselected**, 0 collected.
- `-m hub` → all **14 selected**; marker registered (no `PytestUnknownMarkWarning`).
- `ruff check` / `ruff format --check` clean on both files; `pyproject.toml` + `ci.yml` parse.
- **Coverage gate holds** (computed from the failed run's `coverage.xml`, 37227/61107 = 60.92%): the 6 other providers are covered by non-hub tests, so realistic loss is the 4 zero-other-coverage providers (adp, toolorchestra, generalthoughts, liveresearchbench = 115 lines) → **60.73%**; paranoid worst case (all 10 provider files fully uncovered) → **60.18%**. Both clear the 60% gate.

## Follow-up (not in this PR)

Add offline unit tests for adp/toolorchestra/generalthoughts/liveresearchbench (fixture/mock the HF load) to restore that thin coverage margin robustly, and optionally a nightly/scheduled `-m hub` lane so real dataset-rename/removal regressions are still caught.

🤖 Generated with [Claude Code](https://claude.com/claude-code)