### PR TITLE
fix(version): restore version to 1.0.2 (undo erroneous revert to 0.1.1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "OpenJarvis"
-version = "0.1.1"
+version = "1.0.2"
 description = "OpenJarvis — modular AI assistant backend with composable intelligence primitives"
 readme = "README.md"
 # Upper bound: numpy 2.2.x (pinned transitively via datasets/pandas) ships no


### PR DESCRIPTION
## Problem

`pyproject.toml` `version` was reverted from **1.0.2** to **0.1.1**. Consequences:

1. `jarvis --version` and installed metadata report **0.1.1** — the root cause of **#478** ("version unchanged after a successful update") and the version half of **#520** (users can't tell whether they picked up fixes).
2. `autotag.yml` computes the dev version as `MAJOR.MINOR.(PATCH+1).dev<count>` **from this field** — so with `0.1.1` it now tags `0.1.2.dev<count>`, **below** the real 1.0.x line. PyPI's latest stable is `1.0.2` and the dev line was `1.0.3.dev*`; every push to `main` is currently publishing sub-`1.0.2` dev releases.

## Fix

Restore `version = "1.0.2"` (the last released stable). `autotag.yml` resumes `1.0.3.dev<count>`, back on the 1.0.x line, and reported versions are correct again.

This is pipeline-compatible — `pypi-publish.yml` still `sed`s the tag version at build time.

## Note on merge

Merging triggers `autotag.yml` → a corrected `1.0.3.dev<count>` tag + PyPI/desktop publish (the intended behaviour).

## Follow-up (separate PR)

Full **hatch-vcs** dynamic versioning (so editable git checkouts report the exact `git describe` version) requires reworking `autotag.yml` + `pypi-publish.yml` (which currently `sed`s a static `version` line) and a clean 1.0.x anchor tag. Tracked separately to keep this change low-risk.

Fixes #478. Refs #520.

🤖 Generated with [Claude Code](https://claude.com/claude-code)