### PR TITLE
test(engine): expect EngineConnectionError for vllm 404 (fix main CI)

### DIFF
--- a/tests/engine/test_vllm_models.py
+++ b/tests/engine/test_vllm_models.py
@@ -204,10 +204,14 @@ class TestVLLMErrors:
         respx_mock.post(f"{VLLM_HOST}/v1/chat/completions").mock(
             return_value=httpx.Response(404, json={"error": "model not found"})
         )
-        with pytest.raises(httpx.HTTPStatusError):
+        # The OpenAI-compatible engine wraps upstream HTTP errors (incl. 404)
+        # in EngineConnectionError with an actionable message (see #463); the
+        # raw httpx.HTTPStatusError is the chained cause.
+        with pytest.raises(EngineConnectionError) as exc_info:
             engine.generate(
                 [Message(role=Role.USER, content="Hi")], model="nonexistent"
             )
+        assert isinstance(exc_info.value.__cause__, httpx.HTTPStatusError)
 
     def test_timeout_raises_connection_error(self) -> None:
         engine = _make_engine()


### PR DESCRIPTION
## Problem

`main`'s CI `test` job is red on `tests/engine/test_vllm_models.py::TestVLLMErrors::test_invalid_model_404`.

**Cause:** #463 (`a61d3c09`) changed the OpenAI-compatible engine (`_openai_compat.py`) to wrap upstream HTTP errors — including 404 — in a friendlier `EngineConnectionError` ("…returned 404… Make sure this port is running an OpenAI-compatible chat server…"). The test still asserted the raw `httpx.HTTPStatusError`. #463 was a stale fork PR with **no CI run**, so the broken test wasn't caught before it merged.

## Fix

Update `test_invalid_model_404` to expect `EngineConnectionError` (the new, intended behavior), and assert the original `httpx.HTTPStatusError` is preserved as the chained `__cause__` so the test still verifies the 404 propagation.

Whole `tests/engine` suite green again locally (394 passed under the CI marker filter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)