### PR TITLE
Fix PyPI frontend Supabase build env

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -254,6 +254,10 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           TAURI_CONFIG: '{"version":"${{ steps.release-info.outputs.tauri_version }}","bundle":{"externalBin":["binaries/ollama"]}}'
+          # tauri-action runs beforeBuildCommand (npm run build:tauri -> vite
+          # build), which requires this at build time (#587). Strict for
+          # releases: a missing/empty secret fails the build by design.
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
         with:
           projectPath: frontend
           tauriScript: npx tauri

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -55,6 +55,8 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
 
       - name: Build frontend and bundle into package
+        env:
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
         run: |
           set -euo pipefail
           cd frontend


### PR DESCRIPTION
## Summary

Follow-up to #587.

- Pass `secrets.VITE_SUPABASE_ANON_KEY` into the PyPI publish workflow's frontend build step.
- Keep publish builds strict: if the repo secret is missing or empty, `npm run build` still fails as intended.

## Validation

- `VITE_SUPABASE_ANON_KEY=test-anon-key npm run build`