### PR TITLE
ci: parallelize the test suite and cut install/coverage overhead

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.0.0
+        with:
+          enable-cache: true
 
       - name: Install dependencies
         run: uv sync --extra dev --extra framework-comparison --extra server
@@ -55,6 +57,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.0.0
+        with:
+          enable-cache: true
 
       - name: Install dependencies
         run: uv sync --extra dev --extra framework-comparison --extra server
@@ -63,8 +67,13 @@ jobs:
         run: uv run maturin develop --manifest-path rust/crates/openjarvis-python/Cargo.toml
 
       - name: Run tests
+        # COVERAGE_CORE=sysmon uses CPython 3.12's sys.monitoring backend,
+        # which is dramatically cheaper than the default C trace function.
+        # -n auto fans the suite out across all runner cores via pytest-xdist.
+        env:
+          COVERAGE_CORE: sysmon
         run: |
-          uv run pytest tests/ -v --tb=short -m "not live and not cloud and not hub" \
+          uv run pytest tests/ -n auto -q --tb=short -m "not live and not cloud and not hub" \
             --cov=openjarvis \
             --cov-report=term-missing \
             --cov-report=xml \
@@ -107,6 +116,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.0.0
+        with:
+          enable-cache: true
 
       - name: Install dependencies
         run: uv sync --extra dev --extra server

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dev = [
     "pytest>=8",
     "pytest-asyncio>=0.24",
     "pytest-cov>=5",
+    "pytest-xdist>=3",
     "respx>=0.22",
     "ruff>=0.4",
     "pre-commit>=3.0",


### PR DESCRIPTION
## Summary

The `test` job runs ~6,300 tests single-threaded with full coverage instrumentation, which dominates CI wall-clock. This speeds it up **without changing what's tested or the 60% coverage gate**.

## Changes

- **Parallelize tests** — run pytest with `-n auto` (new dev dep `pytest-xdist`) so the suite fans out across all runner cores. Public-repo `ubuntu-latest` is the 4-vCPU tier, so this is ~3–4× on test execution.
- **Cheaper coverage** — `COVERAGE_CORE=sysmon` makes coverage use CPython 3.12's `sys.monitoring` backend instead of the slow C trace function (~30% overhead → ~5%).
- **uv cache** — `enable-cache: true` on all three `setup-uv` steps so dependencies aren't re-downloaded each run.
- **Less log I/O** — test output switched from `-v` to `-q`.

## Safety

- The suite is already parallel-safe: tests use `tmp_path` (zero tests instantiate default-path stores) and the autouse conftest fixture resets all registries + the event bus per test. Workers are separate processes, so in-process global state is per-worker.
- Verified locally that `-n auto` runs green (e.g. a 109-test subset: 6.71s → 2.27s).

## Notes

- `pytest-xdist` is **dev-only** (`[project.optional-dependencies].dev`); it never reaches runtime installs.
- `uv.lock` is intentionally not regenerated here — CI uses `uv sync` (non-frozen), which resolves the new dev dep at install time. The lock uses a newer revision than was convenient to edit cleanly in this change; a maintainer on current `uv` can refresh it in passing if desired.

## Follow-up (not in this PR)

If 4-way isn't enough, shard the suite across a job matrix (`pytest-split`, e.g. 3 shards × `-n auto` ≈ 12-way on free concurrent runners) with a final `coverage combine` job. Happy to send that as a separate PR.