### PR TITLE
fix: isolate Google account sync and account-scoped retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,15 @@ Example:
 ```bash
 jarvis init --preset morning-digest-mac
 jarvis connect gdrive          # one OAuth covers Gmail / Calendar / Tasks
+jarvis connect google --account work      # optional named Google profile
 jarvis digest --fresh          # generate and play your first briefing
 ```
+
+Named Google profiles let you connect accounts such as `personal`, `work`, or
+`subscriptions` side by side. Analysis can then stay scoped with prompts like
+`jarvis ask "Summarize only work Gmail about renewals"` or direct filters such
+as `source="gmail:work"`. See
+[Google Account Profiles](https://open-jarvis.github.io/OpenJarvis/user-guide/google-account-profiles/).
 
 Per-preset deep dives: [morning digest](https://open-jarvis.github.io/OpenJarvis/user-guide/morning-digest/) · [deep research](https://open-jarvis.github.io/OpenJarvis/user-guide/deep-research/) · [code assistant](https://open-jarvis.github.io/OpenJarvis/user-guide/code-assistant/) · [scheduled monitor](https://open-jarvis.github.io/OpenJarvis/user-guide/scheduled-monitor/) · [chat simple](https://open-jarvis.github.io/OpenJarvis/user-guide/chat-simple/) · or the full [quickstart guide](https://open-jarvis.github.io/OpenJarvis/getting-started/quickstart/).
 

--- a/README.md
+++ b/README.md
@@ -78,9 +78,36 @@ jarvis digest --fresh          # generate and play your first briefing
 ```
 
 Named Google profiles let you connect accounts such as `personal`, `work`, or
-`subscriptions` side by side. Analysis can then stay scoped with prompts like
-`jarvis ask "Summarize only work Gmail about renewals"` or direct filters such
-as `source="gmail:work"`. See
+`subscriptions` side by side. Each profile gets its own OAuth token file, source
+IDs, provenance metadata, and sync checkpoint, so Gmail/Drive/Calendar/Tasks data
+from one account does not overwrite or resume from another account's state.
+
+```bash
+# Connect multiple Google identities side by side. The account alias comes
+# before the provider name.
+jarvis connect --account personal-main google
+jarvis connect --account work google
+jarvis connect --account subscriptions google
+
+# Sync or inspect one account at a time through the API server.
+jarvis serve --port 8000
+curl -X POST 'http://127.0.0.1:8000/v1/connectors/gmail/sync?account=personal-main'
+curl 'http://127.0.0.1:8000/v1/connectors/gmail/sync?account=personal-main'
+
+# Scope research to a single account by using source:account filters.
+jarvis ask --research \
+  "Search only gmail:personal-main for the renewal notice. Do not use other accounts."
+jarvis ask --research \
+  "Search only gmail:work for the quarterly planning thread. Do not use other accounts."
+```
+
+Account-scoped filters are available as `gmail:<account>`, `gdrive:<account>`,
+`gcalendar:<account>`, and `google_tasks:<account>` wherever connector sources
+are supported. The search layer treats zero matches inside an account as zero
+matches; it will not synthesize a recent unrelated email as a fallback result.
+Incremental syncs also re-fetch a small lookback window, configurable with
+`OPENJARVIS_SYNC_LOOKBACK_SECONDS`, so messages that arrive slightly before the
+last polling timestamp are not skipped. See
 [Google Account Profiles](https://open-jarvis.github.io/OpenJarvis/user-guide/google-account-profiles/).
 
 Per-preset deep dives: [morning digest](https://open-jarvis.github.io/OpenJarvis/user-guide/morning-digest/) · [deep research](https://open-jarvis.github.io/OpenJarvis/user-guide/deep-research/) · [code assistant](https://open-jarvis.github.io/OpenJarvis/user-guide/code-assistant/) · [scheduled monitor](https://open-jarvis.github.io/OpenJarvis/user-guide/scheduled-monitor/) · [chat simple](https://open-jarvis.github.io/OpenJarvis/user-guide/chat-simple/) · or the full [quickstart guide](https://open-jarvis.github.io/OpenJarvis/getting-started/quickstart/).

--- a/docs/development/google-account-profiles-analysis-layer.md
+++ b/docs/development/google-account-profiles-analysis-layer.md
@@ -113,8 +113,8 @@ preserve the same profile scope.
 The connector sync API accepts an optional account query parameter:
 
 ```text
-POST /api/connectors/{connector_id}/sync?account=work
-GET  /api/connectors/{connector_id}/sync-status?account=work
+POST /v1/connectors/gmail/sync?account=work
+GET  /v1/connectors/gmail/sync?account=work
 ```
 
 Sync state is keyed by connector/profile pair. A long-running `gmail:work` sync

--- a/docs/development/google-account-profiles-analysis-layer.md
+++ b/docs/development/google-account-profiles-analysis-layer.md
@@ -1,0 +1,176 @@
+# Google Account Profiles: Analysis Layer Plan
+
+This note extends the Google connector profile work from the connect/auth layer
+into analysis, retrieval, citations, and test coverage.
+
+## Goal
+
+Named Google profiles should not stop at token storage. Once users connect
+accounts such as `personal`, `work`, `research`, `subscriptions`, or `banqer`,
+OpenJarvis should preserve that account boundary through indexing and analysis
+so a query can intentionally search one persona, several personas, or all
+indexed Google data.
+
+## Data Model
+
+Connector documents now carry profile metadata:
+
+```python
+metadata = {
+    "account": "work",
+    "source_profile": "work",
+    "connector": "gmail",
+}
+```
+
+Google document IDs are also account-aware where applicable, for example:
+
+```text
+gmail:work:<message-id>
+gdrive:research:<file-id>
+gcalendar:family:<event-id>
+```
+
+The knowledge store exposes both plain connector IDs and account-scoped IDs in
+`distinct_sources()`:
+
+```text
+gmail
+gmail:work
+gdrive:research
+gcalendar:family
+```
+
+## Retrieval Semantics
+
+Analysis supports two equivalent scoping styles:
+
+```python
+store.retrieve("renewals", source="gmail:work")
+hybrid.search("renewals", sources=["gmail"], accounts=["work"])
+```
+
+The first form is useful for direct retrieval and config-style source lists.
+The second form is useful for planners because account aliases can be combined
+with multiple connectors:
+
+```python
+hybrid.search(
+    "calendar conflicts",
+    sources=["gcalendar"],
+    accounts=["personal", "work"],
+)
+```
+
+`HybridSearch` applies account filters with
+`json_extract(metadata, '$.account')`, so source and account filters intersect
+instead of overwriting each other. For example, `sources=["gdrive"]` plus
+`accounts=["work"]` returns work Drive chunks, not work Gmail or personal Drive.
+
+## Planner Behavior
+
+The research loop exposes a structured `accounts` search parameter:
+
+```python
+search(query, person=None, time_range=None, sources=None, accounts=None, limit=20)
+```
+
+Planner rules now tell the model:
+
+- Use `sources=[...]` when the user names a connector such as Gmail, Drive, or
+  Calendar.
+- Use account-scoped source IDs such as `gmail:work` only when they appear in
+  the connected-sources list.
+- Use `accounts=[...]` when the user names a persona/profile/account such as
+  "work account", "personal Drive", or "research calendar".
+- Combine both filters when the user names both a connector and an account, for
+  example `sources=["gmail"], accounts=["work"]`.
+
+Example user requests:
+
+```text
+Summarize only my work email and calendar.
+Search my research Drive, not personal Drive.
+What overlaps between my personal calendar and project calendar?
+Find docs related to x0bni across my project account and personal notes.
+```
+
+## Citation And UI Metadata
+
+Search hits now include:
+
+```python
+SearchHit.account
+SearchHit.source_profile
+```
+
+`build_sources_for_client()` passes both fields through to the citation payload
+so the UI can render provenance such as `Gmail / work` and follow-up queries can
+preserve the same profile scope.
+
+## Sync API
+
+The connector sync API accepts an optional account query parameter:
+
+```text
+POST /api/connectors/{connector_id}/sync?account=work
+GET  /api/connectors/{connector_id}/sync-status?account=work
+```
+
+Sync state is keyed by connector/profile pair. A long-running `gmail:work` sync
+does not hide or overwrite `gmail:personal` status.
+
+## Migration
+
+For a clean install that already has one legacy Google profile:
+
+```bash
+jarvis connect google --account work
+```
+
+This creates a fresh token at:
+
+```text
+~/.openjarvis/connectors/google/accounts/work.json
+```
+
+If reauthenticating is not desirable, copy the legacy token:
+
+```bash
+mkdir -p ~/.openjarvis/connectors/google/accounts
+cp ~/.openjarvis/connectors/google.json \
+  ~/.openjarvis/connectors/google/accounts/work.json
+```
+
+Then run a profile sync so newly indexed chunks receive account metadata.
+
+## Test Plan
+
+Connector/auth/profile tests:
+
+```bash
+uv run --extra dev pytest \
+  tests/connectors/test_oauth_flow.py \
+  tests/connectors/test_gmail.py \
+  tests/connectors/test_store.py \
+  tests/cli/test_connect.py
+```
+
+Analysis-layer tests:
+
+```bash
+uv run --extra dev pytest \
+  tests/agents/test_research_loop.py \
+  tests/connectors/test_hybrid_search.py
+```
+
+Lint:
+
+```bash
+uv run --extra dev ruff check \
+  src/openjarvis/agents/research_loop.py \
+  src/openjarvis/connectors/hybrid_search.py \
+  src/openjarvis/server/connectors_router.py \
+  tests/agents/test_research_loop.py \
+  tests/connectors/test_hybrid_search.py
+```

--- a/docs/user-guide/channels-and-connectors.md
+++ b/docs/user-guide/channels-and-connectors.md
@@ -186,6 +186,25 @@ The fastest way is to use the App Manifest — paste this JSON to configure ever
    - Your browser will open Google's consent page → grant read-only access
    - You'll see "Authorization successful!" → Drive data starts syncing
 
+### Named Google profiles
+
+Use a profile alias when you want multiple Google accounts on the same
+OpenJarvis install:
+
+```bash
+jarvis connect google --account work
+jarvis connect google --account personal
+jarvis connect gdrive --account research
+```
+
+Tokens are stored separately under
+`~/.openjarvis/connectors/google/accounts/<alias>.json`, and indexed chunks are
+tagged with that alias. Research queries can then scope analysis to one profile,
+for example `gmail:work` or `sources=["gdrive"], accounts=["research"]`.
+
+See [Google Account Profiles](google-account-profiles.md) for migration steps
+from the legacy single-profile token file and analysis examples.
+
 ### Troubleshooting
 
 | Issue | Solution |

--- a/docs/user-guide/deep-research.md
+++ b/docs/user-guide/deep-research.md
@@ -100,6 +100,9 @@ default_backend = "sqlite"
 # Summarize across multiple documents
 jarvis ask "Summarize all emails about the Q3 budget review"
 
+# Restrict a Google query to a named account profile
+jarvis ask "Summarize only my work Gmail about subscription renewals"
+
 # Cross-reference sources
 jarvis ask "What do papers A and B agree on regarding attention mechanisms?"
 
@@ -112,6 +115,35 @@ jarvis ask "List all action items from the meeting notes in ~/Documents/meetings
 # Research with web fallback
 jarvis ask "Compare our internal benchmarks with the latest published results"
 ```
+
+## Google Account-Scoped Research
+
+If you connect multiple Google profiles, the research agent can keep analysis
+scoped to one persona or compare across personas. Connect profiles with an
+alias:
+
+```bash
+jarvis connect google --account work
+jarvis connect google --account personal
+jarvis connect gdrive --account research
+```
+
+After sync, OpenJarvis exposes both connector-level sources and scoped sources:
+
+```text
+gmail
+gmail:work
+gdrive:research
+gcalendar:personal
+```
+
+The planner uses those aliases as structured filters. For example, "only work
+Gmail" becomes `sources=["gmail"], accounts=["work"]`, while "research Drive"
+becomes `sources=["gdrive"], accounts=["research"]`. Citations include the
+profile alias so the UI can show which account produced each source.
+
+For setup, migration, and test commands, see
+[Google Account Profiles](google-account-profiles.md).
 
 ## Indexing Different Data Sources
 

--- a/docs/user-guide/google-account-profiles.md
+++ b/docs/user-guide/google-account-profiles.md
@@ -129,11 +129,12 @@ hybrid.search("Q3 plan", sources=["gdrive"], accounts=["research"])
 
 ## UI And API Sync
 
-The connector sync API accepts an optional `account` query parameter:
+The connector sync API accepts an optional `account` query parameter. Use the
+real connector routes, not a synthetic `/v1/connectors/google/...` endpoint:
 
 ```text
-POST /api/connectors/google/sync?account=work
-GET  /api/connectors/google/sync-status?account=work
+POST /v1/connectors/gmail/sync?account=work
+GET  /v1/connectors/gmail/sync?account=work
 ```
 
 Sync status is tracked per connector/profile pair, so a long sync for

--- a/docs/user-guide/google-account-profiles.md
+++ b/docs/user-guide/google-account-profiles.md
@@ -1,0 +1,171 @@
+# Google Account Profiles
+
+OpenJarvis supports named Google profile aliases so multiple Google accounts can
+be connected, synced, and searched without overwriting each other's OAuth
+tokens. Use aliases such as `personal`, `work`, `subscriptions`,
+`kanakia-org-home`, or `banqer` to keep indexed data persona-scoped.
+
+## Connect Profiles
+
+Use `jarvis connect google` when you want one OAuth grant to cover Gmail, Drive,
+Calendar, Contacts, and Tasks.
+
+```bash
+# Default Google profile
+jarvis connect google
+
+# Named profiles
+jarvis connect google --account work
+jarvis connect google --account personal
+jarvis connect google --account subscriptions
+```
+
+The connector-specific commands use the same profile store and can also take an
+account alias:
+
+```bash
+jarvis connect gmail --account work
+jarvis connect gdrive --account research
+jarvis connect gcalendar --account family
+```
+
+`--profile` is accepted as an alias for `--account`.
+
+## Alias Names
+
+Aliases should be short, readable, and stable. They are normalized into safe
+directory names, so names such as `aquantive-nirav`, `kanakia.org-home`, and
+`banqer` work. Prefer lowercase words separated by `-`, `_`, or `.`.
+
+Avoid putting secrets in alias names. Aliases are used in local file paths,
+document IDs, metadata, and source filters.
+
+## Token Storage
+
+Named profiles are stored under:
+
+```text
+~/.openjarvis/connectors/google/accounts/<alias>.json
+```
+
+Examples:
+
+```text
+~/.openjarvis/connectors/google/accounts/work.json
+~/.openjarvis/connectors/google/accounts/personal.json
+~/.openjarvis/connectors/google/accounts/banqer.json
+```
+
+The legacy single-profile token path is still read for compatibility:
+
+```text
+~/.openjarvis/connectors/google.json
+```
+
+## Migrating A Clean Install With One Existing Profile
+
+If a machine already has one Google connection from before profile aliases,
+choose the alias you want that account to become and reconnect:
+
+```bash
+jarvis connect google --account work
+```
+
+That is the safest path because it creates a fresh profile token in the new
+segmented location. Existing indexed data can remain in the knowledge store;
+new syncs will write account metadata for the chosen alias.
+
+If you need to preserve the existing token without reauthenticating, copy the
+legacy token into the new account directory:
+
+```bash
+mkdir -p ~/.openjarvis/connectors/google/accounts
+cp ~/.openjarvis/connectors/google.json \
+  ~/.openjarvis/connectors/google/accounts/work.json
+```
+
+After copying, run a sync for that account so newly indexed chunks receive the
+account metadata:
+
+```bash
+jarvis connect google --account work
+```
+
+## Analysis And Queries
+
+Once profiles have synced, analysis works through the normal research and memory
+tools. Each indexed chunk carries account metadata, and source lists expose both
+plain connector IDs and scoped connector IDs:
+
+```text
+gmail
+gmail:work
+gdrive:research
+gcalendar:family
+```
+
+Natural-language examples:
+
+```bash
+jarvis ask "Summarize only my work Gmail about subscription renewals"
+jarvis ask "Find Drive files from research about the Q3 plan"
+jarvis ask "Compare personal calendar and work calendar conflicts this week"
+```
+
+The research planner maps these requests to structured filters:
+
+```python
+search("subscription renewals", sources=["gmail"], accounts=["work"])
+search("Q3 plan", sources=["gdrive"], accounts=["research"])
+search("calendar conflicts", sources=["gcalendar"], accounts=["personal", "work"])
+```
+
+Direct retrieval can use either scoped source IDs or an account filter:
+
+```python
+store.retrieve("subscription renewals", source="gmail:work")
+hybrid.search("Q3 plan", sources=["gdrive"], accounts=["research"])
+```
+
+## UI And API Sync
+
+The connector sync API accepts an optional `account` query parameter:
+
+```text
+POST /api/connectors/google/sync?account=work
+GET  /api/connectors/google/sync-status?account=work
+```
+
+Sync status is tracked per connector/profile pair, so a long sync for
+`gmail:work` does not mask the state of `gmail:personal`.
+
+## How To Test
+
+For CLI and connector profile behavior:
+
+```bash
+uv run --extra dev pytest \
+  tests/connectors/test_oauth_flow.py \
+  tests/connectors/test_gmail.py \
+  tests/connectors/test_store.py \
+  tests/cli/test_connect.py
+```
+
+For analysis-layer account filters:
+
+```bash
+uv run --extra dev pytest \
+  tests/agents/test_research_loop.py \
+  tests/connectors/test_hybrid_search.py
+```
+
+For linting touched code:
+
+```bash
+uv run --extra dev ruff check \
+  src/openjarvis/agents/research_loop.py \
+  src/openjarvis/connectors/hybrid_search.py \
+  src/openjarvis/server/connectors_router.py \
+  tests/agents/test_research_loop.py \
+  tests/connectors/test_hybrid_search.py
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -188,6 +188,7 @@ nav:
       - Simple Chat: user-guide/chat-simple.md
       - Agents: user-guide/agents.md
       - Channels & Connectors: user-guide/channels-and-connectors.md
+      - Google Account Profiles: user-guide/google-account-profiles.md
       - Tools: user-guide/tools.md
       - Memory: user-guide/memory.md
       - External MCP Servers: user-guide/mcp-external-servers.md
@@ -200,5 +201,6 @@ nav:
   - Leaderboard: leaderboard.md
   - Roadmap: development/roadmap.md
   - Development:
+      - Google Account Profiles Analysis Layer: development/google-account-profiles-analysis-layer.md
       - Mining: development/mining.md
       - Pearl Model Enablement: development/pearl-model-enablement.md

--- a/src/openjarvis/agents/research_loop.py
+++ b/src/openjarvis/agents/research_loop.py
@@ -546,6 +546,25 @@ class ResearchAgent:
     def _execute_search(self, args: Dict[str, Any]) -> ToolInvocation:
         query = str(args.get("query", "") or "")
         person = args.get("person") or None
+
+        def _norm_markerish(value: str) -> str:
+            return "".join(ch.lower() for ch in value if ch.isalnum())
+
+        if person:
+            person = str(person).strip() or None
+            # Small/local planners often misclassify exact marker strings,
+            # ticket IDs, and other search literals as a `person` filter. That
+            # turns a good lexical search into an impossible AND over
+            # participants/author. If the supposed person is just the query
+            # rewritten/normalized, treat it as a search term only.
+            if query and person:
+                norm_query = _norm_markerish(query)
+                norm_person = _norm_markerish(person)
+                marker_like_query = any(ch in query for ch in "_-0123456789")
+                if norm_person == norm_query or (
+                    marker_like_query and norm_person and norm_person in norm_query
+                ):
+                    person = None
         time_range = self._parse_time_range(args.get("time_range"))
         sources = args.get("sources") or None
         if sources and not isinstance(sources, list):
@@ -553,6 +572,22 @@ class ResearchAgent:
         accounts = args.get("accounts") or args.get("account") or None
         if accounts and not isinstance(accounts, list):
             accounts = [str(accounts)]
+        if person:
+            # The planner can also mistake an account alias from a scoped
+            # source like gmail:personal-main for a person filter (e.g.
+            # person="Personal Main" or person="work-credain"). Account
+            # scoping already happens through sources/accounts; adding the
+            # alias as a participant/author filter makes exact marker tests
+            # impossible to find. Strip person when it is just the named
+            # account/profile scope.
+            scoped_accounts: list[str] = []
+            for source in sources or []:
+                source_s = str(source)
+                if ":" in source_s:
+                    scoped_accounts.append(source_s.split(":", 1)[1])
+            scoped_accounts.extend(str(account) for account in (accounts or []))
+            if any(_norm_markerish(person) == _norm_markerish(account) for account in scoped_accounts):
+                person = None
         limit = int(args.get("limit", 20) or 20)
         limit = max(1, min(limit, 20))
 

--- a/src/openjarvis/agents/research_loop.py
+++ b/src/openjarvis/agents/research_loop.py
@@ -71,8 +71,9 @@ SEARCH_TOOL_SPEC: Dict[str, Any] = {
             "notes, calendar events, attachments). Combines BM25 lexical match "
             "with dense embedding similarity, ranked by reciprocal rank fusion. "
             "Use structured filters (person, time_range, sources) whenever the "
-            "user names a specific person or time window. Each call returns up "
-            "to 'limit' results with content snippets and thread context."
+            "user names a specific person, time window, connector, or account "
+            "alias. Each call returns up to 'limit' results with content "
+            "snippets and thread context."
         ),
         "parameters": {
             "type": "object",
@@ -107,10 +108,18 @@ SEARCH_TOOL_SPEC: Dict[str, Any] = {
                         "Restrict the search to one or more connectors. Use this "
                         "whenever the user names a data source (e.g. \"in my "
                         "Granola notes\" → ['granola']; \"check Slack and Gmail\" "
-                        "→ ['slack', 'gmail']). Valid IDs include: gmail, slack, "
-                        "granola, notion, obsidian, gcalendar, gdrive, gmail_imap, "
-                        "outlook, imessage, whatsapp, apple_notes, apple_contacts, "
-                        "gcontacts, google_tasks, github_notifications."
+                        "→ ['slack', 'gmail']). Named account sources use "
+                        "connector:account syntax, e.g. ['gmail:work'] or "
+                        "['gdrive:research']."
+                    ),
+                    "items": {"type": "string"},
+                },
+                "accounts": {
+                    "type": "array",
+                    "description": (
+                        "Restrict the search to one or more named account aliases "
+                        "across all matching connectors, e.g. ['work'] or "
+                        "['personal', 'research']."
                     ),
                     "items": {"type": "string"},
                 },
@@ -133,15 +142,16 @@ The user's corpus contains data from these sources only:
 
 You answer questions by calling two tools:
 
-    search(query, person=None, time_range=None, sources=None, limit=20)
+    search(query, person=None, time_range=None, sources=None, accounts=None, limit=20)
     clarify(question)
 
 Strategy:
   1. If the user names a person, ALWAYS pass `person=` rather than relying on lexical match. Hybrid search will fuzzy-match name or address fragments.
   2. When the user mentions ANY time window — "this past week", "recently", "last month", "past few days", "yesterday" — you MUST translate it to a `time_range` parameter. Today is {today}.
   3. The `time_range` argument is a JSON object: `{{"start": "<ISO 8601>", "end": "<ISO 8601>"}}`. Either bound may be omitted, but pass at least one whenever the user gave you a temporal cue.
-  4. When the user names a specific data source — "my Granola notes", "in Slack", "from my email" — you MUST pass `sources=[...]` with the matching connector ID. Only use IDs that appear in the connected-sources list above; do NOT invent or assume sources that are not connected. Common synonyms: "meeting notes"/"meetings"/"transcripts" → granola; "email"/"inbox" → gmail; "DMs"/"channels" → slack. Without this filter the search returns mail/messages ABOUT a tool instead of records FROM that tool.
+  4. When the user names a specific data source — "my Granola notes", "in Slack", "from my email" — you MUST pass `sources=[...]` with the matching connector ID. Account-scoped source IDs such as `gmail:work`, `gdrive:research`, and `gcalendar:family` are valid when they appear in the connected-sources list. Only use IDs that appear in the connected-sources list above; do NOT invent or assume sources that are not connected. Common synonyms: "meeting notes"/"meetings"/"transcripts" → granola; "email"/"inbox" → gmail; "DMs"/"channels" → slack. Without this filter the search returns mail/messages ABOUT a tool instead of records FROM that tool.
   4a. Never apologize about sources that aren't in the connected-sources list — if the user asks about "Notion" but Notion isn't connected, just say "Notion isn't connected, but here's what I found in {available_sources}" and answer from what is available.
+  4b. When the user names an account/profile/persona — "work account", "personal Drive", "research calendar", "only banqer" — pass `accounts=[...]` with the matching alias if that alias appears in connected sources. Use `sources=[...]` as well when the user also names a connector, e.g. sources=["gmail"], accounts=["work"] for work email only.
   5. If the first structured search returns nothing useful, broaden with a semantic query and drop filters one at a time.
   6. You have a clarify tool. Only use it AFTER at least one search attempt. Use it when: you found multiple ambiguous matches (e.g. 3 different people named John), search returned zero results and the query might need reframing, or the scope is too broad to synthesize meaningfully. Never use clarify before searching — always try first.
   7. After receiving a clarify response, use the information to construct a precise search with the correct person, time_range, sources, and query parameters. Never send an empty query or a query with no parameters — extract every concrete signal from the user's reply (names, dates, topics, sources) and put it on the call.
@@ -393,6 +403,8 @@ def build_sources_for_client(
                 "sender": sender,
                 "date": _hit_date(h.timestamp),
                 "source": h.source,
+                "account": h.account,
+                "source_profile": h.source_profile,
                 "source_id": _bare_doc_id(h.source, h.document_id),
                 "url": url,
             }
@@ -538,6 +550,9 @@ class ResearchAgent:
         sources = args.get("sources") or None
         if sources and not isinstance(sources, list):
             sources = [str(sources)]
+        accounts = args.get("accounts") or args.get("account") or None
+        if accounts and not isinstance(accounts, list):
+            accounts = [str(accounts)]
         limit = int(args.get("limit", 20) or 20)
         limit = max(1, min(limit, 20))
 
@@ -546,6 +561,7 @@ class ResearchAgent:
             person=person,
             time_range=time_range,
             sources=sources,
+            accounts=accounts,
             limit=limit,
         )
         titles = [h.title or (h.content_snippet[:60] + "…") for h in hits[:5]]
@@ -560,6 +576,7 @@ class ResearchAgent:
                     if time_range else None
                 ),
                 "sources": sources,
+                "accounts": accounts,
                 "limit": limit,
             },
             num_results=len(hits),

--- a/src/openjarvis/cli/ask.py
+++ b/src/openjarvis/cli/ask.py
@@ -65,13 +65,14 @@ def _run_research(
     store = KnowledgeStore(**store_kwargs)
 
     # Research mode is wired specifically to Ollama: the planner prompt
-    # (gemma4:31b) and the function-call schema for search/clarify both
-    # assume Ollama's /api/chat tool semantics. Using the engine returned
-    # by get_engine() here is a foot-gun — discovery can pick any
-    # OpenAI-compatible engine registered on the same port as our own
-    # API server. research_router.py hardcodes OllamaEngine() for the
-    # same reason; mirror that here so CLI and HTTP behave identically.
-    engine = OllamaEngine()
+    # and the function-call schema for search/clarify both assume Ollama's
+    # /api/chat tool semantics. Using the engine returned by get_engine() here
+    # is a foot-gun — discovery can pick any OpenAI-compatible engine registered
+    # on the same port as our own API server. Honor configured/remote Ollama
+    # host though; otherwise LAN setups fall back to localhost during research.
+    cfg = load_config()
+    ollama_host = cfg.engine.ollama.host or None
+    engine = OllamaEngine(host=ollama_host)
 
     chunk_count = store._conn.execute(
         "SELECT COUNT(*) FROM knowledge_chunks"
@@ -84,7 +85,7 @@ def _run_research(
         chunk_count,
     )
 
-    embedder = OllamaEmbedder()
+    embedder = OllamaEmbedder(host=ollama_host or "http://localhost:11434")
     embedder_available = embedder.is_available()
     logger.debug("research: embedder available=%s", embedder_available)
     if not embedder_available:
@@ -94,7 +95,9 @@ def _run_research(
         )
         embedder = None
 
-    planner_model = model_name or DEFAULT_PLANNER_MODEL
+    planner_model = (
+        model_name or cfg.intelligence.default_model or DEFAULT_PLANNER_MODEL
+    )
     logger.debug("research: planner_model=%s", planner_model)
 
     # ---- Output styling --------------------------------------------------

--- a/src/openjarvis/cli/connect_cmd.py
+++ b/src/openjarvis/cli/connect_cmd.py
@@ -37,9 +37,19 @@ def _list_sources(registry: object) -> None:
     console.print(table)
 
 
-def _disconnect_source(registry: object, source: str) -> None:
+def _disconnect_source(registry: object, source: str, account: str = "") -> None:
     """Find and disconnect a registered source connector."""
     console = Console()
+
+    if source == "google" and account:
+        from openjarvis.connectors.oauth import (
+            delete_tokens,
+            google_account_credentials_path,
+        )
+
+        delete_tokens(google_account_credentials_path(account))
+        console.print(f"[green]Disconnected google:{account}.[/green]")
+        return
 
     if not registry.contains(source):  # type: ignore[attr-defined]
         console.print(f"[red]Unknown source: {source}[/red]")
@@ -47,16 +57,66 @@ def _disconnect_source(registry: object, source: str) -> None:
 
     connector_cls = registry.get(source)  # type: ignore[attr-defined]
     try:
-        instance = connector_cls()
+        try:
+            instance = connector_cls(account=account) if account else connector_cls()
+        except TypeError:
+            instance = connector_cls()
         instance.disconnect()
-        console.print(f"[green]Disconnected {source}.[/green]")
+        suffix = f":{account}" if account else ""
+        console.print(f"[green]Disconnected {source}{suffix}.[/green]")
     except Exception as exc:  # noqa: BLE001
         console.print(f"[red]Failed to disconnect {source}: {exc}[/red]")
 
 
-def _connect_source(registry: object, source: str, path: str = "") -> None:
+def _connect_source(
+    registry: object,
+    source: str,
+    path: str = "",
+    account: str = "",
+) -> None:
     """Route connector setup by auth_type."""
     console = Console()
+
+    if source == "google":
+        from openjarvis.connectors.oauth import (
+            OAUTH_PROVIDERS,
+            get_client_credentials,
+            run_connector_oauth,
+            save_client_credentials,
+        )
+
+        try:
+            provider = OAUTH_PROVIDERS["google"]
+            creds = get_client_credentials(provider, account=account)
+            client_id = creds[0] if creds else ""
+            client_secret = creds[1] if creds else ""
+
+            if not client_id or not client_secret:
+                console.print("[cyan]First-time setup for Google.[/cyan]")
+                console.print(
+                    f"[yellow]Create an OAuth app at: {provider.setup_url}[/yellow]"
+                )
+                console.print(f"[dim]{provider.setup_hint}[/dim]")
+                client_id = click.prompt("Client ID")
+                client_secret = click.prompt("Client Secret")
+                save_client_credentials(
+                    provider,
+                    client_id,
+                    client_secret,
+                    account=account,
+                )
+
+            run_connector_oauth(
+                "gmail",
+                client_id,
+                client_secret,
+                account=account,
+            )
+            suffix = f":{account}" if account else ""
+            console.print(f"[green]google{suffix} authorised successfully.[/green]")
+        except Exception as exc:  # noqa: BLE001
+            console.print(f"[red]OAuth flow failed for google: {exc}[/red]")
+        return
 
     if not registry.contains(source):  # type: ignore[attr-defined]
         console.print(f"[red]Unknown source: {source}[/red]")
@@ -104,9 +164,15 @@ def _connect_source(registry: object, source: str, path: str = "") -> None:
         )
 
         try:
-            instance = connector_cls()
+            try:
+                instance = (
+                    connector_cls(account=account) if account else connector_cls()
+                )
+            except TypeError:
+                instance = connector_cls()
             if instance.is_connected():
-                console.print(f"[green]{source} is already connected.[/green]")
+                suffix = f":{account}" if account else ""
+                console.print(f"[green]{source}{suffix} is already connected.[/green]")
                 return
 
             provider = get_provider_for_connector(source)
@@ -114,7 +180,7 @@ def _connect_source(registry: object, source: str, path: str = "") -> None:
                 console.print(f"[red]No OAuth provider configured for {source}.[/red]")
                 return
 
-            creds = get_client_credentials(provider)
+            creds = get_client_credentials(provider, account=account)
             client_id = creds[0] if creds else ""
             client_secret = creds[1] if creds else ""
 
@@ -126,10 +192,16 @@ def _connect_source(registry: object, source: str, path: str = "") -> None:
                 console.print(f"[dim]{provider.setup_hint}[/dim]")
                 client_id = click.prompt("Client ID")
                 client_secret = click.prompt("Client Secret")
-                save_client_credentials(provider, client_id, client_secret)
+                save_client_credentials(
+                    provider,
+                    client_id,
+                    client_secret,
+                    account=account,
+                )
 
-            run_connector_oauth(source, client_id, client_secret)
-            console.print(f"[green]{source} authorised successfully.[/green]")
+            run_connector_oauth(source, client_id, client_secret, account=account)
+            suffix = f":{account}" if account else ""
+            console.print(f"[green]{source}{suffix} authorised successfully.[/green]")
         except Exception as exc:  # noqa: BLE001
             console.print(f"[red]OAuth flow failed for {source}: {exc}[/red]")
 
@@ -193,6 +265,16 @@ def _connect_source(registry: object, source: str, path: str = "") -> None:
     default="",
     help="Path for filesystem connectors (e.g., Obsidian vault).",
 )
+@click.option(
+    "--account",
+    default="",
+    help="Named connector account alias (e.g., personal, work).",
+)
+@click.option(
+    "--profile",
+    default="",
+    help="Alias for --account.",
+)
 @click.pass_context
 def connect(
     ctx: click.Context,
@@ -201,11 +283,15 @@ def connect(
     trigger_sync: bool,
     disconnect_source: str,
     path: str,
+    account: str,
+    profile: str,
 ) -> None:
     """Manage data source connections (Gmail, Obsidian, etc.)."""
     # Lazy imports to avoid top-level side effects
     import openjarvis.connectors  # noqa: F401 — registers all connectors
     from openjarvis.core.registry import ConnectorRegistry
+
+    account_alias = account or profile
 
     if list_sources:
         _list_sources(ConnectorRegistry)
@@ -216,11 +302,11 @@ def connect(
         return
 
     if disconnect_source:
-        _disconnect_source(ConnectorRegistry, disconnect_source)
+        _disconnect_source(ConnectorRegistry, disconnect_source, account=account_alias)
         return
 
     if source:
-        _connect_source(ConnectorRegistry, source, path=path)
+        _connect_source(ConnectorRegistry, source, path=path, account=account_alias)
         return
 
     # No arguments — show help

--- a/src/openjarvis/connectors/gcalendar.py
+++ b/src/openjarvis/connectors/gcalendar.py
@@ -18,7 +18,10 @@ from openjarvis.connectors.oauth import (
     GOOGLE_ALL_SCOPES,
     build_google_auth_url,
     delete_tokens,
+    google_account_doc_id,
+    google_account_metadata,
     load_tokens,
+    normalize_account_alias,
     resolve_google_credentials,
     save_tokens,
 )
@@ -247,9 +250,11 @@ class GCalendarConnector(BaseConnector):
     display_name = "Google Calendar"
     auth_type = "oauth"
 
-    def __init__(self, credentials_path: str = "") -> None:
+    def __init__(self, credentials_path: str = "", account: str = "") -> None:
+        self._account = normalize_account_alias(account)
         self._credentials_path = resolve_google_credentials(
-            credentials_path or _DEFAULT_CREDENTIALS_PATH
+            credentials_path or _DEFAULT_CREDENTIALS_PATH,
+            account=self._account if not credentials_path else "",
         )
         self._items_synced: int = 0
         self._items_total: int = 0
@@ -399,7 +404,9 @@ class GCalendarConnector(BaseConnector):
                             break
 
                     doc = Document(
-                        doc_id=f"gcalendar:{evt_id}",
+                        doc_id=google_account_doc_id(
+                            "gcalendar", evt_id, self._account
+                        ),
                         source="gcalendar",
                         doc_type="event",
                         content=content,
@@ -412,6 +419,7 @@ class GCalendarConnector(BaseConnector):
                             "calendar_id": calendar_id,
                             "event_id": evt_id,
                             "response_status": self_status,
+                            **google_account_metadata("gcalendar", self._account),
                         },
                     )
                     synced += 1
@@ -503,6 +511,14 @@ class GCalendarConnector(BaseConnector):
                             ),
                             "default": "primary",
                         },
+                        "account": {
+                            "type": "string",
+                            "description": (
+                                "Optional Google account alias, e.g. 'personal' "
+                                "or 'work'."
+                            ),
+                            "default": self._account,
+                        },
                     },
                     "required": [],
                 },
@@ -533,6 +549,14 @@ class GCalendarConnector(BaseConnector):
                             ),
                             "default": "primary",
                         },
+                        "account": {
+                            "type": "string",
+                            "description": (
+                                "Optional Google account alias, e.g. 'personal' "
+                                "or 'work'."
+                            ),
+                            "default": self._account,
+                        },
                     },
                     "required": ["query"],
                 },
@@ -553,6 +577,14 @@ class GCalendarConnector(BaseConnector):
                                 "Calendar ID to query. Defaults to 'primary'."
                             ),
                             "default": "primary",
+                        },
+                        "account": {
+                            "type": "string",
+                            "description": (
+                                "Optional Google account alias, e.g. 'personal' "
+                                "or 'work'."
+                            ),
+                            "default": self._account,
                         },
                     },
                     "required": [],

--- a/src/openjarvis/connectors/gcalendar.py
+++ b/src/openjarvis/connectors/gcalendar.py
@@ -252,9 +252,14 @@ class GCalendarConnector(BaseConnector):
 
     def __init__(self, credentials_path: str = "", account: str = "") -> None:
         self._account = normalize_account_alias(account)
+        self._explicit_credentials_path = bool(credentials_path)
         self._credentials_path = resolve_google_credentials(
             credentials_path or _DEFAULT_CREDENTIALS_PATH,
-            account=self._account if not credentials_path else "",
+            account=self._account,
+            allow_shared_fallback=not self._explicit_credentials_path,
+        )
+        self._mirror_shared_credentials = (
+            not self._explicit_credentials_path and not self._account
         )
         self._items_synced: int = 0
         self._items_total: int = 0

--- a/src/openjarvis/connectors/gcontacts.py
+++ b/src/openjarvis/connectors/gcontacts.py
@@ -157,9 +157,14 @@ class GContactsConnector(BaseConnector):
 
     def __init__(self, credentials_path: str = "", account: str = "") -> None:
         self._account = normalize_account_alias(account)
+        self._explicit_credentials_path = bool(credentials_path)
         self._credentials_path = resolve_google_credentials(
             credentials_path or _DEFAULT_CREDENTIALS_PATH,
-            account=self._account if not credentials_path else "",
+            account=self._account,
+            allow_shared_fallback=not self._explicit_credentials_path,
+        )
+        self._mirror_shared_credentials = (
+            not self._explicit_credentials_path and not self._account
         )
         self._items_synced: int = 0
         self._items_total: int = 0

--- a/src/openjarvis/connectors/gcontacts.py
+++ b/src/openjarvis/connectors/gcontacts.py
@@ -18,7 +18,10 @@ from openjarvis.connectors.oauth import (
     GOOGLE_ALL_SCOPES,
     build_google_auth_url,
     delete_tokens,
+    google_account_doc_id,
+    google_account_metadata,
     load_tokens,
+    normalize_account_alias,
     resolve_google_credentials,
     save_tokens,
 )
@@ -152,9 +155,11 @@ class GContactsConnector(BaseConnector):
     display_name = "Google Contacts"
     auth_type = "oauth"
 
-    def __init__(self, credentials_path: str = "") -> None:
+    def __init__(self, credentials_path: str = "", account: str = "") -> None:
+        self._account = normalize_account_alias(account)
         self._credentials_path = resolve_google_credentials(
-            credentials_path or _DEFAULT_CREDENTIALS_PATH
+            credentials_path or _DEFAULT_CREDENTIALS_PATH,
+            account=self._account if not credentials_path else "",
         )
         self._items_synced: int = 0
         self._items_total: int = 0
@@ -269,7 +274,9 @@ class GContactsConnector(BaseConnector):
                 content = _format_contact(person)
 
                 doc = Document(
-                    doc_id=f"gcontacts:{resource_name}",
+                    doc_id=google_account_doc_id(
+                        "gcontacts", resource_name, self._account
+                    ),
                     source="gcontacts",
                     doc_type="contact",
                     content=content,
@@ -277,6 +284,7 @@ class GContactsConnector(BaseConnector):
                     author=primary_email,
                     metadata={
                         "resource_name": resource_name,
+                        **google_account_metadata("gcontacts", self._account),
                     },
                 )
                 synced += 1
@@ -330,6 +338,14 @@ class GContactsConnector(BaseConnector):
                             "description": "Maximum number of contacts to return",
                             "default": 20,
                         },
+                        "account": {
+                            "type": "string",
+                            "description": (
+                                "Optional Google account alias, e.g. 'personal' "
+                                "or 'work'."
+                            ),
+                            "default": self._account,
+                        },
                     },
                     "required": ["query"],
                 },
@@ -351,6 +367,14 @@ class GContactsConnector(BaseConnector):
                                 "Contact resource name (e.g. 'people/c123') "
                                 "or email address"
                             ),
+                        },
+                        "account": {
+                            "type": "string",
+                            "description": (
+                                "Optional Google account alias, e.g. 'personal' "
+                                "or 'work'."
+                            ),
+                            "default": self._account,
                         },
                     },
                     "required": ["identifier"],

--- a/src/openjarvis/connectors/gdrive.py
+++ b/src/openjarvis/connectors/gdrive.py
@@ -18,7 +18,10 @@ from openjarvis.connectors.oauth import (
     GOOGLE_ALL_SCOPES,
     build_google_auth_url,
     delete_tokens,
+    google_account_doc_id,
+    google_account_metadata,
     load_tokens,
+    normalize_account_alias,
     resolve_google_credentials,
     save_tokens,
 )
@@ -135,9 +138,11 @@ class GDriveConnector(BaseConnector):
     display_name = "Google Drive"
     auth_type = "oauth"
 
-    def __init__(self, credentials_path: str = "") -> None:
+    def __init__(self, credentials_path: str = "", account: str = "") -> None:
+        self._account = normalize_account_alias(account)
         self._credentials_path = resolve_google_credentials(
-            credentials_path or _DEFAULT_CREDENTIALS_PATH
+            credentials_path or _DEFAULT_CREDENTIALS_PATH,
+            account=self._account if not credentials_path else "",
         )
         self._items_synced: int = 0
         self._items_total: int = 0
@@ -270,7 +275,7 @@ class GDriveConnector(BaseConnector):
                     content = f"[File: {name}] ({mime_type})"
 
                 doc = Document(
-                    doc_id=f"gdrive:{file_id}",
+                    doc_id=google_account_doc_id("gdrive", file_id, self._account),
                     source="gdrive",
                     doc_type="document",
                     content=content,
@@ -280,6 +285,7 @@ class GDriveConnector(BaseConnector):
                     metadata={
                         "file_id": file_id,
                         "mime_type": mime_type,
+                        **google_account_metadata("gdrive", self._account),
                     },
                 )
                 synced += 1
@@ -330,6 +336,14 @@ class GDriveConnector(BaseConnector):
                             "description": "Maximum number of files to return",
                             "default": 20,
                         },
+                        "account": {
+                            "type": "string",
+                            "description": (
+                                "Optional Google account alias, e.g. 'personal' "
+                                "or 'work'."
+                            ),
+                            "default": self._account,
+                        },
                     },
                     "required": ["query"],
                 },
@@ -347,6 +361,14 @@ class GDriveConnector(BaseConnector):
                         "file_id": {
                             "type": "string",
                             "description": "Google Drive file ID",
+                        },
+                        "account": {
+                            "type": "string",
+                            "description": (
+                                "Optional Google account alias, e.g. 'personal' "
+                                "or 'work'."
+                            ),
+                            "default": self._account,
                         },
                     },
                     "required": ["file_id"],
@@ -374,6 +396,14 @@ class GDriveConnector(BaseConnector):
                             "type": "integer",
                             "description": "Maximum number of files to return",
                             "default": 20,
+                        },
+                        "account": {
+                            "type": "string",
+                            "description": (
+                                "Optional Google account alias, e.g. 'personal' "
+                                "or 'work'."
+                            ),
+                            "default": self._account,
                         },
                     },
                     "required": [],

--- a/src/openjarvis/connectors/gdrive.py
+++ b/src/openjarvis/connectors/gdrive.py
@@ -140,9 +140,14 @@ class GDriveConnector(BaseConnector):
 
     def __init__(self, credentials_path: str = "", account: str = "") -> None:
         self._account = normalize_account_alias(account)
+        self._explicit_credentials_path = bool(credentials_path)
         self._credentials_path = resolve_google_credentials(
             credentials_path or _DEFAULT_CREDENTIALS_PATH,
-            account=self._account if not credentials_path else "",
+            account=self._account,
+            allow_shared_fallback=not self._explicit_credentials_path,
+        )
+        self._mirror_shared_credentials = (
+            not self._explicit_credentials_path and not self._account
         )
         self._items_synced: int = 0
         self._items_total: int = 0

--- a/src/openjarvis/connectors/gmail.py
+++ b/src/openjarvis/connectors/gmail.py
@@ -353,9 +353,14 @@ class GmailConnector(BaseConnector):
 
     def __init__(self, credentials_path: str = "", account: str = "") -> None:
         self._account = normalize_account_alias(account)
+        self._explicit_credentials_path = bool(credentials_path)
         self._credentials_path = resolve_google_credentials(
             credentials_path or _DEFAULT_CREDENTIALS_PATH,
-            account=self._account if not credentials_path else "",
+            account=self._account,
+            allow_shared_fallback=not self._explicit_credentials_path,
+        )
+        self._mirror_shared_credentials = (
+            not self._explicit_credentials_path and not self._account
         )
         self._items_synced: int = 0
         self._items_total: int = 0

--- a/src/openjarvis/connectors/gmail.py
+++ b/src/openjarvis/connectors/gmail.py
@@ -28,7 +28,11 @@ from openjarvis.connectors.oauth import (
     GOOGLE_ALL_SCOPES,
     build_google_auth_url,
     delete_tokens,
+    google_account_doc_id,
+    google_account_metadata,
+    google_account_source_id,
     load_tokens,
+    normalize_account_alias,
     refresh_google_token,
     resolve_google_credentials,
     save_tokens,
@@ -347,9 +351,11 @@ class GmailConnector(BaseConnector):
     display_name = "Gmail"
     auth_type = "oauth"
 
-    def __init__(self, credentials_path: str = "") -> None:
+    def __init__(self, credentials_path: str = "", account: str = "") -> None:
+        self._account = normalize_account_alias(account)
         self._credentials_path = resolve_google_credentials(
-            credentials_path or _DEFAULT_CREDENTIALS_PATH
+            credentials_path or _DEFAULT_CREDENTIALS_PATH,
+            account=self._account if not credentials_path else "",
         )
         self._items_synced: int = 0
         self._items_total: int = 0
@@ -485,9 +491,9 @@ class GmailConnector(BaseConnector):
                 thread_id: Optional[str] = msg.get("threadId")
 
                 doc = Document(
-                    doc_id=f"gmail:{msg_id}",
+                    doc_id=google_account_doc_id("gmail", msg_id, self._account),
                     source="gmail",
-                    source_id=msg_id,
+                    source_id=google_account_source_id(msg_id, self._account),
                     doc_type="email",
                     content=body,
                     title=subject,
@@ -509,6 +515,7 @@ class GmailConnector(BaseConnector):
                         "snippet": msg.get("snippet", ""),
                         "history_id": msg.get("historyId", ""),
                         "size_estimate": msg.get("sizeEstimate", 0),
+                        **google_account_metadata("gmail", self._account),
                     },
                 )
                 synced += 1
@@ -607,6 +614,14 @@ class GmailConnector(BaseConnector):
                             "description": "Maximum number of emails to return",
                             "default": 20,
                         },
+                        "account": {
+                            "type": "string",
+                            "description": (
+                                "Optional Google account alias, e.g. 'personal' "
+                                "or 'work'."
+                            ),
+                            "default": self._account,
+                        },
                     },
                     "required": ["query"],
                 },
@@ -621,6 +636,14 @@ class GmailConnector(BaseConnector):
                         "thread_id": {
                             "type": "string",
                             "description": "Gmail thread ID",
+                        },
+                        "account": {
+                            "type": "string",
+                            "description": (
+                                "Optional Google account alias, e.g. 'personal' "
+                                "or 'work'."
+                            ),
+                            "default": self._account,
                         },
                     },
                     "required": ["thread_id"],
@@ -644,6 +667,14 @@ class GmailConnector(BaseConnector):
                             "type": "integer",
                             "description": "Maximum number of messages to return",
                             "default": 20,
+                        },
+                        "account": {
+                            "type": "string",
+                            "description": (
+                                "Optional Google account alias, e.g. 'personal' "
+                                "or 'work'."
+                            ),
+                            "default": self._account,
                         },
                     },
                     "required": [],

--- a/src/openjarvis/connectors/google_tasks.py
+++ b/src/openjarvis/connectors/google_tasks.py
@@ -13,7 +13,13 @@ import httpx
 
 from openjarvis.connectors._stubs import BaseConnector, Document, SyncStatus
 from openjarvis.connectors.google_auth import call_with_refresh
-from openjarvis.connectors.oauth import load_tokens, resolve_google_credentials
+from openjarvis.connectors.oauth import (
+    google_account_doc_id,
+    google_account_metadata,
+    load_tokens,
+    normalize_account_alias,
+    resolve_google_credentials,
+)
 from openjarvis.core.config import DEFAULT_CONFIG_DIR
 from openjarvis.core.registry import ConnectorRegistry
 
@@ -43,9 +49,13 @@ class GoogleTasksConnector(BaseConnector):
     display_name = "Google Tasks"
     auth_type = "oauth"
 
-    def __init__(self, *, credentials_path: str = "") -> None:
+    def __init__(self, *, credentials_path: str = "", account: str = "") -> None:
+        self._account = normalize_account_alias(account)
         self._credentials_path = Path(
-            resolve_google_credentials(credentials_path or _DEFAULT_CREDENTIALS_PATH)
+            resolve_google_credentials(
+                credentials_path or _DEFAULT_CREDENTIALS_PATH,
+                account=self._account if not credentials_path else "",
+            )
         )
         self._status = SyncStatus()
 
@@ -108,7 +118,9 @@ class GoogleTasksConnector(BaseConnector):
                 )
 
                 yield Document(
-                    doc_id=f"gtasks-{task['id']}",
+                    doc_id=google_account_doc_id(
+                        "google_tasks", task["id"], self._account
+                    ),
                     source="google_tasks",
                     doc_type="task",
                     content=task.get("notes", ""),
@@ -120,6 +132,7 @@ class GoogleTasksConnector(BaseConnector):
                         "status": status,
                         "due": due,
                         "completed": task.get("completed", ""),
+                        **google_account_metadata("google_tasks", self._account),
                     },
                 )
 

--- a/src/openjarvis/connectors/google_tasks.py
+++ b/src/openjarvis/connectors/google_tasks.py
@@ -51,11 +51,16 @@ class GoogleTasksConnector(BaseConnector):
 
     def __init__(self, *, credentials_path: str = "", account: str = "") -> None:
         self._account = normalize_account_alias(account)
+        self._explicit_credentials_path = bool(credentials_path)
         self._credentials_path = Path(
             resolve_google_credentials(
                 credentials_path or _DEFAULT_CREDENTIALS_PATH,
-                account=self._account if not credentials_path else "",
+                account=self._account,
+                allow_shared_fallback=not self._explicit_credentials_path,
             )
+        )
+        self._mirror_shared_credentials = (
+            not self._explicit_credentials_path and not self._account
         )
         self._status = SyncStatus()
 

--- a/src/openjarvis/connectors/hybrid_search.py
+++ b/src/openjarvis/connectors/hybrid_search.py
@@ -464,10 +464,12 @@ class HybridSearch:
         )
         fused = self._fuse(bm25, vector)
 
-        # Metadata-only fallback: empty query, or both legs produced nothing
-        # despite a non-empty query. Return the most recent rows matching the
-        # filter so the agent still gets a useful corpus snapshot.
-        if not fused:
+        # Metadata-only fallback: only for empty-query/filter-only searches
+        # such as "all mail from Kelly in May". For a non-empty query,
+        # returning recent rows on zero lexical/vector hits creates false
+        # positives, especially for account-boundary tests where "no hit in
+        # gmail:work" must not synthesize an unrelated work email as a match.
+        if not fused and not query.strip():
             sql = f"""
                 SELECT id FROM knowledge_chunks
                 WHERE {unaliased_filter_sql}

--- a/src/openjarvis/connectors/hybrid_search.py
+++ b/src/openjarvis/connectors/hybrid_search.py
@@ -54,6 +54,8 @@ class SearchHit:
     vector_score: float
     thread_id: str = ""
     thread_context: List[Dict[str, Any]] = field(default_factory=list)
+    account: str = ""
+    source_profile: str = ""
     # ``url`` is the connector-provided deep-link, persisted on
     # ``knowledge_chunks.url``. Empty when the source didn't supply one — in
     # that case callers may fall back to a doc_id-based reconstruction (Slack,
@@ -72,6 +74,8 @@ class SearchHit:
             "chunk_idx": self.chunk_idx,
             "thread_id": self.thread_id,
             "thread_context": self.thread_context,
+            "account": self.account,
+            "source_profile": self.source_profile,
         }
 
 
@@ -111,6 +115,22 @@ def _parse_participants(raw: Any) -> List[str]:
         return [str(x) for x in parsed] if isinstance(parsed, list) else []
     except (json.JSONDecodeError, TypeError):
         return []
+
+
+def _split_source_accounts(
+    sources: Optional[Sequence[str]],
+) -> Tuple[List[str], List[Tuple[str, str]]]:
+    """Split source filters into plain sources and ``source:account`` pairs."""
+    plain: List[str] = []
+    scoped: List[Tuple[str, str]] = []
+    for source in sources or []:
+        if ":" in source:
+            base, account = source.split(":", 1)
+            if base and account:
+                scoped.append((base, account))
+                continue
+        plain.append(source)
+    return plain, scoped
 
 
 def _snippet(content: str, max_chars: int = 500) -> str:
@@ -175,6 +195,7 @@ class HybridSearch:
         person: Optional[str],
         time_range: Optional[Tuple[Optional[datetime], Optional[datetime]]],
         sources: Optional[Sequence[str]],
+        accounts: Optional[Sequence[str]],
         alias: str = "",
     ) -> Tuple[str, List[Any]]:
         """Return ``(where_fragment, params)`` for the structured filters.
@@ -209,9 +230,26 @@ class HybridSearch:
                 params.append(_iso(end))
 
         if sources:
-            placeholders = ",".join("?" for _ in sources)
-            clauses.append(f"{prefix}source IN ({placeholders})")
-            params.extend(sources)
+            plain_sources, scoped_sources = _split_source_accounts(sources)
+            source_clauses: List[str] = []
+            if plain_sources:
+                placeholders = ",".join("?" for _ in plain_sources)
+                source_clauses.append(f"{prefix}source IN ({placeholders})")
+                params.extend(plain_sources)
+            for source, account in scoped_sources:
+                source_clauses.append(
+                    f"({prefix}source = ? AND "
+                    f"json_extract({prefix}metadata, '$.account') = ?)"
+                )
+                params.extend([source, account])
+            clauses.append("(" + " OR ".join(source_clauses) + ")")
+
+        if accounts:
+            placeholders = ",".join("?" for _ in accounts)
+            clauses.append(
+                f"json_extract({prefix}metadata, '$.account') IN ({placeholders})"
+            )
+            params.extend(accounts)
 
         return " AND ".join(clauses), params
 
@@ -388,6 +426,7 @@ class HybridSearch:
         person: Optional[str] = None,
         time_range: Optional[Tuple[Optional[datetime], Optional[datetime]]] = None,
         sources: Optional[Sequence[str]] = None,
+        accounts: Optional[Sequence[str]] = None,
         limit: int = 20,
     ) -> List[SearchHit]:
         """Run the hybrid pipeline and return up to ``limit`` hits.
@@ -400,10 +439,17 @@ class HybridSearch:
         returned.
         """
         bm25_filter_sql, bm25_filter_params = self._build_filters(
-            person=person, time_range=time_range, sources=sources, alias="kc"
+            person=person,
+            time_range=time_range,
+            sources=sources,
+            accounts=accounts,
+            alias="kc",
         )
         unaliased_filter_sql, unaliased_filter_params = self._build_filters(
-            person=person, time_range=time_range, sources=sources
+            person=person,
+            time_range=time_range,
+            sources=sources,
+            accounts=accounts,
         )
 
         bm25 = (
@@ -442,7 +488,7 @@ class HybridSearch:
         meta_rows = self._store._conn.execute(
             f"""
             SELECT id, doc_id, content, source, title, author, participants,
-                   timestamp, thread_id, chunk_index, url
+                   timestamp, thread_id, chunk_index, url, metadata
             FROM knowledge_chunks
             WHERE id IN ({placeholders})
             """,
@@ -455,6 +501,7 @@ class HybridSearch:
             r = by_id.get(chunk_id)
             if r is None:
                 continue
+            metadata = json.loads(r["metadata"]) if r["metadata"] else {}
             hits.append(
                 SearchHit(
                     chunk_id=chunk_id,
@@ -470,6 +517,8 @@ class HybridSearch:
                     vector_score=vec_score,
                     thread_id=r["thread_id"] or "",
                     thread_context=self._thread_context(r["thread_id"] or "", chunk_id),
+                    account=str(metadata.get("account", "") or ""),
+                    source_profile=str(metadata.get("source_profile", "") or ""),
                     url=r["url"] or "",
                 )
             )

--- a/src/openjarvis/connectors/oauth.py
+++ b/src/openjarvis/connectors/oauth.py
@@ -325,13 +325,16 @@ def resolve_google_credentials(
 ) -> str:
     """Return the best available Google credentials file path.
 
-    With *account*, returns the segmented account credential file path under
-    ``google/accounts/{alias}.json``. Without an account, checks the
-    connector-specific file first, then optionally falls back to the shared
-    ``google.json`` when ``allow_shared_fallback`` is true. Returns
-    *connector_path* if neither exists (so ``is_connected()`` correctly
-    returns ``False``).
+    When ``allow_shared_fallback`` is false, *connector_path* is treated as an
+    explicit caller-supplied path and always wins, even if an account alias is
+    also supplied. Otherwise, named accounts resolve to the segmented account
+    path under ``google/accounts/{alias}.json``. Default connectors check their
+    connector-specific file first, then optionally fall back to shared
+    ``google.json``.
     """
+    if not allow_shared_fallback:
+        return connector_path
+
     alias = normalize_account_alias(account)
     if alias:
         return google_account_credentials_path(alias)

--- a/src/openjarvis/connectors/oauth.py
+++ b/src/openjarvis/connectors/oauth.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import base64
 import json
 import os
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -24,6 +25,9 @@ from openjarvis.core.config import DEFAULT_CONFIG_DIR
 # ---------------------------------------------------------------------------
 
 _CONNECTORS_DIR = DEFAULT_CONFIG_DIR / "connectors"
+_GOOGLE_ACCOUNT_PROVIDER = "google"
+_GOOGLE_ACCOUNTS_DIR = _CONNECTORS_DIR / _GOOGLE_ACCOUNT_PROVIDER / "accounts"
+_ACCOUNT_ALIAS_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}$")
 
 # ---------------------------------------------------------------------------
 # OAuth provider registry
@@ -129,6 +133,82 @@ def get_provider_for_connector(connector_id: str) -> Optional[OAuthProvider]:
     return None
 
 
+def normalize_account_alias(account: str = "") -> str:
+    """Validate and normalise a connector account/profile alias.
+
+    Empty means "legacy/default credentials". Named aliases are intentionally
+    restricted to a small filesystem-safe slug format because they become JSON
+    filenames under ``~/.openjarvis/connectors/google/accounts``.
+    """
+    alias = account.strip()
+    if not alias:
+        return ""
+    if not _ACCOUNT_ALIAS_RE.fullmatch(alias):
+        raise ValueError(
+            "Account aliases must be 1-64 characters and contain only letters, "
+            "numbers, dots, underscores, or hyphens."
+        )
+    return alias
+
+
+def google_account_credentials_path(account: str) -> str:
+    """Return the credential file path for a named Google account alias."""
+    alias = normalize_account_alias(account)
+    if not alias:
+        raise ValueError("A non-empty Google account alias is required.")
+    return str(_GOOGLE_ACCOUNTS_DIR / f"{alias}.json")
+
+
+def google_account_metadata(connector_id: str, account: str = "") -> Dict[str, str]:
+    """Return provenance metadata for a named connector account."""
+    alias = normalize_account_alias(account)
+    if not alias:
+        return {"connector": connector_id}
+    return {
+        "account": alias,
+        "source_profile": alias,
+        "connector": connector_id,
+        "connector_instance": f"{connector_id}:{alias}",
+    }
+
+
+def google_account_doc_id(connector_id: str, native_id: str, account: str = "") -> str:
+    """Build a collision-safe document ID for optional Google account aliases."""
+    alias = normalize_account_alias(account)
+    if alias:
+        return f"{connector_id}:{alias}:{native_id}"
+    return f"{connector_id}:{native_id}"
+
+
+def google_account_source_id(native_id: str, account: str = "") -> str:
+    """Build a collision-safe source_id while preserving legacy default IDs."""
+    alias = normalize_account_alias(account)
+    if alias:
+        return f"{alias}:{native_id}"
+    return native_id
+
+
+def _credential_paths_for_provider(
+    provider: OAuthProvider,
+    *,
+    account: str = "",
+) -> Tuple[Path, ...]:
+    """Return credential paths for a provider/account combination."""
+    alias = normalize_account_alias(account)
+    if provider.name == _GOOGLE_ACCOUNT_PROVIDER and alias:
+        return (Path(google_account_credentials_path(alias)),)
+    return tuple(_CONNECTORS_DIR / filename for filename in provider.credential_files)
+
+
+def _is_google_account_credentials_path(path: str) -> bool:
+    """Return True when *path* points under the named Google accounts dir."""
+    try:
+        Path(path).resolve().relative_to(_GOOGLE_ACCOUNTS_DIR.resolve())
+        return True
+    except ValueError:
+        return False
+
+
 # ---------------------------------------------------------------------------
 # Credential helpers
 # ---------------------------------------------------------------------------
@@ -136,6 +216,8 @@ def get_provider_for_connector(connector_id: str) -> Optional[OAuthProvider]:
 
 def get_client_credentials(
     provider: OAuthProvider,
+    *,
+    account: str = "",
 ) -> Optional[Tuple[str, str]]:
     """Load stored client_id and client_secret for *provider*.
 
@@ -143,12 +225,19 @@ def get_client_credentials(
     back to environment variables ``OPENJARVIS_{NAME}_CLIENT_ID`` and
     ``OPENJARVIS_{NAME}_CLIENT_SECRET``.
     """
-    # Check credential files
-    for filename in provider.credential_files:
-        path = _CONNECTORS_DIR / filename
+    # Check credential files. For named Google accounts, prefer the alias file
+    # but fall back to legacy provider files below so users do not need to
+    # re-enter OAuth client credentials for every account.
+    for path in _credential_paths_for_provider(provider, account=account):
         tokens = load_tokens(str(path))
         if tokens and tokens.get("client_id") and tokens.get("client_secret"):
             return tokens["client_id"], tokens["client_secret"]
+
+    if provider.name == _GOOGLE_ACCOUNT_PROVIDER and normalize_account_alias(account):
+        for path in _credential_paths_for_provider(provider):
+            tokens = load_tokens(str(path))
+            if tokens and tokens.get("client_id") and tokens.get("client_secret"):
+                return tokens["client_id"], tokens["client_secret"]
 
     # Check environment variables
     prefix = f"OPENJARVIS_{provider.name.upper()}"
@@ -164,10 +253,11 @@ def save_client_credentials(
     provider: OAuthProvider,
     client_id: str,
     client_secret: str,
+    *,
+    account: str = "",
 ) -> None:
     """Persist client credentials so the user never has to enter them again."""
-    for filename in provider.credential_files:
-        path = _CONNECTORS_DIR / filename
+    for path in _credential_paths_for_provider(provider, account=account):
         existing = load_tokens(str(path)) or {}
         existing["client_id"] = client_id
         existing["client_secret"] = client_secret
@@ -227,13 +317,18 @@ def build_google_auth_url(
     return f"{_GOOGLE_AUTH_ENDPOINT}?{urlencode(params)}"
 
 
-def resolve_google_credentials(connector_path: str) -> str:
+def resolve_google_credentials(connector_path: str, *, account: str = "") -> str:
     """Return the best available Google credentials file path.
 
-    Checks the connector-specific file first, then falls back to the
-    shared ``google.json``.  Returns *connector_path* if neither exists
-    (so ``is_connected()`` correctly returns ``False``).
+    With *account*, returns the segmented account credential file path under
+    ``google/accounts/{alias}.json``. Without an account, checks the
+    connector-specific file first, then falls back to the shared
+    ``google.json``. Returns *connector_path* if neither exists (so
+    ``is_connected()`` correctly returns ``False``).
     """
+    alias = normalize_account_alias(account)
+    if alias:
+        return google_account_credentials_path(alias)
     if Path(connector_path).exists():
         return connector_path
     if Path(_SHARED_GOOGLE_CREDENTIALS_PATH).exists():
@@ -524,9 +619,14 @@ def run_oauth_flow(
     }
     save_tokens(credentials_path, token_payload)
 
-    # Also save to the shared Google credentials file so that all Google
-    # connectors can use this token without a separate OAuth flow.
-    if credentials_path != _SHARED_GOOGLE_CREDENTIALS_PATH:
+    # Also save to the shared Google credentials file for the legacy flow so
+    # all Google connectors can use this token without a separate OAuth flow.
+    # Named account aliases must stay segmented and must not overwrite the
+    # default credentials.
+    if (
+        credentials_path != _SHARED_GOOGLE_CREDENTIALS_PATH
+        and not _is_google_account_credentials_path(credentials_path)
+    ):
         save_tokens(_SHARED_GOOGLE_CREDENTIALS_PATH, token_payload)
 
     return tokens
@@ -649,6 +749,8 @@ def run_connector_oauth(
     connector_id: str,
     client_id: str = "",
     client_secret: str = "",
+    *,
+    account: str = "",
 ) -> Dict[str, Any]:
     """Run a complete OAuth flow for *connector_id*.
 
@@ -668,7 +770,7 @@ def run_connector_oauth(
 
     # Resolve credentials
     if not (client_id and client_secret):
-        creds = get_client_credentials(provider)
+        creds = get_client_credentials(provider, account=account)
         if creds:
             client_id, client_secret = creds
     if not (client_id and client_secret):
@@ -713,8 +815,9 @@ def run_connector_oauth(
         "client_secret": client_secret,
     }
 
-    # Save to all credential files for this provider
-    for filename in provider.credential_files:
-        save_tokens(str(_CONNECTORS_DIR / filename), payload)
+    # Save to the legacy provider files, or to one segmented account file when
+    # a named Google alias is supplied.
+    for path in _credential_paths_for_provider(provider, account=account):
+        save_tokens(str(path), payload)
 
     return tokens

--- a/src/openjarvis/connectors/oauth.py
+++ b/src/openjarvis/connectors/oauth.py
@@ -317,21 +317,27 @@ def build_google_auth_url(
     return f"{_GOOGLE_AUTH_ENDPOINT}?{urlencode(params)}"
 
 
-def resolve_google_credentials(connector_path: str, *, account: str = "") -> str:
+def resolve_google_credentials(
+    connector_path: str,
+    *,
+    account: str = "",
+    allow_shared_fallback: bool = True,
+) -> str:
     """Return the best available Google credentials file path.
 
     With *account*, returns the segmented account credential file path under
     ``google/accounts/{alias}.json``. Without an account, checks the
-    connector-specific file first, then falls back to the shared
-    ``google.json``. Returns *connector_path* if neither exists (so
-    ``is_connected()`` correctly returns ``False``).
+    connector-specific file first, then optionally falls back to the shared
+    ``google.json`` when ``allow_shared_fallback`` is true. Returns
+    *connector_path* if neither exists (so ``is_connected()`` correctly
+    returns ``False``).
     """
     alias = normalize_account_alias(account)
     if alias:
         return google_account_credentials_path(alias)
     if Path(connector_path).exists():
         return connector_path
-    if Path(_SHARED_GOOGLE_CREDENTIALS_PATH).exists():
+    if allow_shared_fallback and Path(_SHARED_GOOGLE_CREDENTIALS_PATH).exists():
         return _SHARED_GOOGLE_CREDENTIALS_PATH
     return connector_path
 
@@ -368,6 +374,22 @@ def delete_tokens(path: str) -> None:
     p = Path(path)
     if p.exists():
         p.unlink()
+
+
+def _persist_google_oauth_tokens(
+    credentials_path: str,
+    token_payload: Dict[str, Any],
+    *,
+    mirror_shared_credentials: bool = True,
+) -> None:
+    """Persist Google OAuth tokens and optionally mirror to legacy shared auth."""
+    save_tokens(credentials_path, token_payload)
+
+    if mirror_shared_credentials and (
+        credentials_path != _SHARED_GOOGLE_CREDENTIALS_PATH
+        and not _is_google_account_credentials_path(credentials_path)
+    ):
+        save_tokens(_SHARED_GOOGLE_CREDENTIALS_PATH, token_payload)
 
 
 def refresh_google_token(path: str) -> Optional[str]:
@@ -478,6 +500,8 @@ def run_oauth_flow(
     client_secret: str,
     scopes: List[str],
     credentials_path: str,
+    *,
+    mirror_shared_credentials: bool = True,
     redirect_uri: str = _DEFAULT_REDIRECT_URI,
 ) -> Dict[str, Any]:
     """Run the full OAuth flow: browser consent, callback, token exchange.
@@ -502,6 +526,10 @@ def run_oauth_flow(
         List of OAuth scopes to request.
     credentials_path:
         Where to persist the resulting tokens.
+    mirror_shared_credentials:
+        When true, also mirror the resulting tokens into the legacy shared
+        Google credentials file. Set this to false for explicit temp paths or
+        named account aliases so tests and segmented profiles remain isolated.
     redirect_uri:
         Local callback URI.  Defaults to ``http://localhost:8789/callback``.
 
@@ -617,17 +645,11 @@ def run_oauth_flow(
         "client_id": client_id,
         "client_secret": client_secret,
     }
-    save_tokens(credentials_path, token_payload)
-
-    # Also save to the shared Google credentials file for the legacy flow so
-    # all Google connectors can use this token without a separate OAuth flow.
-    # Named account aliases must stay segmented and must not overwrite the
-    # default credentials.
-    if (
-        credentials_path != _SHARED_GOOGLE_CREDENTIALS_PATH
-        and not _is_google_account_credentials_path(credentials_path)
-    ):
-        save_tokens(_SHARED_GOOGLE_CREDENTIALS_PATH, token_payload)
+    _persist_google_oauth_tokens(
+        credentials_path,
+        token_payload,
+        mirror_shared_credentials=mirror_shared_credentials,
+    )
 
     return tokens
 

--- a/src/openjarvis/connectors/retriever.py
+++ b/src/openjarvis/connectors/retriever.py
@@ -240,6 +240,7 @@ class TwoStageRetriever:
         *,
         top_k: int = 10,
         source: str = "",
+        account: str = "",
         doc_type: str = "",
         author: str = "",
         since: str = "",
@@ -254,7 +255,10 @@ class TwoStageRetriever:
         top_k:
             Maximum number of results to return.
         source:
-            Restrict to chunks from this source (e.g. ``"gmail"``).
+            Restrict to chunks from this source (e.g. ``"gmail"`` or
+            ``"gmail:work"``).
+        account:
+            Restrict to chunks from a named connector account alias.
         doc_type:
             Restrict to chunks of this doc type (e.g. ``"email"``).
         author:
@@ -276,6 +280,8 @@ class TwoStageRetriever:
         filter_kwargs = {}
         if source:
             filter_kwargs["source"] = source
+        if account:
+            filter_kwargs["account"] = account
         if doc_type:
             filter_kwargs["doc_type"] = doc_type
         if author:

--- a/src/openjarvis/connectors/store.py
+++ b/src/openjarvis/connectors/store.py
@@ -140,6 +140,16 @@ def _to_epoch(ts: Union[datetime, str, float, int]) -> float:
     return ts.timestamp()
 
 
+def _split_source_account(source: Optional[str]) -> tuple[Optional[str], Optional[str]]:
+    """Parse optional ``source:account`` filters while preserving legacy source."""
+    if not source or ":" not in source:
+        return source, None
+    base, account = source.split(":", 1)
+    if not base or not account:
+        return source, None
+    return base, account
+
+
 # ---------------------------------------------------------------------------
 # KnowledgeStore
 # ---------------------------------------------------------------------------
@@ -342,6 +352,7 @@ class KnowledgeStore(MemoryBackend):
         *,
         top_k: int = 5,
         source: Optional[str] = None,
+        account: Optional[str] = None,
         doc_type: Optional[str] = None,
         author: Optional[str] = None,
         since: Optional[Union[datetime, str]] = None,
@@ -354,7 +365,8 @@ class KnowledgeStore(MemoryBackend):
         ----------
         query:    Full-text search query.
         top_k:    Maximum number of results.
-        source:   Restrict to chunks from this source (e.g. "gmail").
+        source:   Restrict to chunks from this source (e.g. "gmail" or "gmail:work").
+        account:  Restrict to chunks from a named connector account alias.
         doc_type: Restrict to chunks of this type (e.g. "email").
         author:   Restrict to chunks authored by this person.
         since:    Exclude chunks whose timestamp is earlier than this value.
@@ -365,6 +377,8 @@ class KnowledgeStore(MemoryBackend):
 
         since_str = _to_iso(since) if since is not None else None
         until_str = _to_iso(until) if until is not None else None
+        source, source_account = _split_source_account(source)
+        account = account or source_account
 
         # Build the WHERE clause for filter columns
         filters: List[str] = []
@@ -373,6 +387,9 @@ class KnowledgeStore(MemoryBackend):
         if source is not None:
             filters.append("kc.source = ?")
             params.append(source)
+        if account is not None:
+            filters.append("json_extract(kc.metadata, '$.account') = ?")
+            params.append(account)
         if doc_type is not None:
             filters.append("kc.doc_type = ?")
             params.append(doc_type)
@@ -439,6 +456,7 @@ class KnowledgeStore(MemoryBackend):
                     "source": source,
                     "doc_type": doc_type,
                     "author": author,
+                    "account": account,
                     "since": since_str,
                     "until": until_str,
                 },
@@ -478,12 +496,29 @@ class KnowledgeStore(MemoryBackend):
         mention "Notion" or "Apple Notes" when nothing from those sources
         is in the corpus.
         """
-        rows = self._conn.execute(
-            "SELECT DISTINCT source FROM knowledge_chunks "
-            "WHERE source IS NOT NULL AND source != '' "
-            "ORDER BY source"
-        ).fetchall()
-        return [r[0] for r in rows]
+        try:
+            rows = self._conn.execute(
+                "SELECT DISTINCT source, "
+                "json_extract(metadata, '$.account') AS account "
+                "FROM knowledge_chunks "
+                "WHERE source IS NOT NULL AND source != '' "
+                "ORDER BY source, account"
+            ).fetchall()
+        except sqlite3.OperationalError:
+            rows = self._conn.execute(
+                "SELECT DISTINCT source, NULL AS account FROM knowledge_chunks "
+                "WHERE source IS NOT NULL AND source != '' "
+                "ORDER BY source"
+            ).fetchall()
+
+        sources: set[str] = set()
+        for row in rows:
+            source = row["source"]
+            account = row["account"]
+            sources.add(source)
+            if account:
+                sources.add(f"{source}:{account}")
+        return sorted(sources)
 
     def close(self) -> None:
         """Close the underlying SQLite connection."""

--- a/src/openjarvis/connectors/sync_engine.py
+++ b/src/openjarvis/connectors/sync_engine.py
@@ -16,8 +16,9 @@ Typical usage::
 
 from __future__ import annotations
 
+import os
 import sqlite3
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -87,9 +88,14 @@ class SyncEngine:
         exception is re-raised so callers can handle it.
         """
         connector_id: str = connector.connector_id
+        account = str(getattr(connector, "_account", "") or "").strip()
+        checkpoint_id = f"{connector_id}:{account}" if account else connector_id
 
-        # Load any previous checkpoint so we can resume.
-        checkpoint = self.get_checkpoint(connector_id)
+        # Load any previous checkpoint so we can resume. Named account aliases
+        # must have independent checkpoints; otherwise syncing personal-main
+        # makes work-main resume from personal's last_sync and silently skip
+        # account-specific mail.
+        checkpoint = self.get_checkpoint(checkpoint_id)
         prior_cursor: Optional[str] = checkpoint["cursor"] if checkpoint else None
         prior_items: int = checkpoint["items_synced"] if checkpoint else 0
 
@@ -97,6 +103,17 @@ class SyncEngine:
         if checkpoint and checkpoint.get("last_sync"):
             try:
                 since = datetime.fromisoformat(checkpoint["last_sync"])
+                # Gmail and similar APIs often filter by message Date/internal
+                # timestamp, not by the moment OpenJarvis last polled. A new
+                # email can legitimately have a Date a few minutes before the
+                # checkpoint wall clock, so exact `after:last_sync` polling can
+                # miss it forever. Re-fetch a bounded overlap and rely on the
+                # store natural key to ignore already-ingested documents.
+                lookback_seconds = int(
+                    os.environ.get("OPENJARVIS_SYNC_LOOKBACK_SECONDS", "86400")
+                )
+                if lookback_seconds > 0:
+                    since = since - timedelta(seconds=lookback_seconds)
             except (ValueError, TypeError):
                 pass
 
@@ -114,7 +131,7 @@ class SyncEngine:
                     items_ingested += self._pipeline.ingest(batch)
                     batch = []
                     self._save_checkpoint(
-                        connector_id,
+                        checkpoint_id,
                         prior_items + items_ingested,
                         cursor=current_cursor,
                     )
@@ -125,7 +142,7 @@ class SyncEngine:
 
         except Exception as exc:
             self._save_checkpoint(
-                connector_id,
+                checkpoint_id,
                 prior_items + items_ingested,
                 cursor=current_cursor,
                 error=str(exc),
@@ -134,7 +151,7 @@ class SyncEngine:
 
         # Final checkpoint — clear any previous error.
         self._save_checkpoint(
-            connector_id,
+            checkpoint_id,
             prior_items + items_ingested,
             cursor=current_cursor,
             error=None,

--- a/src/openjarvis/engine/ollama.py
+++ b/src/openjarvis/engine/ollama.py
@@ -55,7 +55,15 @@ class OllamaEngine(InferenceEngine):
             env_host = os.environ.get("OLLAMA_HOST")
             host = env_host or self._DEFAULT_HOST
         self._host = host.rstrip("/")
-        self._client = httpx.Client(base_url=self._host, timeout=timeout)
+        # Do not inherit proxy/environment transport settings for LAN Ollama.
+        # On macOS, httpx trust_env=True can route private-subnet requests
+        # through system proxy discovery and intermittently time out even when
+        # direct curl and trust_env=False succeed.
+        self._client = httpx.Client(
+            base_url=self._host,
+            timeout=timeout,
+            trust_env=False,
+        )
         # Last stream usage — captured from Ollama's final chunk
         self._last_stream_usage: Dict[str, int] = {}
 
@@ -408,7 +416,12 @@ class OllamaEngine(InferenceEngine):
 
     def health(self) -> bool:
         try:
-            resp = self._client.get("/api/tags", timeout=2.0)
+            # LAN-hosted Ollama can take longer than localhost to accept the
+            # first connection, especially while models/Rust extensions are
+            # warming. Keep the probe short enough for discovery, but not so
+            # short that `serve` rejects a reachable subnet Ollama instance.
+            timeout = float(os.environ.get("OPENJARVIS_OLLAMA_HEALTH_TIMEOUT", "10"))
+            resp = self._client.get("/api/tags", timeout=timeout)
             return resp.status_code == 200
         except Exception as exc:
             logger.debug("Ollama health check failed at %s: %s", self._host, exc)

--- a/src/openjarvis/server/connectors_router.py
+++ b/src/openjarvis/server/connectors_router.py
@@ -81,6 +81,8 @@ try:
         code: Optional[str] = None
         email: Optional[str] = None
         password: Optional[str] = None
+        account: Optional[str] = None
+        profile: Optional[str] = None
 
 except ImportError:
     ConnectRequest = None  # type: ignore[assignment,misc]
@@ -111,12 +113,19 @@ def create_connectors_router():
     # Helpers
     # ------------------------------------------------------------------
 
-    def _get_or_create(connector_id: str) -> Any:
+    def _instance_key(connector_id: str, account: str = "") -> str:
+        return f"{connector_id}:{account}" if account else connector_id
+
+    def _get_or_create(connector_id: str, account: str = "") -> Any:
         """Return a cached connector instance, creating it if needed."""
-        if connector_id not in _instances:
+        key = _instance_key(connector_id, account)
+        if key not in _instances:
             cls = ConnectorRegistry.get(connector_id)
-            _instances[connector_id] = cls()
-        return _instances[connector_id]
+            try:
+                _instances[key] = cls(account=account) if account else cls()
+            except TypeError:
+                _instances[key] = cls()
+        return _instances[key]
 
     def _connector_summary(connector_id: str, instance: Any) -> Dict[str, Any]:
         """Build the dict returned by GET /connectors."""
@@ -226,7 +235,7 @@ def create_connectors_router():
             return "Connection timed out."
         return raw
 
-    def _start_sync(connector_id: str, instance: Any) -> str:
+    def _start_sync(connector_id: str, instance: Any, account: str = "") -> str:
         """Spawn a background sync; returns ``"started"`` or ``"already_syncing"``.
 
         Records baseline items in ``_sync_state`` so GET /{id}/sync polls
@@ -237,7 +246,8 @@ def create_connectors_router():
         """
         import threading
 
-        existing = _sync_threads.get(connector_id)
+        sync_key = _instance_key(connector_id, account)
+        existing = _sync_threads.get(sync_key)
         if existing and existing.is_alive():
             return "already_syncing"
 
@@ -257,7 +267,7 @@ def create_connectors_router():
         except Exception:  # noqa: BLE001
             baseline_items = 0
 
-        _sync_state[connector_id] = {
+        _sync_state[sync_key] = {
             "state": "syncing",
             "error": None,
             "baseline_items": baseline_items,
@@ -273,24 +283,24 @@ def create_connectors_router():
                 pipeline = IngestionPipeline(store=store)
                 engine = SyncEngine(pipeline=pipeline)
                 engine.sync(instance)
-                logger.info("Sync completed for %s", connector_id)
-                _sync_state[connector_id] = {
+                logger.info("Sync completed for %s", sync_key)
+                _sync_state[sync_key] = {
                     "state": "complete",
                     "error": None,
                     "baseline_items": baseline_items,
                 }
             except Exception as exc:
                 error_msg = _translate_sync_error(str(exc))
-                logger.error("Sync failed for %s: %s", connector_id, error_msg)
-                _sync_state[connector_id] = {
+                logger.error("Sync failed for %s: %s", sync_key, error_msg)
+                _sync_state[sync_key] = {
                     "state": "error",
                     "error": error_msg,
                     "baseline_items": baseline_items,
                 }
 
-        t = threading.Thread(target=_run_sync, daemon=True)
+        t = threading.Thread(target=_run_sync, daemon=True, name=f"sync-{sync_key}")
         t.start()
-        _sync_threads[connector_id] = t
+        _sync_threads[sync_key] = t
         return "started"
 
     # ------------------------------------------------------------------
@@ -382,7 +392,8 @@ def create_connectors_router():
                 status_code=404,
                 detail=f"Connector '{connector_id}' not found",
             )
-        instance = _get_or_create(connector_id)
+        account = (req.account or req.profile or "").strip()
+        instance = _get_or_create(connector_id, account)
 
         try:
             auth_type = getattr(instance, "auth_type", "unknown")
@@ -446,17 +457,18 @@ def create_connectors_router():
         # immediately — the user shouldn't have to click "Sync Now".
         sync_status: Optional[str] = None
         if instance.is_connected():
-            sync_status = _start_sync(connector_id, instance)
+            sync_status = _start_sync(connector_id, instance, account)
 
         return {
             "connector_id": connector_id,
+            "account": account or None,
             "connected": instance.is_connected(),
             "status": "connected" if instance.is_connected() else "pending",
             "sync_status": sync_status,
         }
 
     @router.post("/{connector_id}/disconnect")
-    async def disconnect_connector(connector_id: str):
+    async def disconnect_connector(connector_id: str, account: str = ""):
         """Disconnect a connector and clear its credentials."""
         _ensure_connectors_registered()
         if not ConnectorRegistry.contains(connector_id):
@@ -464,19 +476,22 @@ def create_connectors_router():
                 status_code=404,
                 detail=f"Connector '{connector_id}' not found",
             )
-        instance = _get_or_create(connector_id)
+        account = account.strip()
+        instance = _get_or_create(connector_id, account)
         try:
             instance.disconnect()
         except Exception as exc:
             raise HTTPException(status_code=500, detail=str(exc))
+        _instances.pop(_instance_key(connector_id, account), None)
         return {
             "connector_id": connector_id,
+            "account": account or None,
             "connected": False,
             "status": "disconnected",
         }
 
     @router.get("/{connector_id}/oauth/start")
-    async def oauth_start(connector_id: str, request: Request):
+    async def oauth_start(connector_id: str, request: Request, account: str = ""):
         """Redirect to the OAuth provider's consent page.
 
         The callback will come back to /v1/connectors/{id}/oauth/callback.
@@ -496,7 +511,8 @@ def create_connectors_router():
         if not provider:
             raise HTTPException(400, f"No OAuth provider for '{connector_id}'")
 
-        creds = get_client_credentials(provider)
+        account = account.strip()
+        creds = get_client_credentials(provider, account=account)
         if not creds:
             raise HTTPException(
                 400,
@@ -516,6 +532,8 @@ def create_connectors_router():
             "scope": " ".join(provider.scopes),
             **provider.extra_auth_params,
         }
+        if account:
+            params["state"] = account
         auth_url = f"{provider.auth_endpoint}?{urlencode(params)}"
 
         from fastapi.responses import RedirectResponse
@@ -528,12 +546,14 @@ def create_connectors_router():
         request: Request,
         code: str = "",
         error: str = "",
+        state: str = "",
+        account: str = "",
     ):
         """Handle OAuth callback from the provider."""
         from fastapi.responses import HTMLResponse
 
         from openjarvis.connectors.oauth import (
-            _CONNECTORS_DIR,
+            _credential_paths_for_provider,
             _exchange_token,
             get_client_credentials,
             get_provider_for_connector,
@@ -562,7 +582,8 @@ def create_connectors_router():
         if not provider:
             raise HTTPException(400, f"No OAuth provider for '{connector_id}'")
 
-        creds = get_client_credentials(provider)
+        account_alias = (account or state or "").strip()
+        creds = get_client_credentials(provider, account=account_alias)
         if not creds:
             raise HTTPException(400, "No client credentials configured")
 
@@ -595,11 +616,11 @@ def create_connectors_router():
             "client_secret": client_secret,
         }
 
-        for filename in provider.credential_files:
-            save_tokens(str(_CONNECTORS_DIR / filename), payload)
+        for path in _credential_paths_for_provider(provider, account=account_alias):
+            save_tokens(str(path), payload)
 
         # Clear cached instance so it picks up new credentials
-        _instances.pop(connector_id, None)
+        _instances.pop(_instance_key(connector_id, account_alias), None)
 
         _style = "font-family:system-ui;text-align:center;padding:60px"
         return HTMLResponse(
@@ -613,7 +634,7 @@ def create_connectors_router():
         )
 
     @router.post("/{connector_id}/sync")
-    def trigger_sync(connector_id: str) -> Dict[str, Any]:
+    def trigger_sync(connector_id: str, account: str = "") -> Dict[str, Any]:
         """Trigger a sync in the background and return immediately."""
         _ensure_connectors_registered()
         if not ConnectorRegistry.contains(connector_id):
@@ -621,17 +642,22 @@ def create_connectors_router():
                 status_code=404,
                 detail=f"Connector '{connector_id}' not found",
             )
-        inst = _get_or_create(connector_id)
+        account = account.strip()
+        inst = _get_or_create(connector_id, account)
         if not inst.is_connected():
             raise HTTPException(
                 status_code=400,
                 detail=f"Connector '{connector_id}' is not connected",
             )
-        status = _start_sync(connector_id, inst)
-        return {"connector_id": connector_id, "status": status}
+        status = _start_sync(connector_id, inst, account)
+        return {
+            "connector_id": connector_id,
+            "account": account or None,
+            "status": status,
+        }
 
     @router.get("/{connector_id}/sync")
-    async def sync_status(connector_id: str):
+    async def sync_status(connector_id: str, account: str = ""):
         """Return the current sync status for a connector."""
         _ensure_connectors_registered()
         if not ConnectorRegistry.contains(connector_id):
@@ -639,15 +665,17 @@ def create_connectors_router():
                 status_code=404,
                 detail=f"Connector '{connector_id}' not found",
             )
-        instance = _get_or_create(connector_id)
+        account = account.strip()
+        instance = _get_or_create(connector_id, account)
         try:
             status = instance.sync_status()
         except Exception as exc:
             raise HTTPException(status_code=500, detail=str(exc))
 
         # Override with router-level sync state (background thread tracking)
-        bg = _sync_state.get(connector_id, {})
-        bg_thread = _sync_threads.get(connector_id)
+        sync_key = _instance_key(connector_id, account)
+        bg = _sync_state.get(sync_key, {})
+        bg_thread = _sync_threads.get(sync_key)
         is_bg_running = bg_thread is not None and bg_thread.is_alive()
 
         # Fall back to the SyncEngine's persistent checkpoint for items_synced
@@ -679,11 +707,17 @@ def create_connectors_router():
             # ISO 8601 strings sort correctly under MIN(); skip rows with no
             # timestamp and any tombstoned chunks so the display reflects
             # what's actually retrievable.
-            row = store._conn.execute(
+            oldest_sql = (
                 "SELECT MIN(timestamp) FROM knowledge_chunks "
-                "WHERE source = ? AND timestamp != '' AND deleted_at IS NULL",
-                (store_source,),
-            ).fetchone()
+                "WHERE source = ? AND timestamp != '' AND deleted_at IS NULL"
+            )
+            oldest_params: tuple[Any, ...]
+            if account:
+                oldest_sql += " AND json_extract(metadata, '$.account') = ?"
+                oldest_params = (store_source, account)
+            else:
+                oldest_params = (store_source,)
+            row = store._conn.execute(oldest_sql, oldest_params).fetchone()
             if row is not None and row[0]:
                 oldest_item_date = str(row[0])
         except Exception:  # noqa: BLE001

--- a/src/openjarvis/server/connectors_router.py
+++ b/src/openjarvis/server/connectors_router.py
@@ -261,7 +261,7 @@ def create_connectors_router():
 
             cp = SyncEngine(
                 pipeline=IngestionPipeline(store=KnowledgeStore()),
-            ).get_checkpoint(connector_id)
+            ).get_checkpoint(sync_key)
             if cp and cp.get("items_synced") is not None:
                 baseline_items = int(cp["items_synced"])
         except Exception:  # noqa: BLE001
@@ -694,7 +694,7 @@ def create_connectors_router():
             store = KnowledgeStore()
             checkpoint = SyncEngine(
                 pipeline=IngestionPipeline(store=store),
-            ).get_checkpoint(connector_id)
+            ).get_checkpoint(sync_key)
 
             # Map connector_id → source field as written by the connector.
             # Most match 1:1, but the IMAP/OAuth Gmail connectors both write

--- a/src/openjarvis/tools/knowledge_search.py
+++ b/src/openjarvis/tools/knowledge_search.py
@@ -57,7 +57,15 @@ class KnowledgeSearchTool(BaseTool):
                         "type": "string",
                         "description": (
                             "Filter by source connector"
-                            " (e.g. 'gmail', 'slack', 'obsidian')."
+                            " (e.g. 'gmail', 'slack', 'obsidian', or"
+                            " 'gmail:work' for a named account alias)."
+                        ),
+                    },
+                    "account": {
+                        "type": "string",
+                        "description": (
+                            "Optional named connector account alias "
+                            "(e.g. 'personal' or 'work')."
                         ),
                     },
                     "doc_type": {
@@ -111,6 +119,7 @@ class KnowledgeSearchTool(BaseTool):
 
         top_k: int = int(params.get("top_k", 10))
         source: Optional[str] = params.get("source")
+        account: Optional[str] = params.get("account")
         doc_type: Optional[str] = params.get("doc_type")
         author: Optional[str] = params.get("author")
         since: Optional[str] = params.get("since")
@@ -121,6 +130,7 @@ class KnowledgeSearchTool(BaseTool):
                 query,
                 top_k=top_k,
                 source=source or "",
+                account=account or "",
                 doc_type=doc_type or "",
                 author=author or "",
                 since=since or "",
@@ -131,6 +141,7 @@ class KnowledgeSearchTool(BaseTool):
                 query,
                 top_k=top_k,
                 source=source,
+                account=account,
                 doc_type=doc_type,
                 author=author,
                 since=since,

--- a/tests/agents/test_research_loop.py
+++ b/tests/agents/test_research_loop.py
@@ -230,6 +230,8 @@ def _mk_hit(
     document_id: str = "granola:not_abc12345678901",
     url: str = "",
     title: str = "Sprint Planning",
+    account: str = "",
+    source_profile: str = "",
 ) -> SearchHit:
     """Tiny SearchHit factory for URL-routing tests."""
     return SearchHit(
@@ -244,6 +246,8 @@ def _mk_hit(
         score=0.5,
         bm25_score=0.5,
         vector_score=0.5,
+        account=account,
+        source_profile=source_profile,
         url=url,
     )
 
@@ -257,6 +261,27 @@ def test_build_sources_prefers_stored_url_over_reconstruction() -> None:
     stored = "https://notes.granola.ai/d/e98b5d85-ff57-46ac-a0ce-849fc68d086f"
     sources = build_sources_for_client([_mk_hit(url=stored)])
     assert sources[0]["url"] == stored
+
+
+def test_build_sources_includes_account_metadata() -> None:
+    """Citation payloads include the Google profile alias for UI chips.
+
+    The frontend can show "Gmail / work" and follow-up queries can preserve
+    the same scope instead of silently falling back to all Gmail accounts.
+    """
+    sources = build_sources_for_client(
+        [
+            _mk_hit(
+                source="gmail",
+                document_id="gmail:work:msg-1",
+                account="work",
+                source_profile="work",
+            )
+        ]
+    )
+
+    assert sources[0]["account"] == "work"
+    assert sources[0]["source_profile"] == "work"
 
 
 def test_build_sources_falls_back_to_reconstruction_when_url_missing() -> None:
@@ -362,6 +387,70 @@ def test_search_sources_coerces_scalar_to_list(stub_search: MagicMock) -> None:
     assert kwargs.get("sources") == ["slack"]
 
 
+def test_search_with_accounts_filter_is_passed_through(
+    stub_search: MagicMock,
+) -> None:
+    """A planner-selected account alias reaches HybridSearch.search."""
+    engine = _MockEngine(
+        responses=[
+            {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "s1",
+                        "name": "search",
+                        "arguments": json.dumps(
+                            {
+                                "query": "subscription renewals",
+                                "sources": ["gmail"],
+                                "accounts": ["work"],
+                            }
+                        ),
+                    }
+                ],
+                "usage": {},
+            },
+            _text_response("Found work subscription renewals."),
+        ]
+    )
+
+    agent = ResearchAgent(engine, stub_search, model="mock", max_iterations=2)
+    result = agent.run("summarize subscription renewals in work Gmail")
+
+    stub_search.search.assert_called_once()
+    kwargs = stub_search.search.call_args.kwargs
+    assert kwargs.get("sources") == ["gmail"]
+    assert kwargs.get("accounts") == ["work"]
+    assert result.tool_calls[0].arguments["accounts"] == ["work"]
+
+
+def test_search_account_scalar_is_coerced_to_list(stub_search: MagicMock) -> None:
+    """If the model sends ``account='personal'``, wrap it as ``['personal']``."""
+    engine = _MockEngine(
+        responses=[
+            {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "s1",
+                        "name": "search",
+                        "arguments": json.dumps(
+                            {"query": "anything", "account": "personal"}
+                        ),
+                    }
+                ],
+                "usage": {},
+            },
+            _text_response("done"),
+        ]
+    )
+    agent = ResearchAgent(engine, stub_search, model="mock", max_iterations=2)
+    agent.run("anything from my personal profile")
+
+    kwargs = stub_search.search.call_args.kwargs
+    assert kwargs.get("accounts") == ["personal"]
+
+
 # ---------------------------------------------------------------------------
 # Prompt + tool schema — the planner must see the sources directive
 # ---------------------------------------------------------------------------
@@ -376,8 +465,21 @@ def test_tool_schema_sources_lists_known_connectors() -> None:
     """
     sources_prop = SEARCH_TOOL_SPEC["function"]["parameters"]["properties"]["sources"]
     desc = sources_prop["description"]
-    for connector_id in ("granola", "slack", "gmail", "notion"):
+    for connector_id in ("granola", "slack", "gmail", "gdrive"):
         assert connector_id in desc
+    assert "connector:account" in desc
+    assert "gmail:work" in desc
+
+
+def test_tool_schema_includes_accounts_filter() -> None:
+    """The planner has an explicit account/persona filter parameter."""
+    accounts_prop = (
+        SEARCH_TOOL_SPEC["function"]["parameters"]["properties"]["accounts"]
+    )
+    desc = accounts_prop["description"]
+    assert accounts_prop["type"] == "array"
+    assert "account aliases" in desc
+    assert "work" in desc
 
 
 def test_system_prompt_mandates_sources_extraction() -> None:
@@ -391,6 +493,9 @@ def test_system_prompt_mandates_sources_extraction() -> None:
     # Synonym mapping for the most-common alias.
     assert "granola" in SYSTEM_PROMPT.lower()
     assert "meeting notes" in SYSTEM_PROMPT.lower()
+    assert "accounts=" in SYSTEM_PROMPT
+    assert "gmail:work" in SYSTEM_PROMPT
+    assert "account/profile/persona" in SYSTEM_PROMPT
     # The dynamic placeholder is what's interpolated per-run.
     assert "{available_sources}" in SYSTEM_PROMPT
 
@@ -428,7 +533,6 @@ def test_available_sources_override_appears_in_prompt(
     # unconnected source, which is intentional.)
     assert "obsidian" not in sys_content.lower()
     assert "apple_notes" not in sys_content.lower()
-    assert "gdrive" not in sys_content.lower()
 
 
 def test_available_sources_fall_back_to_store(stub_search: MagicMock) -> None:

--- a/tests/cli/test_connect.py
+++ b/tests/cli/test_connect.py
@@ -108,3 +108,25 @@ def test_connect_disconnect() -> None:
 
     assert result.exit_code == 0
     mock_instance.disconnect.assert_called_once()
+
+
+def test_connect_google_with_account_runs_segmented_oauth() -> None:
+    """connect google --account work routes OAuth through the account alias."""
+    runner = CliRunner()
+
+    with (
+        mock.patch(
+            "openjarvis.connectors.oauth.get_client_credentials",
+            return_value=("client.apps.googleusercontent.com", "secret"),
+        ),
+        mock.patch("openjarvis.connectors.oauth.run_connector_oauth") as mock_run,
+    ):
+        result = runner.invoke(cli, ["connect", "--account", "work", "google"])
+
+    assert result.exit_code == 0
+    mock_run.assert_called_once_with(
+        "gmail",
+        "client.apps.googleusercontent.com",
+        "secret",
+        account="work",
+    )

--- a/tests/connectors/test_account_scoped_retrieval.py
+++ b/tests/connectors/test_account_scoped_retrieval.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Iterator
+
+from openjarvis.connectors._stubs import BaseConnector, Document, SyncStatus
+from openjarvis.connectors.hybrid_search import HybridSearch
+from openjarvis.connectors.pipeline import IngestionPipeline
+from openjarvis.connectors.store import KnowledgeStore
+from openjarvis.connectors.sync_engine import SyncEngine
+
+MARKER = "OPENJARVIS_PERSONAL_MAIN_MARKER_001"
+
+
+def test_hybrid_search_does_not_fallback_to_recent_rows_for_nonempty_query(tmp_path):
+    store = KnowledgeStore(tmp_path / "knowledge.db")
+    store.store(
+        MARKER,
+        source="gmail",
+        source_id="personal-main:msg-1",
+        doc_type="email",
+        doc_id="gmail:personal-main:msg-1",
+        title="test",
+        author="Nirav <nirav@example.com>",
+        metadata={"account": "personal-main", "source_profile": "personal-main"},
+        timestamp="2026-06-05T14:28:51-04:00",
+    )
+    store.store(
+        "An unrelated work email",
+        source="gmail",
+        source_id="work-credain:msg-1",
+        doc_type="email",
+        doc_id="gmail:work-credain:msg-1",
+        title="unrelated",
+        author="Work <work@example.com>",
+        metadata={"account": "work-credain", "source_profile": "work-credain"},
+        timestamp="2026-06-05T14:29:00-04:00",
+    )
+
+    search = HybridSearch(store, embedder=None)
+
+    personal_hits = search.search(MARKER, sources=["gmail:personal-main"])
+    work_hits = search.search(MARKER, sources=["gmail:work-credain"])
+
+    assert len(personal_hits) == 1
+    assert personal_hits[0].account == "personal-main"
+    assert MARKER in personal_hits[0].content_snippet
+    assert work_hits == []
+
+
+def test_research_agent_strips_account_alias_person_filter():
+    from openjarvis.agents.research_loop import ResearchAgent
+
+    class _FakeSearch:
+        def __init__(self):
+            self.calls = []
+
+        def search(
+            self,
+            query,
+            *,
+            person=None,
+            time_range=None,
+            sources=None,
+            accounts=None,
+            limit=20,
+        ):
+            self.calls.append(
+                {
+                    "query": query,
+                    "person": person,
+                    "time_range": time_range,
+                    "sources": sources,
+                    "accounts": accounts,
+                    "limit": limit,
+                }
+            )
+            return []
+
+    fake_search = _FakeSearch()
+    agent = ResearchAgent(engine=None, search=fake_search)  # type: ignore[arg-type]
+
+    agent._execute_search(
+        {
+            "query": MARKER,
+            "person": "Personal Main",
+            "sources": ["gmail:personal-main"],
+        }
+    )
+    agent._execute_search(
+        {
+            "query": MARKER,
+            "person": "work-credain",
+            "sources": ["gmail"],
+            "accounts": ["work-credain"],
+        }
+    )
+
+    agent._execute_search(
+        {
+            "query": MARKER,
+            "person": "OpenJarvis",
+            "sources": ["gmail:personal-main"],
+        }
+    )
+
+    assert fake_search.calls[0]["person"] is None
+    assert fake_search.calls[1]["person"] is None
+    assert fake_search.calls[2]["person"] is None
+
+
+class _AccountConnector(BaseConnector):
+    connector_id = "gmail"
+    display_name = "Gmail"
+    auth_type = "oauth"
+
+    def __init__(self, account: str, marker: str):
+        self._account = account
+        self._marker = marker
+
+    def is_connected(self) -> bool:
+        return True
+
+    def disconnect(self) -> None:
+        return None
+
+    def sync(self, *, since=None, cursor=None) -> Iterator[Document]:
+        # If sync state is incorrectly shared across accounts, the second
+        # account receives since from the first account and emits nothing.
+        if since is not None:
+            return iter(())
+        return iter(
+            [
+                Document(
+                    doc_id=f"gmail:{self._account}:msg-1",
+                    source="gmail",
+                    doc_type="email",
+                    content=self._marker,
+                    title=self._marker,
+                    author=f"{self._account}@example.com",
+                    timestamp=datetime(2026, 6, 5, tzinfo=timezone.utc),
+                    metadata={
+                        "account": self._account,
+                        "source_profile": self._account,
+                    },
+                    source_id=f"{self._account}:msg-1",
+                )
+            ]
+        )
+
+    def sync_status(self) -> SyncStatus:
+        return SyncStatus()
+
+
+def test_sync_engine_checkpoints_are_account_scoped(tmp_path):
+    store = KnowledgeStore(tmp_path / "knowledge.db")
+    engine = SyncEngine(
+        IngestionPipeline(store=store),
+        state_db=str(tmp_path / "sync_state.db"),
+    )
+
+    assert engine.sync(_AccountConnector("personal-main", "personal marker")) == 1
+    assert engine.sync(_AccountConnector("work-credain", "work marker")) == 1
+
+    assert engine.get_checkpoint("gmail:personal-main")["items_synced"] == 1
+    assert engine.get_checkpoint("gmail:work-credain")["items_synced"] == 1
+    assert engine.get_checkpoint("gmail") is None
+
+    rows = store._conn.execute(
+        """
+        SELECT json_extract(metadata, '$.account') AS account, COUNT(*) AS count
+        FROM knowledge_chunks
+        WHERE source='gmail'
+        GROUP BY json_extract(metadata, '$.account')
+        ORDER BY account
+        """
+    ).fetchall()
+    assert [(row["account"], row["count"]) for row in rows] == [
+        ("personal-main", 1),
+        ("work-credain", 1),
+    ]
+
+
+def test_sync_engine_applies_checkpoint_lookback(monkeypatch, tmp_path):
+    seen_since = []
+
+    class _RecordingConnector(_AccountConnector):
+        def sync(self, *, since=None, cursor=None):
+            seen_since.append(since)
+            return iter(())
+
+    monkeypatch.setenv("OPENJARVIS_SYNC_LOOKBACK_SECONDS", "3600")
+    store = KnowledgeStore(tmp_path / "knowledge.db")
+    engine = SyncEngine(
+        IngestionPipeline(store=store),
+        state_db=str(tmp_path / "sync_state.db"),
+    )
+    engine._conn.execute(
+        """
+        INSERT INTO sync_state (connector_id, items_synced, cursor, last_sync, error)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        ("gmail:personal-main", 1, None, "2026-06-05T20:00:00+00:00", None),
+    )
+    engine._conn.commit()
+
+    engine.sync(_RecordingConnector("personal-main", "marker"))
+
+    assert seen_since[0].isoformat() == "2026-06-05T19:00:00+00:00"

--- a/tests/connectors/test_gmail.py
+++ b/tests/connectors/test_gmail.py
@@ -167,6 +167,37 @@ def test_sync_yields_documents(
     assert mock_get.call_count == 2
 
 
+@patch("openjarvis.connectors.gmail._gmail_api_list_messages")
+@patch("openjarvis.connectors.gmail._gmail_api_get_message")
+def test_sync_with_account_namespaces_ids_and_metadata(
+    mock_get,
+    mock_list,
+    tmp_path: Path,
+) -> None:
+    """Named Google accounts get collision-safe IDs and provenance metadata."""
+    from openjarvis.connectors import oauth  # noqa: PLC0415
+    from openjarvis.connectors.gmail import GmailConnector  # noqa: PLC0415
+
+    with patch.object(oauth, "_GOOGLE_ACCOUNTS_DIR", tmp_path / "google" / "accounts"):
+        conn = GmailConnector(account="work")
+
+    creds_path = Path(conn._credentials_path)
+    creds_path.parent.mkdir(parents=True, exist_ok=True)
+    creds_path.write_text(json.dumps({"token": "fake-access-token"}), encoding="utf-8")
+
+    mock_list.return_value = {"messages": [{"id": "msg1"}]}
+    mock_get.return_value = _MSG1
+
+    docs: List[Document] = list(conn.sync())
+
+    assert len(docs) == 1
+    assert docs[0].doc_id == "gmail:work:msg1"
+    assert docs[0].source_id == "work:msg1"
+    assert docs[0].metadata["account"] == "work"
+    assert docs[0].metadata["source_profile"] == "work"
+    assert docs[0].metadata["connector_instance"] == "gmail:work"
+
+
 # ---------------------------------------------------------------------------
 # Test 5 — disconnect removes the credentials file
 # ---------------------------------------------------------------------------

--- a/tests/connectors/test_hybrid_search.py
+++ b/tests/connectors/test_hybrid_search.py
@@ -1,0 +1,98 @@
+"""Tests for HybridSearch account/profile filtering."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from openjarvis.connectors.hybrid_search import HybridSearch
+from openjarvis.connectors.store import KnowledgeStore
+
+
+def _store(ks: KnowledgeStore, **kwargs) -> str:  # type: ignore[type-arg]
+    defaults = {
+        "content": "project alpha update",
+        "source": "gmail",
+        "doc_type": "email",
+        "doc_id": None,
+        "title": "",
+        "author": "",
+        "participants": None,
+        "timestamp": "2026-01-01T00:00:00",
+        "thread_id": None,
+        "url": None,
+        "metadata": None,
+        "chunk_index": 0,
+    }
+    defaults.update(kwargs)
+    return ks.store(**defaults)  # type: ignore[call-arg]
+
+
+def test_hybrid_search_filters_by_account_alias(tmp_path: Path) -> None:
+    """accounts=['work'] narrows all matching connectors to that profile."""
+    ks = KnowledgeStore(db_path=tmp_path / "knowledge.db")
+    _store(
+        ks,
+        content="project alpha renewal from work inbox",
+        title="Work renewal",
+        doc_id="gmail:work:1",
+        metadata={"account": "work", "source_profile": "work"},
+    )
+    _store(
+        ks,
+        content="project alpha renewal from personal inbox",
+        title="Personal renewal",
+        doc_id="gmail:personal:1",
+        metadata={"account": "personal", "source_profile": "personal"},
+        chunk_index=1,
+    )
+
+    hits = HybridSearch(ks).search("project alpha renewal", accounts=["work"])
+
+    assert hits
+    assert {h.title for h in hits} == {"Work renewal"}
+    assert all(h.account == "work" for h in hits)
+    assert all(h.source_profile == "work" for h in hits)
+
+
+def test_hybrid_search_intersects_sources_and_accounts(tmp_path: Path) -> None:
+    """Connector and account filters combine for precise persona-scoped queries."""
+    ks = KnowledgeStore(db_path=tmp_path / "knowledge.db")
+    _store(
+        ks,
+        content="project alpha roadmap in work Gmail",
+        source="gmail",
+        title="Work Gmail roadmap",
+        doc_id="gmail:work:1",
+        metadata={"account": "work", "source_profile": "work"},
+    )
+    _store(
+        ks,
+        content="project alpha roadmap in work Drive",
+        source="gdrive",
+        doc_type="file",
+        title="Work Drive roadmap",
+        doc_id="gdrive:work:1",
+        metadata={"account": "work", "source_profile": "work"},
+        chunk_index=1,
+    )
+    _store(
+        ks,
+        content="project alpha roadmap in personal Drive",
+        source="gdrive",
+        doc_type="file",
+        title="Personal Drive roadmap",
+        doc_id="gdrive:personal:1",
+        metadata={"account": "personal", "source_profile": "personal"},
+        chunk_index=2,
+    )
+
+    hits = HybridSearch(ks).search(
+        "project alpha roadmap",
+        sources=["gdrive"],
+        accounts=["work"],
+    )
+
+    assert hits
+    assert {h.title for h in hits} == {"Work Drive roadmap"}
+    assert all(h.source == "gdrive" for h in hits)
+    assert all(h.account == "work" for h in hits)

--- a/tests/connectors/test_oauth_flow.py
+++ b/tests/connectors/test_oauth_flow.py
@@ -5,6 +5,14 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+from openjarvis.connectors.gcalendar import GCalendarConnector
+from openjarvis.connectors.gcontacts import GContactsConnector
+from openjarvis.connectors.gdrive import GDriveConnector
+from openjarvis.connectors.gmail import GmailConnector
+from openjarvis.connectors.google_tasks import GoogleTasksConnector
+
 
 def test_exchange_google_token_calls_endpoint() -> None:
     from openjarvis.connectors.oauth import exchange_google_token
@@ -167,6 +175,122 @@ def test_google_account_credentials_path_is_segmented(tmp_path: Path) -> None:
         path = oauth.google_account_credentials_path("work")
 
     assert path == str(tmp_path / "google" / "accounts" / "work.json")
+
+
+def test_resolve_google_credentials_keeps_explicit_path_isolated(
+    tmp_path: Path,
+) -> None:
+    """An explicit temp credentials path must not fall back to shared Google auth."""
+    from openjarvis.connectors import oauth
+
+    shared = tmp_path / "google.json"
+    oauth.save_tokens(
+        str(shared),
+        {
+            "access_token": "ya29.shared",
+            "client_id": "shared-id",
+            "client_secret": "shared-secret",
+        },
+    )
+
+    explicit = str(tmp_path / "gdrive.json")
+    with patch.object(oauth, "_SHARED_GOOGLE_CREDENTIALS_PATH", str(shared)):
+        resolved = oauth.resolve_google_credentials(
+            explicit,
+            allow_shared_fallback=False,
+        )
+
+    assert resolved == explicit
+
+
+def test_resolve_google_credentials_still_falls_back_for_implicit_default(
+    tmp_path: Path,
+) -> None:
+    """The legacy implicit default path still resolves to shared Google auth."""
+    from openjarvis.connectors import oauth
+
+    shared = tmp_path / "google.json"
+    oauth.save_tokens(
+        str(shared),
+        {
+            "access_token": "ya29.shared",
+            "client_id": "shared-id",
+            "client_secret": "shared-secret",
+        },
+    )
+
+    default_path = str(tmp_path / "gdrive.json")
+    with patch.object(oauth, "_SHARED_GOOGLE_CREDENTIALS_PATH", str(shared)):
+        resolved = oauth.resolve_google_credentials(
+            default_path,
+            allow_shared_fallback=True,
+        )
+
+    assert resolved == str(shared)
+
+
+@pytest.mark.parametrize(
+    ("connector_cls", "credentials_name"),
+    [
+        (GDriveConnector, "gdrive"),
+        (GCalendarConnector, "gcalendar"),
+        (GContactsConnector, "gcontacts"),
+        (GmailConnector, "gmail"),
+        (GoogleTasksConnector, "google_tasks"),
+    ],
+)
+def test_google_connectors_keep_explicit_temp_paths_isolated(
+    connector_cls,
+    credentials_name: str,
+    tmp_path: Path,
+) -> None:
+    """Explicit temp credentials never read real host Google auth state."""
+    from openjarvis.connectors import oauth
+
+    shared = tmp_path / "google.json"
+    oauth.save_tokens(
+        str(shared),
+        {
+            "access_token": "ya29.shared",
+            "client_id": "shared-id",
+            "client_secret": "shared-secret",
+        },
+    )
+
+    explicit = str(tmp_path / f"{credentials_name}.json")
+    with patch.object(oauth, "_SHARED_GOOGLE_CREDENTIALS_PATH", str(shared)):
+        connector = connector_cls(credentials_path=explicit)
+
+    assert str(connector._credentials_path) == explicit
+    assert connector.is_connected() is False
+
+
+def test_persist_google_oauth_tokens_keeps_explicit_path_isolated(
+    tmp_path: Path,
+) -> None:
+    """Explicit temp OAuth paths stay isolated from the shared legacy file."""
+    from openjarvis.connectors import oauth
+
+    shared = tmp_path / "google.json"
+    explicit = tmp_path / "gdrive.json"
+    token_payload = {
+        "access_token": "ya29.work",
+        "refresh_token": "1//work",
+        "token_type": "Bearer",
+        "expires_in": 3600,
+        "client_id": "client.apps.googleusercontent.com",
+        "client_secret": "secret",
+    }
+
+    with patch.object(oauth, "_SHARED_GOOGLE_CREDENTIALS_PATH", str(shared)):
+        oauth._persist_google_oauth_tokens(
+            str(explicit),
+            token_payload,
+            mirror_shared_credentials=False,
+        )
+
+    assert explicit.exists()
+    assert not shared.exists()
 
 
 def test_run_connector_oauth_saves_named_google_account_only(tmp_path: Path) -> None:

--- a/tests/connectors/test_oauth_flow.py
+++ b/tests/connectors/test_oauth_flow.py
@@ -158,3 +158,44 @@ def test_gdrive_auth_url_returns_consent_url_with_client_id(
     url = conn.auth_url()
     assert "accounts.google.com" in url
     assert "test-id.apps.googleusercontent.com" in url
+
+
+def test_google_account_credentials_path_is_segmented(tmp_path: Path) -> None:
+    from openjarvis.connectors import oauth
+
+    with patch.object(oauth, "_GOOGLE_ACCOUNTS_DIR", tmp_path / "google" / "accounts"):
+        path = oauth.google_account_credentials_path("work")
+
+    assert path == str(tmp_path / "google" / "accounts" / "work.json")
+
+
+def test_run_connector_oauth_saves_named_google_account_only(tmp_path: Path) -> None:
+    from openjarvis.connectors import oauth
+
+    account_dir = tmp_path / "google" / "accounts"
+    legacy_dir = tmp_path / "legacy"
+
+    with (
+        patch.object(oauth, "_GOOGLE_ACCOUNTS_DIR", account_dir),
+        patch.object(oauth, "_CONNECTORS_DIR", legacy_dir),
+        patch("openjarvis.connectors.oauth.open_browser"),
+        patch("openjarvis.connectors.oauth._wait_for_callback_code", return_value="c"),
+        patch(
+            "openjarvis.connectors.oauth._exchange_token",
+            return_value={
+                "access_token": "ya29.work",
+                "refresh_token": "1//work",
+                "token_type": "Bearer",
+                "expires_in": 3600,
+            },
+        ),
+    ):
+        oauth.run_connector_oauth(
+            "gmail",
+            "client.apps.googleusercontent.com",
+            "secret",
+            account="work",
+        )
+
+    assert (account_dir / "work.json").exists()
+    assert not (legacy_dir / "gmail.json").exists()

--- a/tests/connectors/test_oauth_flow.py
+++ b/tests/connectors/test_oauth_flow.py
@@ -180,10 +180,11 @@ def test_google_account_credentials_path_is_segmented(tmp_path: Path) -> None:
 def test_resolve_google_credentials_keeps_explicit_path_isolated(
     tmp_path: Path,
 ) -> None:
-    """An explicit temp credentials path must not fall back to shared Google auth."""
+    """An explicit temp credentials path must not fall back or segment."""
     from openjarvis.connectors import oauth
 
     shared = tmp_path / "google.json"
+    account_dir = tmp_path / "google" / "accounts"
     oauth.save_tokens(
         str(shared),
         {
@@ -194,9 +195,13 @@ def test_resolve_google_credentials_keeps_explicit_path_isolated(
     )
 
     explicit = str(tmp_path / "gdrive.json")
-    with patch.object(oauth, "_SHARED_GOOGLE_CREDENTIALS_PATH", str(shared)):
+    with (
+        patch.object(oauth, "_SHARED_GOOGLE_CREDENTIALS_PATH", str(shared)),
+        patch.object(oauth, "_GOOGLE_ACCOUNTS_DIR", account_dir),
+    ):
         resolved = oauth.resolve_google_credentials(
             explicit,
+            account="work",
             allow_shared_fallback=False,
         )
 
@@ -263,6 +268,34 @@ def test_google_connectors_keep_explicit_temp_paths_isolated(
 
     assert str(connector._credentials_path) == explicit
     assert connector.is_connected() is False
+
+
+@pytest.mark.parametrize(
+    ("connector_cls", "credentials_name"),
+    [
+        (GDriveConnector, "gdrive"),
+        (GCalendarConnector, "gcalendar"),
+        (GContactsConnector, "gcontacts"),
+        (GmailConnector, "gmail"),
+        (GoogleTasksConnector, "google_tasks"),
+    ],
+)
+def test_google_connectors_prefer_explicit_path_over_account_alias(
+    connector_cls,
+    credentials_name: str,
+    tmp_path: Path,
+) -> None:
+    """credentials_path wins even when account is supplied."""
+    from openjarvis.connectors import oauth
+
+    account_dir = tmp_path / "google" / "accounts"
+    explicit = str(tmp_path / f"{credentials_name}.json")
+
+    with patch.object(oauth, "_GOOGLE_ACCOUNTS_DIR", account_dir):
+        connector = connector_cls(credentials_path=explicit, account="work")
+
+    assert str(connector._credentials_path) == explicit
+    assert str(connector._credentials_path) != str(account_dir / "work.json")
 
 
 def test_persist_google_oauth_tokens_keeps_explicit_path_isolated(

--- a/tests/connectors/test_store.py
+++ b/tests/connectors/test_store.py
@@ -86,6 +86,31 @@ def test_retrieve_filter_by_source(ks: KnowledgeStore) -> None:
     assert len(obsidian_results) >= 1
 
 
+def test_retrieve_filter_by_source_account_alias(ks: KnowledgeStore) -> None:
+    """source='gmail:work' filters to Gmail chunks from that account alias."""
+    _store(
+        ks,
+        content="Email about project alpha",
+        source="gmail",
+        doc_type="email",
+        metadata={"account": "work"},
+    )
+    _store(
+        ks,
+        content="Email about project alpha",
+        source="gmail",
+        doc_type="email",
+        metadata={"account": "personal"},
+        chunk_index=1,
+    )
+
+    work_results = ks.retrieve("project alpha", top_k=10, source="gmail:work")
+
+    assert len(work_results) >= 1
+    assert all(r.metadata.get("account") == "work" for r in work_results)
+    assert "gmail:work" in ks.distinct_sources()
+
+
 def test_retrieve_filter_by_doc_type(ks: KnowledgeStore) -> None:
     """retrieve() with doc_type= filters correctly."""
     _store(


### PR DESCRIPTION
## What does this PR do?

Adds account-scoped Google connector support so multiple Google accounts can be connected side by side without sharing credentials, sync checkpoints, source IDs, or retrieval state.

Key changes:
- Store Google/Gmail provenance with account metadata and account-prefixed source IDs.
- Use account-scoped sync checkpoints such as `gmail:personal-main` instead of one shared `gmail` checkpoint.
- Support account-scoped retrieval filters such as `gmail:<account>`.
- Prevent non-empty searches from falling back to unrelated recent rows.
- Improve research behavior when account aliases or marker-like strings are accidentally treated as people filters.
- Add sync lookback handling so messages near checkpoint boundaries are not skipped.
- Document multi-account setup and account-scoped queries in the README.

## Why?

Users may have multiple Google accounts for personal, work, subscriptions, persona, or organization-specific data. Without strict account scoping, sync state and retrieval can produce misleading results or make it hard to prove which account a result came from.

This PR makes account provenance explicit and testable.

## How was this tested?

Automated local validation:

```bash
uv run --with pytest pytest tests/connectors/test_account_scoped_retrieval.py -q
# 4 passed

uv run --with ruff ruff check src/openjarvis/agents/research_loop.py src/openjarvis/connectors/sync_engine.py tests/connectors/test_account_scoped_retrieval.py
# All checks passed
```

Manual local validation with placeholder account aliases:
- Connected multiple Google/Gmail accounts using named account aliases.
- Ran clean Gmail syncs per account.
- Verified marker-like searches return results only for the requested `gmail:<account>` filter.
- Verified account/source isolation directly in SQLite using the invariant: `metadata.account` must match the `source_id` prefix.
- Verified mismatch count was `0` in the local test corpus.

## Known follow-up

Large multi-year Gmail corpora need better throttled sync orchestration, progress estimates, and transient network/backoff handling. This PR focuses on account isolation and retrieval correctness rather than full large-mailbox operations.

## Checklist

- [x] Tests pass for the touched account-scoping behavior
- [x] Linter passes for touched files
- [ ] Formatter passes (`uv run ruff format --check src/ tests/`)
- [x] New/changed public behavior documented in README
- [x] Documentation updated where applicable
