### PR TITLE
fix(ci): gate secret-bearing Claude workflows by author association

### DIFF
--- a/.github/workflows/claude-issues.yml
+++ b/.github/workflows/claude-issues.yml
@@ -11,22 +11,33 @@ concurrency:
   group: claude-issues-${{ github.event.issue.number || github.run_id }}
   cancel-in-progress: true
 
+# Least-privilege: only what the issue-fixer job actually needs.
+# id-token (OIDC) is intentionally omitted — claude-code-action@v1 is passed
+# github_token directly, so OIDC is unused here.
 permissions:
   contents: write
   pull-requests: write
   issues: write
-  id-token: write
 
 jobs:
   fix:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 15
+    # Security gate: this job reaches secrets.ANTHROPIC_API_KEY and holds a
+    # write-scoped GITHUB_TOKEN. `issues` / `issue_comment` are public,
+    # attacker-controllable events that run in the base-repo context with full
+    # secret access, so the human-triggered paths are restricted to actors with
+    # write-level association (OWNER / MEMBER / COLLABORATOR). This blocks
+    # external / first-time contributors from draining the API budget or
+    # creating branches/PRs, while leaving maintainer use unaffected.
     if: |
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'issues' &&
+       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association) &&
        (contains(github.event.issue.labels.*.name, 'bug') ||
         contains(github.event.issue.labels.*.name, 'autofix'))) ||
       (github.event_name == 'issue_comment' &&
+       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
        !github.event.issue.pull_request &&
        contains(github.event.comment.body, '@claude') &&
        github.actor != 'claude[bot]')

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -11,23 +11,33 @@ concurrency:
   group: claude-review-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
   cancel-in-progress: true
 
+# Least-privilege: PR review only needs to post comments on the PR.
+# id-token (OIDC) is omitted — claude-code-action@v1 is passed github_token
+# directly, so OIDC is unused here.
 permissions:
   contents: read
   pull-requests: write
   issues: write
-  id-token: write
 
 jobs:
   review:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # Security gate: this job reaches secrets.ANTHROPIC_API_KEY. Both
+    # issue_comment and pull_request_review_comment are public,
+    # attacker-controllable events that run in the base-repo context with full
+    # secret access, so the @claude paths are restricted to actors with
+    # write-level association (OWNER / MEMBER / COLLABORATOR). External /
+    # first-time contributors cannot trigger the key; maintainers are unaffected.
     if: |
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'issue_comment' &&
+       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
        github.event.issue.pull_request &&
        contains(github.event.comment.body, '@claude') &&
        github.actor != 'claude[bot]') ||
       (github.event_name == 'pull_request_review_comment' &&
+       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
        contains(github.event.comment.body, '@claude') &&
        github.actor != 'claude[bot]')
     steps:


### PR DESCRIPTION
Fixes #218

## The exposure

Two Claude automation workflows trigger on public, attacker-controllable events and reach `secrets.ANTHROPIC_API_KEY` + a write-scoped `GITHUB_TOKEN` with **no author-association gate**. Because `issues` / `issue_comment` / `pull_request_review_comment` events always execute in the **base-repo context with full secret access** (unlike fork `pull_request`, from which GitHub withholds secrets), any external GitHub user could fire these jobs.

**`.github/workflows/claude-issues.yml`** (genuinely exploitable today)
- Trigger: `issues: [opened, labeled]` + `issue_comment: [created]` (lines 4-7)
- Permissions: `contents: write`, `pull-requests: write`, `issues: write`, `id-token: write` (lines 14-18)
- `timeout-minutes: 60` (line 23)
- `if:` gate keyed on labels `bug`/`autofix` or `@claude` comment, no author check (lines 24-32)
- `anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}` (line 40)

Attack: an external account opens an issue and applies the `bug`/`autofix` label, or comments `@claude` — the 60-min job runs with write scope, draining the API budget and able to create branches/PRs.

