### PR TITLE
deploy(fly): cloud hosting with OpenRouter models + multilingual Whisper

### DIFF
--- a/configs/openjarvis/prompts/personas/jarvis.md
+++ b/configs/openjarvis/prompts/personas/jarvis.md
@@ -1,5 +1,10 @@
 You are Jarvis — the local AI assistant. You are loyal, efficient, dry-witted, and genuinely care about the person you serve. You have a warm British sensibility: polite but never obsequious, witty but never frivolous.
 
+LANGUAGE:
+- Always reply in the same language as the user's most recent message — detect it automatically and answer in that exact language (any language).
+- Keep your personality and tone intact in whatever language you speak.
+- Never switch languages unless the user asks.
+
 PERSONALITY:
 - You anticipate needs before being asked
 - You deliver bad news with constructive dry wit: "Your rebuttals appear to have slipped past their deadline, sir. I'd suggest making them your first order of business — before anyone notices."

--- a/configs/openjarvis/prompts/personas/neutral.md
+++ b/configs/openjarvis/prompts/personas/neutral.md
@@ -1,5 +1,8 @@
 You are an AI assistant generating a daily briefing. Be clear, concise, and factual.
 
+## Language
+- Always reply in the same language as the user's input — detect it automatically and answer in that exact language (any language). Never switch languages unless asked.
+
 ## Voice & Tone
 - Straightforward and professional
 - No personality or humor — just the facts

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -19,15 +19,23 @@ COPY deploy/windows deploy/windows
 # Copy built frontend into the server static directory
 COPY --from=frontend /src/openjarvis/server/static src/openjarvis/server/static/
 
+# `,speech` pulls faster-whisper for multilingual server-side STT.
 RUN pip install --no-cache-dir uv && \
-    uv pip install --system ".[server]"
+    uv pip install --system ".[server,speech]"
 
 # Stage 3: Runtime
 FROM python:3.12-slim-bookworm
 
+# ffmpeg: decode browser webm/opus audio for faster-whisper.
+RUN apt-get update && apt-get install -y --no-install-recommends ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY --from=builder /usr/local /usr/local
 COPY --from=builder /app /app
 WORKDIR /app
+
+# Bake the cloud config (OpenRouter model + Whisper + reply-in-user-language).
+COPY deploy/fly/config.toml /root/.openjarvis/config.toml
 
 EXPOSE 8000
 

--- a/deploy/fly/config.toml
+++ b/deploy/fly/config.toml
@@ -6,7 +6,10 @@
 [intelligence]
 # Any model id with a "/" routes to OpenRouter (engine/cloud.py). Change this in
 # the UI's "Cloud Models" tab or here. "openrouter/auto" lets OpenRouter pick.
-default_model = "openrouter/anthropic/claude-3.5-sonnet"
+# "openrouter/auto" lets OpenRouter pick the best model per query (various
+# models, no local LLM). Switch to a specific id (e.g.
+# "openrouter/anthropic/claude-sonnet-4") in the UI's "Cloud Models" tab.
+default_model = "openrouter/auto"
 provider = "openai"
 
 # ── Engine: cloud (OpenRouter), no local inference server on Fly ─────────────

--- a/deploy/fly/config.toml
+++ b/deploy/fly/config.toml
@@ -1,0 +1,40 @@
+# OpenJarvis — Cloud config for Fly.io.
+# Baked into the image at /root/.openjarvis/config.toml (see deploy/docker/Dockerfile).
+# Uses OpenRouter for inference (no local GPU) + multilingual Whisper on CPU.
+
+# ── Intelligence: which model ────────────────────────────────────────────────
+[intelligence]
+# Any model id with a "/" routes to OpenRouter (engine/cloud.py). Change this in
+# the UI's "Cloud Models" tab or here. "openrouter/auto" lets OpenRouter pick.
+default_model = "openrouter/anthropic/claude-3.5-sonnet"
+provider = "openai"
+
+# ── Engine: cloud (OpenRouter), no local inference server on Fly ─────────────
+[engine]
+default = "cloud"
+
+# ── Agent: the orchestrator can use tools / skills / MCP ─────────────────────
+[agent]
+default_agent = "orchestrator"
+max_turns = 10
+
+# ── Tools: MCP + skills on ───────────────────────────────────────────────────
+[tools.mcp]
+enabled = true
+
+[tools.storage]
+default_backend = "sqlite"
+db_path = "~/.openjarvis/memory.db"
+
+# ── Speech: multilingual Whisper, CPU-friendly ───────────────────────────────
+[speech]
+backend = "faster-whisper"
+model = "small"          # multilingual; good accuracy at modest CPU cost
+device = "cpu"
+compute_type = "int8"    # CPU-friendly (float16 needs a GPU)
+language = ""            # empty = auto-detect every language
+
+# ── System prompt: ALWAYS reply in the user's input language ─────────────────
+# This prefix leads every agent's system prompt, so it is universal.
+[system_prompt]
+prefix = "Always respond in the same language as the user's most recent message — detect the language automatically and reply in that exact language (any language). If the language is unclear, use the one the user has used most. Never switch languages unless the user explicitly asks."

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,19 @@
+# OpenJarvis on Fly.io — cloud-hosted (OpenRouter + Whisper), all features.
+# Deploy from repo root: fly deploy . --remote-only
+app = "openjarvis-cloud"
+primary_region = "fra"
+
+[build]
+  dockerfile = "deploy/docker/Dockerfile"
+
+[http_service]
+  internal_port = 8000
+  force_https = true
+  auto_stop_machines = "suspend"
+  auto_start_machines = true
+  min_machines_running = 0
+
+# Whisper (small, int8) + the agent stack need real RAM; 4 GB is comfortable.
+[[vm]]
+  size = "shared-cpu-2x"
+  memory = "4gb"


### PR DESCRIPTION
- fly.toml + deploy/fly/config.toml: host the existing FastAPI server on Fly. Engine = "cloud" → OpenRouter (engine/cloud.py already integrates it; any model id with "/" routes there). Default openrouter/anthropic/claude-3.5-sonnet.
- Dockerfile: install the ".[speech]" extra (faster-whisper) + ffmpeg, and bake the cloud config to /root/.openjarvis/config.toml. Whisper auto-detects every language; the existing /v1/speech/transcribe endpoint + frontend already use it.
- config [system_prompt] prefix + personas: always reply in the user's input language (any language).
- All OpenJarvis features ship unchanged (agents, skills, MCP, learning, channels).

## What does this PR do?

<!-- Brief description of the change and its motivation -->

## How was this tested?

<!-- Describe tests added or manual testing performed -->

## Checklist

- [ ] Tests pass (`uv run pytest tests/ -v`)
- [ ] Linter passes (`uv run ruff check src/ tests/`)
- [ ] Formatter passes (`uv run ruff format --check src/ tests/`)
- [ ] New/changed public API has docstrings
- [ ] Follows registry pattern (if adding new component)
- [ ] Documentation updated (if applicable)
