### PR TITLE
fix(research): respect configured engine/model in Deep Research

### DIFF
--- a/src/openjarvis/core/config.py
+++ b/src/openjarvis/core/config.py
@@ -1553,6 +1553,20 @@ class DigestConfig:
     )
 
 
+@dataclass(slots=True)
+class DeepResearchConfig:
+    """Engine/model for the Deep Research planner.
+
+    Empty values fall back to the configured chat engine/model
+    (``engine.default`` / ``intelligence.default_model``), then to the legacy
+    ``ollama`` / ``gemma4:31b``. The planner uses native function-calling, so a
+    custom model must support OpenAI-style tool calls.
+    """
+
+    engine: str = ""
+    model: str = ""
+
+
 @dataclass
 class JarvisConfig:
     """Top-level configuration for OpenJarvis."""
@@ -1565,6 +1579,7 @@ class JarvisConfig:
     learning: LearningConfig = field(default_factory=LearningConfig)
     tools: ToolsConfig = field(default_factory=ToolsConfig)
     agent: AgentConfig = field(default_factory=AgentConfig)
+    deep_research: DeepResearchConfig = field(default_factory=DeepResearchConfig)
     server: ServerConfig = field(default_factory=ServerConfig)
     telemetry: TelemetryConfig = field(default_factory=TelemetryConfig)
     analytics: AnalyticsConfig = field(default_factory=AnalyticsConfig)

