### PR TITLE
Remove hardcoded Supabase leaderboard credentials

### DIFF
--- a/docs/javascripts/leaderboard.js
+++ b/docs/javascripts/leaderboard.js
@@ -1,9 +1,9 @@
 (function () {
   "use strict";
 
-  var SUPABASE_URL = "https://mtbtgpwzrbostweaanpr.supabase.co";
-  var SUPABASE_ANON_KEY =
-    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im10YnRncHd6cmJvc3R3ZWFhbnByIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzMxODk0OTQsImV4cCI6MjA4ODc2NTQ5NH0._xMlqCfljtXpwPj54H-ghxfLFO-jiq4W2WhpU8vVL1c";
+  var config = window.OPENJARVIS_LEADERBOARD_CONFIG || {};
+  var SUPABASE_URL = config.supabaseUrl || "";
+  var SUPABASE_ANON_KEY = config.supabaseAnonKey || "";
 
   var PAGE_SIZE = 50;
   var allRows = [];

--- a/frontend/src/components/Desktop/SavingsDashboard.tsx
+++ b/frontend/src/components/Desktop/SavingsDashboard.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import type React from 'react';
 import { invoke } from '@tauri-apps/api/core';
+import { SUPABASE_ANON_KEY, SUPABASE_URL } from '../../lib/supabaseConfig';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -279,9 +280,6 @@ function getOrCreateAnonId(): string {
   return id;
 }
 
-const SUPABASE_URL = 'https://mtbtgpwzrbostweaanpr.supabase.co';
-const SUPABASE_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im10YnRncHd6cmJvc3R3ZWFhbnByIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzMxODk0OTQsImV4cCI6MjA4ODc2NTQ5NH0._xMlqCfljtXpwPj54H-ghxfLFO-jiq4W2WhpU8vVL1c';
-
 const REFRESH_INTERVAL_MS = 5000;
 
 export function SavingsDashboard({ apiUrl }: { apiUrl: string }) {
@@ -321,12 +319,13 @@ export function SavingsDashboard({ apiUrl }: { apiUrl: string }) {
   // Share savings to Supabase when opted in and data changes
   useEffect(() => {
     if (!optInEnabled || !displayName || !data) return;
+    if (!SUPABASE_URL || !SUPABASE_ANON_KEY) return;
     const dollarSavings = data.per_provider.reduce((s, p) => s + p.total_cost, 0);
     const energySaved = data.per_provider.reduce((s, p) => s + (p.energy_wh || 0), 0);
     const flopsSaved = data.per_provider.reduce((s, p) => s + (p.flops || 0), 0);
     invoke('submit_savings', {
       supabaseUrl: SUPABASE_URL,
-      supabaseKey: SUPABASE_KEY,
+      supabaseKey: SUPABASE_ANON_KEY,
       payload: {
         anon_id: anonId,
         display_name: displayName,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,11 +1,5 @@
 import type { ModelInfo, SavingsData, ServerInfo } from '../types';
-
-// ---------------------------------------------------------------------------
-// Supabase config — safe to embed (RLS protects writes)
-// ---------------------------------------------------------------------------
-
-const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL || 'https://mtbtgpwzrbostweaanpr.supabase.co';
-const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im10YnRncHd6cmJvc3R3ZWFhbnByIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzMxODk0OTQsImV4cCI6MjA4ODc2NTQ5NH0._xMlqCfljtXpwPj54H-ghxfLFO-jiq4W2WhpU8vVL1c';
+import { SUPABASE_ANON_KEY, SUPABASE_URL } from './supabaseConfig';
 
 declare global {
   interface Window {

--- a/frontend/src/lib/supabaseConfig.test.ts
+++ b/frontend/src/lib/supabaseConfig.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = resolve(__dirname, '../../..');
+
+const publicSupabaseSources = [
+  'frontend/src/lib/api.ts',
+  'frontend/src/components/Desktop/SavingsDashboard.tsx',
+  'docs/javascripts/leaderboard.js',
+];
+
+describe('public Supabase configuration', () => {
+  it('does not hardcode the Supabase project URL or anon JWT in public sources', () => {
+    for (const source of publicSupabaseSources) {
+      const text = readFileSync(resolve(repoRoot, source), 'utf8');
+
+      expect(text, source).not.toMatch(/https:\/\/[a-z0-9]{20}\.supabase\.co/);
+      expect(text, source).not.toMatch(/\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/);
+    }
+  });
+});

--- a/frontend/src/lib/supabaseConfig.ts
+++ b/frontend/src/lib/supabaseConfig.ts
@@ -1,0 +1,2 @@
+export const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL ?? '';
+export const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY ?? '';

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,7 +1,10 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
-  readonly VITE_API_URL: string;
+  readonly VITE_API_URL?: string;
+  readonly VITE_OPENJARVIS_API_KEY?: string;
+  readonly VITE_SUPABASE_URL?: string;
+  readonly VITE_SUPABASE_ANON_KEY?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
- move Supabase leaderboard config to Vite environment variables/runtime docs config
- stop embedding the Supabase project URL and anon JWT in public frontend/docs sources
- add a regression test that scans public Supabase sources for hardcoded Supabase URLs/JWTs

## Verification
- npm test -- supabaseConfig.test.ts
- npm test -- api.auth.test.ts
- npm run build
- rg search for the previous Supabase project URL/JWT returned no matches in working sources