### PR TITLE
fix(chat): pass conversation history to agent for multi-turn memory

### DIFF
--- a/src/openjarvis/cli/chat_cmd.py
+++ b/src/openjarvis/cli/chat_cmd.py
@@ -12,7 +12,7 @@ from rich.markdown import Markdown
 from openjarvis.cli._tool_names import resolve_tool_names
 from openjarvis.core.config import load_config
 from openjarvis.core.events import EventBus
-from openjarvis.core.types import Message, Role
+from openjarvis.core.types import Conversation, Message, Role
 from openjarvis.memory import publish_completed_exchange
 
 
@@ -265,7 +265,15 @@ def chat(
         # Generate response
         try:
             if agent is not None:
-                response = agent.run(user_input)
+                # Pass prior conversation so the agent is multi-turn aware.
+                # history[:-1] excludes the user message just appended above;
+                # the agent re-adds it from `user_input` in _build_messages.
+                from openjarvis.agents._stubs import AgentContext
+
+                ctx = AgentContext(
+                    conversation=Conversation(messages=list(history[:-1]))
+                )
+                response = agent.run(user_input, context=ctx)
                 content = (
                     response.content if hasattr(response, "content") else str(response)
                 )


### PR DESCRIPTION
# Bug: `jarvis chat` is stateless across turns when an agent is active

## Summary
In `jarvis chat`, multi-turn memory is lost whenever an agent (e.g. the default `simple` agent) is active. Each turn is answered in isolation — the model never sees prior turns.

## Reproduction
```
$ jarvis chat            # default agent = simple
You> What is 17 times 3?
17 times 3 is 51.
You> Now add 9 to that.
I see you want me to add 9 to something. Could you please specify what you want me to add 9 to?
```
Expected: "60". The model has no access to the previous turn.

## Root cause
`src/openjarvis/cli/chat_cmd.py` maintains a `history: List[Message]` and appends each user/assistant turn, but the agent branch calls:
```python
response = agent.run(user_input)        # no context passed
```
`BaseAgent._build_messages(input, context)` only includes prior conversation when `context.conversation.messages` is populated. With no context, every call is single-turn. The no-agent branch (`engine.generate(history, ...)`) already passes full history, so the bug only manifests when an agent is configured — which is the default.

## Fix
Build an `AgentContext` from the prior history (excluding the just-appended user turn, which `_build_messages` re-adds from `input`) and pass it to `agent.run`:
```python
from openjarvis.agents._stubs import AgentContext
ctx = AgentContext(conversation=Conversation(messages=list(history[:-1])))
response = agent.run(user_input, context=ctx)
```

Verified: with the patch, the default `simple` agent chains correctly — 51 → 60 → 120 — and agent tools remain available.

## Environment
- OpenJarvis main (post v1.0.3.dev857)
- macOS, Apple M1, engine = mlx (`mlx_lm.server`), model `mlx-community/Qwen2.5-3B-Instruct-4bit`
- Behavior is engine-independent (logic bug in `chat_cmd.py`)