--- a/src/openjarvis/server/research_router.py
+++ b/src/openjarvis/server/research_router.py
@@ -38,8 +38,9 @@ from openjarvis.agents.research_loop import (
 from openjarvis.connectors.embeddings import OllamaEmbedder
 from openjarvis.connectors.hybrid_search import HybridSearch
 from openjarvis.connectors.store import KnowledgeStore
-from openjarvis.core.config import DEFAULT_CONFIG_DIR
+from openjarvis.core.config import DEFAULT_CONFIG_DIR, load_config
 from openjarvis.core.types import TelemetryRecord
+from openjarvis.engine._discovery import get_engine
 from openjarvis.engine.ollama import OllamaEngine
 from openjarvis.telemetry.store import TelemetryStore
 
@@ -48,6 +49,25 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api", tags=["research"])
 
 _WEB_CLARIFY_RESPONSE = "no clarification available in web session"
+
+
+def _resolve_planner(config) -> tuple[str, str]:
+    """Resolve the Deep Research planner ``(engine_key, model)``.
+
+    Order: explicit ``[deep_research]`` override → the configured chat
+    engine/model (``engine.default`` / ``intelligence.default_model``) →
+    legacy ``ollama`` / ``gemma4:31b``. The planner uses native
+    function-calling, so a custom model must support OpenAI-style tool calls.
+    """
+    dr = getattr(config, "deep_research", None)
+    engine_key = getattr(dr, "engine", "") or config.engine.default or "ollama"
+    model = (
+        getattr(dr, "model", "")
+        or config.intelligence.default_model
+        or DEFAULT_PLANNER_MODEL
+    )
+    return engine_key, model
+
 
 # Sentinel placed on the queue when the agent thread terminates.
 _DONE = object()
@@ -151,6 +171,7 @@ class _LiveGPUSampler:
         try:
             # Suppress legacy pynvml deprecation FutureWarning (#389).
             import warnings as _warnings
+
             with _warnings.catch_warnings():
                 _warnings.filterwarnings(
                     "ignore",
@@ -161,9 +182,7 @@ class _LiveGPUSampler:
 
             pynvml.nvmlInit()
             count = pynvml.nvmlDeviceGetCount()
-            self._handles = [
-                pynvml.nvmlDeviceGetHandleByIndex(i) for i in range(count)
-            ]
+            self._handles = [pynvml.nvmlDeviceGetHandleByIndex(i) for i in range(count)]
             self._pynvml = pynvml
             self._available = bool(self._handles)
             if not self._available:
@@ -245,9 +264,10 @@ class _LiveGPUSampler:
 class ResearchRequest(BaseModel):
     query: str = Field(..., description="Natural-language question to research.")
     # Deep Research has its own model requirements (function-calling support,
-    # sufficient reasoning capability) that the chat-model selector should not
-    # override. We accept the field for forward-compat with older clients but
-    # ignore it — the planner always runs on DEFAULT_PLANNER_MODEL.
+    # sufficient reasoning capability). The planner model is resolved from
+    # server config — a [deep_research] override, else the configured chat
+    # engine/model (engine.default + intelligence.default_model). We accept
+    # this field for forward-compat with older clients but ignore it.
     model: Optional[str] = Field(
         default=None, description="Ignored; retained for client compatibility."
     )
@@ -290,7 +310,7 @@ def _chunk_synthesis(text: str, window_chars: int = 40) -> list[str]:
 # ---------------------------------------------------------------------------
 
 
-async def _stream_research(query: str, model: str) -> AsyncGenerator[str, None]:
+async def _stream_research(query: str) -> AsyncGenerator[str, None]:
     """Drive ResearchAgent on a worker thread; yield SSE frames as they land.
 
     Three error envelopes — setup, worker, consumer — all funnel into the
@@ -320,7 +340,13 @@ async def _stream_research(query: str, model: str) -> AsyncGenerator[str, None]:
             )
             embedder = None
 
-        engine = OllamaEngine()
+        config = load_config()
+        engine_key, model = _resolve_planner(config)
+        if engine_key == "ollama":
+            engine = OllamaEngine()  # default path unchanged
+        else:
+            resolved = get_engine(config, engine_key, model)
+            engine = resolved[1] if resolved else OllamaEngine()
         agent = ResearchAgent(
             engine=engine,
             search=HybridSearch(store, embedder),
@@ -426,9 +452,7 @@ async def _stream_research(query: str, model: str) -> AsyncGenerator[str, None]:
                 for piece in _chunk_synthesis(final_answer or ""):
                     yield _sse({"type": "synthesis", "text": piece})
                 if final_sources:
-                    yield _sse(
-                        {"type": "final_sources", "sources": final_sources}
-                    )
+                    yield _sse({"type": "final_sources", "sources": final_sources})
                 continue
 
             yield _sse(event)
@@ -437,9 +461,7 @@ async def _stream_research(query: str, model: str) -> AsyncGenerator[str, None]:
         # client still gets the error frame (emitted above) followed by done.
         # The done frame also carries the deduped sources so a client that
         # only listens for ``done`` still gets the canonical citation list.
-        yield _sse(
-            {"type": "done", "usage": final_usage, "sources": final_sources}
-        )
+        yield _sse({"type": "done", "usage": final_usage, "sources": final_sources})
     except Exception as exc:  # noqa: BLE001
         # Consumer loop crashed unexpectedly (e.g. JSON serialization fault,
         # logic bug). Surface a clean error frame rather than letting the
@@ -451,9 +473,7 @@ async def _stream_research(query: str, model: str) -> AsyncGenerator[str, None]:
                 "message": f"Research failed: {type(exc).__name__}: {exc}",
             }
         )
-        yield _sse(
-            {"type": "done", "usage": final_usage, "sources": final_sources}
-        )
+        yield _sse({"type": "done", "usage": final_usage, "sources": final_sources})
     finally:
         # The worker may still be cleaning up (rarely) — make sure we don't
         # leak a dangling task. Swallow any straggler exception so a worker
@@ -480,14 +500,15 @@ async def research(req: ResearchRequest) -> StreamingResponse:
     terminates the stream so clients can detect end-of-response without
     parsing the underlying ``[DONE]`` sentinel used by OpenAI-style routes.
     """
-    if req.model and req.model != DEFAULT_PLANNER_MODEL:
+    if req.model:
         logger.info(
-            "research: ignoring client model=%r; using DEFAULT_PLANNER_MODEL=%r",
+            "research: ignoring client model=%r; planner resolved from config "
+            "([deep_research] override, else engine.default + "
+            "intelligence.default_model)",
             req.model,
-            DEFAULT_PLANNER_MODEL,
         )
     return StreamingResponse(
-        _stream_research(req.query, DEFAULT_PLANNER_MODEL),
+        _stream_research(req.query),
         media_type="text/event-stream",
         headers={
             "Cache-Control": "no-cache",

--- a/tests/core/test_deep_research_config.py
+++ b/tests/core/test_deep_research_config.py
@@ -1,0 +1,14 @@
+from openjarvis.core.config import JarvisConfig, validate_config_key
+
+
+def test_deep_research_defaults_are_empty():
+    cfg = JarvisConfig()
+    assert cfg.deep_research.engine == ""
+    assert cfg.deep_research.model == ""
+
+
+def test_deep_research_keys_are_settable():
+    # _SETTABLE_SECTIONS is derived from JarvisConfig fields, so a new section
+    # must be config-set-able without any extra registration.
+    assert validate_config_key("deep_research.engine") is str
+    assert validate_config_key("deep_research.model") is str

--- a/tests/server/test_research_planner.py
+++ b/tests/server/test_research_planner.py
@@ -12,10 +12,10 @@ def test_legacy_fallback_when_nothing_configured():
 def test_uses_configured_chat_engine_and_model():
     cfg = JarvisConfig()
     cfg.engine.default = "lmstudio"
-    cfg.intelligence.default_model = "qwen3.5-9b-uncensored-hauhaucs-aggressive"
+    cfg.intelligence.default_model = "fine-tuned-model"
     assert _resolve_planner(cfg) == (
         "lmstudio",
-        "qwen3.5-9b-uncensored-hauhaucs-aggressive",
+        "fine-tuned-model",
     )
 
 

--- a/tests/server/test_research_planner.py
+++ b/tests/server/test_research_planner.py
@@ -1,0 +1,28 @@
+from openjarvis.core.config import JarvisConfig
+from openjarvis.server.research_router import _resolve_planner
+
+
+def test_legacy_fallback_when_nothing_configured():
+    cfg = JarvisConfig()
+    cfg.engine.default = "ollama"
+    cfg.intelligence.default_model = ""
+    assert _resolve_planner(cfg) == ("ollama", "gemma4:31b")
+
+
+def test_uses_configured_chat_engine_and_model():
+    cfg = JarvisConfig()
+    cfg.engine.default = "lmstudio"
+    cfg.intelligence.default_model = "qwen3.5-9b-uncensored-hauhaucs-aggressive"
+    assert _resolve_planner(cfg) == (
+        "lmstudio",
+        "qwen3.5-9b-uncensored-hauhaucs-aggressive",
+    )
+
+
+def test_explicit_override_wins():
+    cfg = JarvisConfig()
+    cfg.engine.default = "lmstudio"
+    cfg.intelligence.default_model = "chat-model"
+    cfg.deep_research.engine = "vllm"
+    cfg.deep_research.model = "research-model"
+    assert _resolve_planner(cfg) == ("vllm", "research-model")


### PR DESCRIPTION
Fixes #575.

## Problem

Deep Research is hardwired to Ollama. `server/research_router.py` constructs `OllamaEngine()` directly and always runs the planner on `DEFAULT_PLANNER_MODEL = "gemma4:31b"`, ignoring the configured inference engine. On a non-Ollama setup (e.g. a model served from LM Studio / vLLM / llama-server) Deep Research fails with:

```
Research failed: RuntimeError: Ollama returned 404: {"error":"model 'gemma4:31b' not found"}
```

## Change

Resolve the Deep Research planner's engine/model from config instead of hardcoding it:

1. **Explicit override** — a new `[deep_research]` config section (`engine` / `model`).
2. **else the configured chat engine/model** — `engine.default` + `intelligence.default_model` (this is what the issue asks for: "use the model I'm already using for Chat").
3. **else the legacy** `ollama` / `gemma4:31b`.

The engine is built through the existing `get_engine()` registry; the `engine == "ollama"` path is unchanged. A new `DeepResearchConfig` dataclass is added (auto-included in the settable-config sections). The client-supplied `model` field keeps its existing "ignored" contract — the planner is server-resolved.

## Backwards compatibility

With no `[deep_research]` config, behavior is unchanged for Ollama users (it resolves to their configured engine/model, falling back to `gemma4:31b` only when nothing is set). No public APIs change.

## Tests

- `tests/core/test_deep_research_config.py` — the new config section + `validate_config_key` wiring.
- `tests/server/test_research_planner.py` — `_resolve_planner` for all three cases (legacy fallback, configured chat engine/model, explicit override).

Verified end-to-end: Deep Research now runs against an LM Studio engine over the network instead of 404-ing on Ollama.