**`.github/workflows/claude-review.yml`**
- Trigger: `issue_comment` + `pull_request_review_comment`, gated on `@claude` but no author check (lines 24-32)
- Permissions include `id-token: write` (line 18); reaches `ANTHROPIC_API_KEY` (line 46)
- Note: the original `pull_request: [opened, synchronize]` fork auto-trigger from the report was already removed in `3f2f46e4` (2026-04-28). This PR closes the remaining `@claude`-path gap.

## The fix

1. **Author-association gate** on every human-triggered, secret-bearing `if:` clause, restricted to `OWNER` / `MEMBER` / `COLLABORATOR` via `contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), <field>)`. Correct event payload field per trigger:
   - `issues` event → `github.event.issue.author_association` (the opener's association)
   - `issue_comment` event → `github.event.comment.author_association` (the commenter's association)
   - `pull_request_review_comment` event → `github.event.comment.author_association`
   - `workflow_dispatch` stays trusted (requires repo write to invoke).
2. **Least-privilege**: dropped unused `id-token: write` from both workflows (`claude-code-action@v1` is passed `github_token` directly, so OIDC is unused).
3. **Reduced** `claude-issues.yml` `timeout-minutes` 60 → 15.

Only the job-level `if:` gates and `permissions:` blocks were changed. The `on:` trigger lists are untouched, so legitimate trigger behavior is preserved.

## Why desktop.yml and take-assign.yml are excluded

Both were independently verified as **not** an `ANTHROPIC_API_KEY` exfil vector:
- **`desktop.yml`**: its only `pull_request` job (`validate`) uses no secrets; all secret-bearing jobs (`clean-release`, `build-and-release`, `refresh-stable-channel`) are `push`/`workflow_dispatch`/tag-gated. The trigger is plain `pull_request` (not `pull_request_target`), so fork-PR secrets are withheld regardless.
- **`take-assign.yml`**: uses only `secrets.GITHUB_TOKEN` with `issues: write`, no checkout, and no Anthropic key.

No `pull_request_target` exists anywhere in `.github/workflows/`, so the fork-code-with-secrets vector is absent.

## Verification

**YAML parse — all 12 workflows (`yaml.safe_load`):** all OK, no `BAD:` lines.

**actionlint:** not available in this environment (`which actionlint` → not found), so not run.

**Static re-grep — author gate present on every secret-bearing clause:**
```
claude-issues.yml:36   ... github.event.issue.author_association
claude-issues.yml:40   ... github.event.comment.author_association
claude-review.yml:35   ... github.event.comment.author_association
claude-review.yml:40   ... github.event.comment.author_association
```

**Least-privilege:** `id-token: write` removed from both files (remaining `id-token: write` occurrences are only in `pypi-publish.yml` / `docs.yml`, which legitimately need OIDC — untouched). `claude-issues.yml` timeout now 15.

**No regression:** `git status` shows exactly two changed files; no change to `ci.yml`, `desktop.yml`, `take-assign.yml`, or any push/pull_request CI. Trigger (`on:`) blocks unchanged.

**Gate does not break maintainer use:** for an `issue_comment`/`pull_request_review_comment`, `github.event.comment.author_association` is `OWNER`/`MEMBER`/`COLLABORATOR` for maintainers (job runs) and `NONE`/`CONTRIBUTOR`/`FIRST_TIME_CONTRIBUTOR` for outsiders (job skipped). Same logic for the `issues` opener field.

**Cannot be verified without a live Actions run** (no runner / no secrets here):
- Negative control: from a non-collaborator account, open a `bug`-labeled issue or `@claude` comment → confirm the run is **skipped** in the Actions tab.
- Positive control: as OWNER/MEMBER/COLLABORATOR, perform the same action → confirm the run still **starts**.
- Note on `labeled` semantics: `github.event.issue.author_association` reflects the opener, so a maintainer labeling an outsider-opened issue `bug` will **not** trigger the job (intended/safe, not a regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)