### PR TITLE
test(server): make TestTraceRecording hermetic (env-independent)

### DIFF
--- a/tests/server/test_routes.py
+++ b/tests/server/test_routes.py
@@ -790,8 +790,25 @@ class TestCreateApp:
 # ---------------------------------------------------------------------------
 
 
+def _traces_enabled_config(tmp_path):
+    """A config with traces explicitly enabled, isolated to *tmp_path*.
+
+    ``create_app`` only builds a trace store when ``config.traces.enabled`` is
+    true (server/app.py). Relying on the ambient ``load_config()`` made these
+    tests fail on any machine whose ``~/.openjarvis/config.toml`` disables
+    traces; pinning an explicit config + tmp db keeps them hermetic and
+    parallel-safe under ``pytest -n auto``.
+    """
+    from openjarvis.core.config import JarvisConfig
+
+    cfg = JarvisConfig()
+    cfg.traces.enabled = True
+    cfg.traces.db_path = str(tmp_path / "traces.db")
+    return cfg
+
+
 class TestTraceRecording:
-    def test_agent_completion_creates_trace(self):
+    def test_agent_completion_creates_trace(self, tmp_path):
         """A non-streaming agent completion records exactly one trace.
 
         The collector is the single writer: it saves directly and also
@@ -810,9 +827,10 @@ class TestTraceRecording:
             "test-model",
             agent=agent,
             bus=EventBus(record_history=False),
+            config=_traces_enabled_config(tmp_path),
         )
         store = app.state.trace_store
-        assert store is not None, "traces enabled by default → store should exist"
+        assert store is not None, "traces explicitly enabled → store should exist"
         assert store.count() == 0
 
         client = TestClient(app)
@@ -831,10 +849,10 @@ class TestTraceRecording:
         assert trace.query == "What is 2+2?"
         assert trace.result == "traced reply"
 
-    def test_streaming_completion_creates_trace(self):
+    def test_streaming_completion_creates_trace(self, tmp_path):
         """A streamed completion (no agent) records the assembled response."""
         engine = _make_engine()
-        app = create_app(engine, "test-model")
+        app = create_app(engine, "test-model", config=_traces_enabled_config(tmp_path))
         store = app.state.trace_store
         assert store is not None
         assert store.count() == 0


### PR DESCRIPTION
## Problem

`tests/server/test_routes.py::TestTraceRecording` (both `test_agent_completion_creates_trace` and `test_streaming_completion_creates_trace`) called `create_app(...)` without a `config`, so it fell back to the ambient `load_config()`. The trace store is only created when `config.traces.enabled` is true (`server/app.py`), which defaults to True **only when no `~/.openjarvis/config.toml` overrides it**.

Result: on any dev machine whose local config has `[traces] enabled = false`, both tests fail with:

```
AssertionError: traces enabled by default → store should exist
assert None is not None
```

They pass in CI only because the CI runner has no config file, so the code default (`True`) applies. This surfaced while reviewing #579/#580 (see #582).

## Fix

Pin an explicit traces-enabled config with a tmp `db_path` via a small `_traces_enabled_config(tmp_path)` helper, and pass it to `create_app`. This makes the tests:
- **environment-independent** — no longer dependent on ambient `~/.openjarvis/config.toml`,
- **hermetic** — each writes its trace db under `tmp_path`,
- **parallel-safe** — no shared default db path under `pytest -n auto` (#580).

No production code changes; `create_app` already accepts and honors an explicit `config`.

## Verification

On a machine with `[traces] enabled = false` locally (which reproduced the failure):
- `TestTraceRecording` in isolation: **2 passed** (failed before this change).
- Full `tests/server/test_routes.py`: **33 passed**.
- `ruff check` + `ruff format` clean.

Relates to #582.

🤖 Generated with [Claude Code](https://claude.com/claude-code)