### PR TITLE
fix(spec-search): use Message objects in run_self_on_task and planner prompt fix

### DIFF
--- a/src/openjarvis/learning/spec_search/diagnose/tools.py
+++ b/src/openjarvis/learning/spec_search/diagnose/tools.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
+from openjarvis.core.types import Message, Role
 from openjarvis.learning.spec_search.diagnose.types import DiagnosticTool
 
 
@@ -278,7 +279,7 @@ def build_diagnostic_tools(
         if sample is None:
             return json.dumps({"error": f"Task {task_id} not found in benchmark"})
         response = teacher_engine.generate(
-            messages=[{"role": "user", "content": sample.query}],
+            messages=[Message(role=Role.USER, content=sample.query)],
             model=teacher_model,
             max_tokens=max_tokens,
         )

--- a/src/openjarvis/learning/spec_search/plan/planner.py
+++ b/src/openjarvis/learning/spec_search/plan/planner.py
@@ -45,7 +45,8 @@ INTELLIGENCE pillar:
 
 AGENT pillar:
 - replace_system_prompt: {{"new_content": "You are a helpful assistant.\\n..."}}
-- patch_system_prompt: {{"diff": "--- a/prompt.md\\n+++ b/prompt.md\\n@@ ...\\n"}}
+- patch_system_prompt: {{"diff": "--- a/prompt.md\\n+++ b/prompt.md\\n\
+@@ -3,1 +3,1 @@\\n-Old line\\n+New line\\n"}}
 - set_agent_class: {{"agent": "simple", "new_class": "react"}}
 - set_agent_param: {{"agent": "native_react", "param": "max_turns", "value": 10}}
 - edit_few_shot_exemplars: {{"agent": "native_react", \

--- a/tests/learning/spec_search/test_diagnose_tools.py
+++ b/tests/learning/spec_search/test_diagnose_tools.py
@@ -280,3 +280,51 @@ class TestListPersonalBenchmark:
         parsed = json.loads(result)
         assert len(parsed) == 1
         assert parsed[0]["task_id"] == "task-001"
+
+
+class TestRunSelfOnTask:
+    """Tests for the run_self_on_task diagnostic tool."""
+
+    def test_passes_message_objects_to_generate(self, tmp_path: Path) -> None:
+        from openjarvis.core.types import Message, Role
+        from openjarvis.learning.spec_search.diagnose.tools import (
+            build_diagnostic_tools,
+        )
+
+        captured_messages: list[Message] = []
+
+        def _mock_generate(*, messages: list[Message], **_: Any) -> dict[str, Any]:
+            captured_messages.extend(messages)
+            return {
+                "content": "ok",
+                "cost_usd": 0.0,
+                "usage": {"total_tokens": 1},
+            }
+
+        teacher_engine = MagicMock()
+        teacher_engine.generate.side_effect = _mock_generate
+
+        tools = build_diagnostic_tools(
+            trace_store=_make_stub_trace_store(),
+            config=_make_stub_config(tmp_path),
+            benchmark_samples=_make_stub_benchmark_samples(),
+            student_runner=MagicMock(),
+            teacher_engine=teacher_engine,
+            teacher_model="claude-opus-4-6",
+            judge=MagicMock(),
+            session_id="session-001",
+        )
+        run_self_on_task = next(t for t in tools if t.name == "run_self_on_task")
+        result = run_self_on_task.fn(task_id="task-001")
+
+        teacher_engine.generate.assert_called_once()
+        assert captured_messages
+        assert isinstance(captured_messages[0], Message)
+        assert captured_messages[0].role == Role.USER
+
+        parsed = json.loads(result)
+        assert parsed["task_id"] == "task-001"
+        assert parsed["output"] == "ok"
+        assert parsed["cost_usd"] == 0.0
+        assert parsed["tokens_used"] == 1
+        assert "error" not in parsed


### PR DESCRIPTION
## What does this PR do?
This PR fixes two concrete Spec Search failure modes in diagnose and planner flows.

- Fix 1: `run_self_on_task` now sends `Message` objects (not dicts) to `teacher_engine.generate`.
- Root cause and failing paths:
  - Diagnose tool call site passed OpenAI-style dict messages at [src/openjarvis/learning/spec_search/diagnose/tools.py#L281](https://github.com/open-jarvis/OpenJarvis/blob/main/src/openjarvis/learning/spec_search/diagnose/tools.py#L281).
  - Cloud engine paths expect `Sequence[Message]` and dereference message attributes:
    - [src/openjarvis/engine/_base.py#L20](https://github.com/open-jarvis/OpenJarvis/blob/main/src/openjarvis/engine/_base.py#L20) (`messages_to_dicts`) uses `m.role.value` and `m.content`.
    - [src/openjarvis/engine/cloud.py#L413](https://github.com/open-jarvis/OpenJarvis/blob/main/src/openjarvis/engine/cloud.py#L413) (`_prepare_anthropic_messages`) branches on `m.role.value`.
    - OpenAI/cloud generation paths call `messages_to_dicts`, e.g. [src/openjarvis/engine/cloud.py#L576](https://github.com/open-jarvis/OpenJarvis/blob/main/src/openjarvis/engine/cloud.py#L576).
  - Runtime symptom: dict inputs can raise `'dict' object has no attribute 'role'`, causing repeated diagnose-tool failures.

- Fix 2: Updated the planner prompt example to a valid numeric hunk (for example `@@ -3,1 +3,1 @@`), so teacher-produced PATCH edits are parseable and no longer downgraded for malformed diff syntax.
- Root cause and parser path:
  - Planner system prompt example in [src/openjarvis/learning/spec_search/plan/planner.py#L48](https://github.com/open-jarvis/OpenJarvis/blob/main/src/openjarvis/learning/spec_search/plan/planner.py#L48) previously used placeholder hunk header `@@ ...`.
  - Patch application logic in [src/openjarvis/learning/spec_search/plan/prompt_diff.py#L50](https://github.com/open-jarvis/OpenJarvis/blob/main/src/openjarvis/learning/spec_search/plan/prompt_diff.py#L50) requires real unified diff hunk headers; parsing starts at [src/openjarvis/learning/spec_search/plan/prompt_diff.py#L73](https://github.com/open-jarvis/OpenJarvis/blob/main/src/openjarvis/learning/spec_search/plan/prompt_diff.py#L73).
  - Invalid hunks return `None` which triggers downgrade warning logic at [src/openjarvis/learning/spec_search/plan/prompt_diff.py#L141](https://github.com/open-jarvis/OpenJarvis/blob/main/src/openjarvis/learning/spec_search/plan/prompt_diff.py#L141): "diff could not be applied, downgrading to REPLACE".

## How was this tested?

Added a regression test asserting Message(role=Role.USER, ...) is passed and output fields are preserved.

## Checklist

- [x] Tests pass (`uv run pytest tests/ -v`)
All green except for `collecting tests/evals/comparison/test_export_to_table_gen_roundtrip.py` failing because of polar import fail (nothing to do with my changes)
- [x] Linter passes (`uv run ruff check src/ tests/`)
- [x] Formatter passes (`uv run ruff format --check src/ tests/`)
- [ ] New/changed public API has docstrings
n/a
- [ ] Follows registry pattern (if adding new component)
n/a
- [ ] Documentation updated (if applicable)
n/a
