### PR TITLE
fix(cloud): make OpenRouter reachable end-to-end from `jarvis ask`

### DIFF
--- a/src/openjarvis/agents/executor.py
+++ b/src/openjarvis/agents/executor.py
@@ -290,17 +290,52 @@ class AgentExecutor:
                 from openjarvis.core.registry import RouterPolicyRegistry
                 from openjarvis.learning.routing.router import (
                     build_routing_context,
+                    emit_route_trace,
+                    explain_route,
                 )
+
+                available_models = []
+                try:
+                    available_models = list(self._system.engine.list_models())
+                except Exception:
+                    available_models = [model]
+                if not available_models:
+                    available_models = [model]
 
                 policy = RouterPolicyRegistry.create(
                     router_policy_key,
-                    available_models=[model],
+                    available_models=available_models,
+                    default_model=self._system.model or model,
+                    fallback_model=(
+                        getattr(self._system.config.intelligence, "fallback_model", "")
+                        if getattr(self._system, "config", None) is not None
+                        else ""
+                    ),
                 )
                 instruction = config.get("instruction", "")
-                ctx = build_routing_context(instruction)
+                ctx = build_routing_context(instruction, model=model)
+                ctx.metadata["agent_type"] = agent_type
+                ctx.interactive = False
                 selected = policy.select_model(ctx)
                 if selected:
                     model = selected
+                route_decision = explain_route(
+                    ctx,
+                    available_models=available_models,
+                    default_model=self._system.model or model,
+                    fallback_model=(
+                        getattr(self._system.config.intelligence, "fallback_model", "")
+                        if getattr(self._system, "config", None) is not None
+                        else ""
+                    ),
+                )
+                emit_route_trace(
+                    self._bus,
+                    context=ctx,
+                    decision=route_decision,
+                    selected_model=model,
+                    selected_engine=type(engine).__name__,
+                )
             except Exception:
                 pass  # Fall back to configured model
 

--- a/src/openjarvis/cli/ask.py
+++ b/src/openjarvis/cli/ask.py
@@ -28,7 +28,11 @@ from openjarvis.intelligence import (
     merge_discovered_models,
     register_builtin_models,
 )
-from openjarvis.learning.routing.router import build_routing_context, explain_route
+from openjarvis.learning.routing.router import (
+    build_routing_context,
+    emit_route_trace,
+    explain_route,
+)
 from openjarvis.telemetry.instrumented_engine import InstrumentedEngine
 from openjarvis.telemetry.store import TelemetryStore
 
@@ -871,25 +875,12 @@ def ask(
                 model_name,
             )
 
-    bus.publish(
-        EventType.TRACE_STEP,
-        {
-            "step_type": StepType.ROUTE.value,
-            "input": {
-                "query": query_text,
-                "task_class": routing_context.task_class,
-            },
-            "output": {
-                "lane": route_decision.lane,
-                "model": model_name,
-                "candidate_models": route_decision.candidate_models,
-                "escalation_chain": route_decision.escalation_chain,
-                "selected_engine": engine_name,
-            },
-            "metadata": {
-                "reason": route_decision.reason,
-            },
-        },
+    emit_route_trace(
+        bus,
+        context=routing_context,
+        decision=route_decision,
+        selected_model=model_name,
+        selected_engine=engine_name,
     )
 
     # Apply security guardrails
@@ -949,6 +940,14 @@ def ask(
                 memory_files_config=effective_mf,
             )
         except EngineConnectionError as exc:
+            emit_route_trace(
+                bus,
+                context=routing_context,
+                decision=route_decision,
+                selected_model=model_name,
+                selected_engine=engine_name,
+                failure_reason=str(exc),
+            )
             console.print(f"[red]Engine error:[/red] {exc}")
             console.print(hint_no_engine())
             sys.exit(1)
@@ -1058,6 +1057,14 @@ def ask(
                 max_tokens=max_tokens,
             )
     except EngineConnectionError as exc:
+        emit_route_trace(
+            bus,
+            context=routing_context,
+            decision=route_decision,
+            selected_model=model_name,
+            selected_engine=engine_name,
+            failure_reason=str(exc),
+        )
         console.print(f"[red]Engine error:[/red] {exc}")
         console.print(hint_no_engine())
         sys.exit(1)

--- a/src/openjarvis/cli/ask.py
+++ b/src/openjarvis/cli/ask.py
@@ -805,26 +805,10 @@ def ask(
         )
         return
 
-    # Apply security guardrails
-    from openjarvis.security import setup_security
-
-    sec = setup_security(config, engine, bus)
-    engine = sec.engine
-
-    # Wrap engine with InstrumentedEngine for telemetry (energy + GPU metrics)
-    energy_monitor = None
-    want_energy = config.telemetry.gpu_metrics or enable_profile
-    if want_energy:
-        try:
-            from openjarvis.telemetry.energy_monitor import create_energy_monitor
-
-            energy_monitor = create_energy_monitor(
-                prefer_vendor=config.telemetry.energy_vendor or None,
-            )
-        except Exception as exc:
-            logger.debug("Failed to create energy monitor: %s", exc)
-    engine = InstrumentedEngine(engine, bus, energy_monitor=energy_monitor)
-
+    # ------------------------------------------------------------------
+    # Resolve the concrete model BEFORE wrapping/securing the engine, so a
+    # fallback model can re-select a different engine (see below).
+    # ------------------------------------------------------------------
     # Discover models and merge into registry
     all_engines = discover_engines(config)
     all_models = discover_models(all_engines)
@@ -851,6 +835,47 @@ def ask(
     if not model_name:
         console.print("[red]No model available on engine.[/red]")
         sys.exit(1)
+
+    # The engine above was selected against the *default* model (or the -m
+    # flag). If model resolution then fell back to a different model — e.g. the
+    # configured ``default_model`` disappeared and we fell back to
+    # ``openrouter/free`` — the originally-selected engine may not be able to
+    # serve it. Re-resolve so a cloud fallback model actually lands on the
+    # cloud engine instead of dying at call time with a local-engine 404. This
+    # is a no-op whenever the current engine can already serve the model.
+    # ``can_serve`` is part of the InferenceEngine ABC; guard with getattr so a
+    # minimal duck-typed engine (e.g. a test stub) is treated as "serves it".
+    can_serve = getattr(engine, "can_serve", None)
+    if callable(can_serve) and not can_serve(model_name):
+        reselected = get_engine(config, effective_engine_key, model=model_name)
+        if reselected is not None:
+            engine_name, engine = reselected
+            engine_models = all_models.get(engine_name, [])
+            logger.debug(
+                "Re-resolved engine to %r for fallback model %r",
+                engine_name,
+                model_name,
+            )
+
+    # Apply security guardrails
+    from openjarvis.security import setup_security
+
+    sec = setup_security(config, engine, bus)
+    engine = sec.engine
+
+    # Wrap engine with InstrumentedEngine for telemetry (energy + GPU metrics)
+    energy_monitor = None
+    want_energy = config.telemetry.gpu_metrics or enable_profile
+    if want_energy:
+        try:
+            from openjarvis.telemetry.energy_monitor import create_energy_monitor
+
+            energy_monitor = create_energy_monitor(
+                prefer_vendor=config.telemetry.energy_vendor or None,
+            )
+        except Exception as exc:
+            logger.debug("Failed to create energy monitor: %s", exc)
+    engine = InstrumentedEngine(engine, bus, energy_monitor=energy_monitor)
 
     # Apply complexity-suggested token budget when user didn't override.
     # Use at least the config default so we never reduce tokens below what

--- a/src/openjarvis/cli/ask.py
+++ b/src/openjarvis/cli/ask.py
@@ -830,13 +830,20 @@ def ask(
     all_models = discover_models(all_engines)
     for ek, model_ids in all_models.items():
         merge_discovered_models(ek, model_ids)
+    engine_models = all_models.get(engine_name, [])
 
     # Resolve model via config fallback chain
     if model_name is None:
         model_name = config.intelligence.default_model
+        if model_name and engine_models and model_name not in engine_models:
+            # If the configured default model is missing on the selected engine,
+            # prefer the configured fallback model before picking an arbitrary
+            # local model. This keeps the cloud fallback reachable when the
+            # local default disappears.
+            model_name = config.intelligence.fallback_model or model_name
     if not model_name:
-        # Try first available from engine
-        engine_models = all_models.get(engine_name, [])
+        # Try first available from the active engine only after explicit
+        # defaults and configured fallback have been exhausted.
         if engine_models:
             model_name = engine_models[0]
     if not model_name:

--- a/src/openjarvis/cli/ask.py
+++ b/src/openjarvis/cli/ask.py
@@ -17,7 +17,7 @@ from openjarvis.cli._tool_names import resolve_tool_names
 from openjarvis.cli.hints import hint_no_engine
 from openjarvis.core.config import load_config
 from openjarvis.core.events import EventBus, EventType
-from openjarvis.core.types import Message, Role
+from openjarvis.core.types import Message, Role, StepType
 from openjarvis.engine import (
     EngineConnectionError,
     discover_engines,
@@ -28,6 +28,7 @@ from openjarvis.intelligence import (
     merge_discovered_models,
     register_builtin_models,
 )
+from openjarvis.learning.routing.router import build_routing_context, explain_route
 from openjarvis.telemetry.instrumented_engine import InstrumentedEngine
 from openjarvis.telemetry.store import TelemetryStore
 
@@ -836,6 +837,19 @@ def ask(
         console.print("[red]No model available on engine.[/red]")
         sys.exit(1)
 
+    routing_context = build_routing_context(
+        query_text,
+        urgency=0.5,
+        model=model_name,
+    )
+    routing_context.vision_required = bool(image_b64)
+    route_decision = explain_route(
+        routing_context,
+        available_models=engine_models,
+        default_model=config.intelligence.default_model or "",
+        fallback_model=config.intelligence.fallback_model or "",
+    )
+
     # The engine above was selected against the *default* model (or the -m
     # flag). If model resolution then fell back to a different model — e.g. the
     # configured ``default_model`` disappeared and we fell back to
@@ -856,6 +870,27 @@ def ask(
                 engine_name,
                 model_name,
             )
+
+    bus.publish(
+        EventType.TRACE_STEP,
+        {
+            "step_type": StepType.ROUTE.value,
+            "input": {
+                "query": query_text,
+                "task_class": routing_context.task_class,
+            },
+            "output": {
+                "lane": route_decision.lane,
+                "model": model_name,
+                "candidate_models": route_decision.candidate_models,
+                "escalation_chain": route_decision.escalation_chain,
+                "selected_engine": engine_name,
+            },
+            "metadata": {
+                "reason": route_decision.reason,
+            },
+        },
+    )
 
     # Apply security guardrails
     from openjarvis.security import setup_security

--- a/src/openjarvis/core/types.py
+++ b/src/openjarvis/core/types.py
@@ -280,6 +280,16 @@ class RoutingContext:
     urgency: float = 0.5
     complexity_score: float = 0.0  # 0.0 (trivial) to 1.0 (very complex)
     suggested_max_tokens: int = 1024
+    task_class: str = ""
+    task_class_confidence: float = 0.0
+    lane: str = ""
+    risk_level: str = "low"
+    latency_sensitivity: str = "medium"
+    budget_sensitivity: str = "medium"
+    required_confidence: Optional[float] = None
+    vision_required: bool = False
+    interactive: bool = True
+    estimated_context_tokens: int = 0
     metadata: Dict[str, Any] = field(default_factory=dict)
 
 

--- a/src/openjarvis/engine/_stubs.py
+++ b/src/openjarvis/engine/_stubs.py
@@ -13,6 +13,22 @@ from typing import Any, Dict, List, Optional, Sequence
 
 from openjarvis.core.types import Message
 
+# Cloud-only model namespaces. A model id beginning with one of these prefixes
+# can only be served by the cloud engine (cf. ``cloud.py``'s
+# ``_is_openrouter_model`` / ``_is_codex_model``). Local engines must NOT claim
+# to serve them: otherwise engine selection can lock onto a local engine for a
+# cloud model and only discover the mismatch at call time, surfacing as a
+# confusing Ollama ``404 model not found`` (e.g. when ``default_model`` is
+# missing and the configured ``fallback_model`` is ``openrouter/free``). Kept
+# here in the low-level base module so every engine sees one source of truth
+# without importing ``cloud.py`` (which would be circular).
+_CLOUD_ONLY_PREFIXES = ("openrouter/", "codex/")
+
+
+def is_cloud_only_model(model: str) -> bool:
+    """Return ``True`` for unambiguously cloud-namespaced model ids."""
+    return model.startswith(_CLOUD_ONLY_PREFIXES)
+
 
 @dataclass(slots=True)
 class StreamChunk:
@@ -122,13 +138,19 @@ class InferenceEngine(ABC):
     def can_serve(self, model: str) -> bool:
         """Return ``True`` if this engine can serve *model*.
 
-        Defaults to ``True``: local engines accept any model id (whether a
-        specific model is *installed* is a separate concern from engine
-        selection). Engines that multiplex provider-specific clients (e.g.
-        the cloud engine) override this so selection can skip an engine whose
-        client for the model's provider isn't configured (see #532).
+        Defaults to ``True`` for ordinary ids: local engines accept any model
+        id (whether a specific model is *installed* is a separate concern from
+        engine selection). The one exception is unambiguously cloud-namespaced
+        ids (``openrouter/``, ``codex/``): a local backend can never serve
+        those, so it must decline here. Otherwise engine selection locks onto a
+        local engine for a cloud model and the mismatch only surfaces at call
+        time as a confusing ``404 model not found`` (see the
+        ``default_model`` missing + ``fallback_model = openrouter/free`` case).
+        Engines that multiplex provider-specific clients (e.g. the cloud
+        engine) override this entirely so selection can also skip an engine
+        whose client for the model's provider isn't configured (see #532).
         """
-        return True
+        return not is_cloud_only_model(model)
 
     def close(self) -> None:
         """Release resources (HTTP clients, connections, threads, etc.)."""
@@ -137,4 +159,9 @@ class InferenceEngine(ABC):
         """Optional warm-up hook called before the first request."""
 
 
-__all__ = ["InferenceEngine", "ResponseFormat", "StreamChunk"]
+__all__ = [
+    "InferenceEngine",
+    "ResponseFormat",
+    "StreamChunk",
+    "is_cloud_only_model",
+]

--- a/src/openjarvis/engine/cloud.py
+++ b/src/openjarvis/engine/cloud.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, List, Tuple
 
 import httpx
 
+from openjarvis.core.paths import get_config_dir
 from openjarvis.core.registry import EngineRegistry
 from openjarvis.core.types import Message
 from openjarvis.engine._base import (
@@ -114,6 +115,82 @@ _CODEX_MODELS = [
     "codex/gpt-5-mini",
     "codex/gpt-5-mini-2025-08-07",
 ]
+
+_CLOUD_ENV_FILE = get_config_dir() / "cloud-keys.env"
+
+
+_CLOUD_KEY_NAMES = (
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GEMINI_API_KEY",
+    "GOOGLE_API_KEY",
+    "OPENROUTER_API_KEY",
+    "MINIMAX_API_KEY",
+    "DEEPSEEK_API_KEY",
+    "OPENAI_CODEX_API_KEY",
+)
+
+
+def _load_vault_keys() -> dict[str, str]:
+    """Return cloud credentials stored in the encrypted ``vault.enc``.
+
+    ``jarvis vault set`` is the supported way to persist secrets on a machine
+    without exporting them into every shell or writing a plaintext
+    ``cloud-keys.env``. The CLI ``jarvis ask`` path builds ``CloudEngine``
+    directly, so it must consult the same vault to make cloud providers (e.g.
+    OpenRouter) reachable end-to-end. Returns an empty mapping if the vault is
+    absent or cannot be decrypted.
+    """
+    config_dir = get_config_dir()
+    vault_file = config_dir / "vault.enc"
+    vault_key_file = config_dir / ".vault_key"
+    if not vault_file.exists() or not vault_key_file.exists():
+        return {}
+    try:
+        from cryptography.fernet import Fernet
+
+        key = vault_key_file.read_bytes().strip()
+        decrypted = Fernet(key).decrypt(vault_file.read_bytes())
+        data = json.loads(decrypted.decode())
+    except Exception:
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    return {
+        name: str(value)
+        for name in _CLOUD_KEY_NAMES
+        if (value := data.get(name))
+    }
+
+
+def _load_cloud_keys() -> dict[str, str]:
+    """Return cloud API keys from the vault, disk, and the process environment.
+
+    Resolution order (later sources override earlier ones):
+
+    1. Encrypted ``vault.enc`` written by ``jarvis vault set``.
+    2. ``cloud-keys.env`` written by the OpenJarvis desktop app.
+    3. Process environment variables.
+
+    The CLI ``jarvis ask`` path uses ``CloudEngine`` directly, so it needs the
+    same fallback sources the server relies on to make OpenRouter available
+    end-to-end.
+    """
+    keys: dict[str, str] = _load_vault_keys()
+    if _CLOUD_ENV_FILE.exists():
+        try:
+            for raw_line in _CLOUD_ENV_FILE.read_text().splitlines():
+                line = raw_line.strip()
+                if line and not line.startswith("#") and "=" in line:
+                    name, value = line.split("=", 1)
+                    keys[name.strip()] = value.strip()
+        except OSError:
+            pass
+    for name in _CLOUD_KEY_NAMES:
+        value = os.environ.get(name)
+        if value:
+            keys[name] = value
+    return keys
 
 
 def _is_minimax_model(model: str) -> bool:
@@ -326,26 +403,31 @@ class CloudEngine(InferenceEngine):
         self._codex_client: Any = None
         # Gemini thought_signatures: tool_call_id -> signature bytes
         self._thought_sigs: Dict[str, bytes] = {}
+        # Resolved slug for the ``openrouter/free`` convenience alias. Cached so
+        # we hit the models endpoint at most once per engine instance.
+        self._openrouter_free_slug: str | None = None
         self._init_clients()
 
     def _init_clients(self) -> None:
-        if os.environ.get("OPENAI_API_KEY"):
+        keys = _load_cloud_keys()
+
+        if keys.get("OPENAI_API_KEY"):
             try:
                 import openai
 
-                self._openai_client = openai.OpenAI()
+                self._openai_client = openai.OpenAI(api_key=keys["OPENAI_API_KEY"])
             except ImportError:
                 pass
-        if os.environ.get("ANTHROPIC_API_KEY"):
+        if keys.get("ANTHROPIC_API_KEY"):
             try:
                 import anthropic
 
-                self._anthropic_client = anthropic.Anthropic()
+                self._anthropic_client = anthropic.Anthropic(
+                    api_key=keys["ANTHROPIC_API_KEY"]
+                )
             except ImportError:
                 pass
-        gemini_key = os.environ.get("GEMINI_API_KEY") or os.environ.get(
-            "GOOGLE_API_KEY"
-        )
+        gemini_key = keys.get("GEMINI_API_KEY") or keys.get("GOOGLE_API_KEY")
         if gemini_key:
             try:
                 from google import genai
@@ -353,7 +435,7 @@ class CloudEngine(InferenceEngine):
                 self._google_client = genai.Client(api_key=gemini_key)
             except ImportError:
                 pass
-        openrouter_key = os.environ.get("OPENROUTER_API_KEY")
+        openrouter_key = keys.get("OPENROUTER_API_KEY")
         if openrouter_key:
             try:
                 import openai
@@ -364,7 +446,7 @@ class CloudEngine(InferenceEngine):
                 )
             except ImportError:
                 pass
-        minimax_key = os.environ.get("MINIMAX_API_KEY")
+        minimax_key = keys.get("MINIMAX_API_KEY")
         if minimax_key:
             try:
                 import openai
@@ -375,7 +457,7 @@ class CloudEngine(InferenceEngine):
                 )
             except ImportError:
                 pass
-        deepseek_key = os.environ.get("DEEPSEEK_API_KEY")
+        deepseek_key = keys.get("DEEPSEEK_API_KEY")
         if deepseek_key:
             try:
                 import openai
@@ -389,7 +471,7 @@ class CloudEngine(InferenceEngine):
         # Codex — uses the OpenAI Responses API.
         # Supports both standard API keys (api.openai.com) and ChatGPT
         # OAuth tokens (chatgpt.com) via OPENAI_CODEX_BASE_URL override.
-        codex_token = os.environ.get("OPENAI_CODEX_API_KEY")
+        codex_token = keys.get("OPENAI_CODEX_API_KEY")
         if codex_token:
             codex_url = os.environ.get(
                 "OPENAI_CODEX_BASE_URL",
@@ -925,6 +1007,77 @@ class CloudEngine(InferenceEngine):
 
         return result
 
+    # Curated preference order for the ``openrouter/free`` alias. The first slug
+    # whose ``:free`` variant is currently listed by OpenRouter is used. For a
+    # fallback lane, availability matters more than raw capability: the large,
+    # popular free models are heavily rate-limited (HTTP 429), so smaller, less
+    # contended instruct models are preferred first. The list is a preference
+    # hint, not a hard requirement.
+    _OPENROUTER_FREE_PREFERENCES = (
+        "liquid/lfm-2.5-1.2b-instruct",
+        "google/gemma-4-31b-it",
+        "qwen/qwen3-next-80b-a3b-instruct",
+        "meta-llama/llama-3.3-70b-instruct",
+        "deepseek/deepseek-chat-v3-0324",
+    )
+
+    def _resolve_openrouter_free(self) -> str:
+        """Resolve ``openrouter/free`` to a concrete, currently-available
+        ``:free`` model slug.
+
+        The bare ``free`` token is not a routable OpenRouter model (it produced
+        an "Invalid URL" 502). To keep the configured fallback strictly
+        zero-cost, we never fall back to a paid model: we query the live models
+        list and pick a ``:free`` slug, preferring the curated list above. The
+        result is cached on the instance.
+        """
+        if self._openrouter_free_slug is not None:
+            return self._openrouter_free_slug
+
+        free_slugs: list[str] = []
+        try:
+            models = self._openrouter_client.models.list()
+            free_slugs = [
+                m.id for m in getattr(models, "data", []) if str(m.id).endswith(":free")
+            ]
+        except Exception:
+            free_slugs = []
+
+        chosen: str | None = None
+        for pref in self._OPENROUTER_FREE_PREFERENCES:
+            candidate = f"{pref}:free"
+            if candidate in free_slugs:
+                chosen = candidate
+                break
+        if chosen is None and free_slugs:
+            chosen = free_slugs[0]
+        if chosen is None:
+            # Last resort: a small free model that is almost always listed. If it
+            # is unavailable the API surfaces a clear error rather than a paid
+            # charge.
+            chosen = "meta-llama/llama-3.3-70b-instruct:free"
+
+        self._openrouter_free_slug = chosen
+        return chosen
+
+    def _openrouter_model_id(self, model: str) -> str:
+        """Return the OpenRouter API slug for a configured model name.
+
+        Strips the ``openrouter/`` prefix and resolves the ``openrouter/free``
+        convenience alias to a concrete zero-cost model so the configured cloud
+        fallback works end-to-end.
+        """
+        actual = model.removeprefix("openrouter/")
+        if actual == "free":
+            # ``openrouter/free`` is a convenience alias, not a routable slug;
+            # resolve it to a currently-available zero-cost model.
+            return self._resolve_openrouter_free()
+        if actual == "auto":
+            # The OpenRouter auto-router's real slug is ``openrouter/auto``; the
+            # prefix strip above would otherwise leave the non-routable ``auto``.
+            return "openrouter/auto"
+        return actual
+
     def _generate_openrouter(
         self,
         messages: Sequence[Message],
@@ -938,8 +1091,8 @@ class CloudEngine(InferenceEngine):
             raise EngineConnectionError(
                 "OpenRouter client not available — set OPENROUTER_API_KEY"
             )
-        # Strip the "openrouter/" prefix to get the actual model ID
-        actual_model = model.removeprefix("openrouter/")
+        # Strip the "openrouter/" prefix and resolve convenience aliases.
+        actual_model = self._openrouter_model_id(model)
         kwargs.pop("response_format", None)
         create_kwargs: Dict[str, Any] = {
             "model": actual_model,
@@ -1316,7 +1469,7 @@ class CloudEngine(InferenceEngine):
     ) -> AsyncIterator[str]:
         if self._openrouter_client is None:
             raise EngineConnectionError("OpenRouter client not available")
-        actual_model = model.removeprefix("openrouter/")
+        actual_model = self._openrouter_model_id(model)
         create_kwargs: Dict[str, Any] = {
             "model": actual_model,
             "messages": messages_to_dicts(messages),
@@ -1417,7 +1570,7 @@ class CloudEngine(InferenceEngine):
             client = self._openrouter_client
             if client is None:
                 raise EngineConnectionError("OpenRouter client not available")
-            actual_model = model.removeprefix("openrouter/")
+            actual_model = self._openrouter_model_id(model)
             create_kwargs: Dict[str, Any] = {
                 "model": actual_model,
                 "messages": messages_to_dicts(messages),

--- a/src/openjarvis/intelligence/model_catalog.py
+++ b/src/openjarvis/intelligence/model_catalog.py
@@ -2,15 +2,177 @@
 
 from __future__ import annotations
 
-from typing import List
+from typing import Dict, List
 
 from openjarvis.core.registry import ModelRegistry
 from openjarvis.core.types import ModelSpec, Quantization
+
+
+def _routing_metadata(
+    lane: str,
+    *,
+    local: bool | None = None,
+    stable_json: bool | None = None,
+    capabilities: list[str] | None = None,
+    latency_band: str | None = None,
+    cost_band: str | None = None,
+) -> Dict[str, object]:
+    metadata: Dict[str, object] = {"routing_lane": lane}
+    if local is not None:
+        metadata["local"] = local
+    if stable_json is not None:
+        metadata["stable_json"] = stable_json
+    if capabilities:
+        metadata["capabilities"] = capabilities
+    if latency_band:
+        metadata["latency_band"] = latency_band
+    if cost_band:
+        metadata["cost_band"] = cost_band
+    return metadata
+
+
+def infer_routing_metadata(model_id: str) -> Dict[str, object]:
+    lower = model_id.lower()
+    if lower in {"qwen2.5:1.5b", "llama3.2:1b"}:
+        return _routing_metadata(
+            "router_control",
+            local=True,
+            stable_json=True,
+            capabilities=["classification", "routing", "structured_output"],
+            latency_band="low",
+            cost_band="local",
+        )
+    if lower == "openrouter/free" or ":free" in lower:
+        return _routing_metadata(
+            "free_fallback",
+            local=False,
+            capabilities=["general"],
+            latency_band="medium",
+            cost_band="free",
+        )
+    if any(tag in lower for tag in ("coder", "deepseek-coder", "code")):
+        return _routing_metadata(
+            "code_specialist",
+            local=not lower.startswith(("openrouter/", "codex/")),
+            capabilities=["code", "patching", "tests"],
+        )
+    if any(tag in lower for tag in ("vision", "vl", "maverick")):
+        return _routing_metadata(
+            "multimodal_vision",
+            local=not lower.startswith("openrouter/"),
+            capabilities=["vision", "ocr", "pdf"],
+        )
+    if any(tag in lower for tag in ("scout", "long", "200k", "1m")):
+        return _routing_metadata(
+            "long_context_research",
+            local=not lower.startswith("openrouter/"),
+            capabilities=["long_context", "research", "synthesis"],
+        )
+    if any(tag in lower for tag in ("opus", "fable", "gpt-5.5")):
+        return _routing_metadata(
+            "frontier_premium",
+            local=False,
+            capabilities=["hard_reasoning", "recovery"],
+        )
+    if any(
+        tag in lower
+        for tag in ("reasoning", "32b", "70b", "deepseek-v3", "mistral-small")
+    ):
+        return _routing_metadata(
+            "premium_workhorse",
+            local=not lower.startswith("openrouter/"),
+            capabilities=["reasoning", "architecture", "debugging"],
+        )
+    if lower.startswith("openrouter/"):
+        return _routing_metadata(
+            "cheap_paid_workhorse",
+            local=False,
+            capabilities=["general"],
+        )
+    return {}
 
 BUILTIN_MODELS: List[ModelSpec] = [
     # -----------------------------------------------------------------------
     # Local models — Dense
     # -----------------------------------------------------------------------
+    ModelSpec(
+        model_id="qwen2.5:1.5b",
+        name="Qwen2.5 1.5B",
+        parameter_count_b=1.5,
+        context_length=131072,
+        supported_engines=("ollama", "vllm", "llamacpp", "mlx", "sglang"),
+        provider="alibaba",
+        metadata={
+            "architecture": "dense",
+            "hf_repo": "Qwen/Qwen2.5-1.5B-Instruct",
+            **infer_routing_metadata("qwen2.5:1.5b"),
+        },
+    ),
+    ModelSpec(
+        model_id="llama3.2:1b",
+        name="Llama 3.2 1B",
+        parameter_count_b=1.0,
+        context_length=131072,
+        supported_engines=("ollama", "vllm", "llamacpp"),
+        provider="meta",
+        metadata={
+            "architecture": "dense",
+            "hf_repo": "meta-llama/Llama-3.2-1B-Instruct",
+            **infer_routing_metadata("llama3.2:1b"),
+        },
+    ),
+    ModelSpec(
+        model_id="qwen2.5-coder:7b",
+        name="Qwen2.5 Coder 7B",
+        parameter_count_b=7.0,
+        context_length=131072,
+        supported_engines=("ollama", "vllm", "llamacpp", "sglang"),
+        provider="alibaba",
+        metadata={
+            "architecture": "dense",
+            "hf_repo": "Qwen/Qwen2.5-Coder-7B-Instruct",
+            **infer_routing_metadata("qwen2.5-coder:7b"),
+        },
+    ),
+    ModelSpec(
+        model_id="openrouter/free",
+        name="OpenRouter Free",
+        parameter_count_b=0.0,
+        context_length=131072,
+        supported_engines=("cloud",),
+        provider="openrouter",
+        requires_api_key=True,
+        metadata={
+            "architecture": "proprietary-router",
+            **infer_routing_metadata("openrouter/free"),
+        },
+    ),
+    ModelSpec(
+        model_id="openrouter/deepseek/deepseek-v3.2",
+        name="DeepSeek V3.2 (OpenRouter)",
+        parameter_count_b=0.0,
+        context_length=131072,
+        supported_engines=("cloud",),
+        provider="openrouter",
+        requires_api_key=True,
+        metadata={
+            "architecture": "proprietary-router",
+            **infer_routing_metadata("openrouter/deepseek/deepseek-v3.2"),
+        },
+    ),
+    ModelSpec(
+        model_id="openrouter/qwen/qwen3-vl-32b-instruct",
+        name="Qwen3 VL 32B (OpenRouter)",
+        parameter_count_b=0.0,
+        context_length=131072,
+        supported_engines=("cloud",),
+        provider="openrouter",
+        requires_api_key=True,
+        metadata={
+            "architecture": "proprietary-router",
+            **infer_routing_metadata("openrouter/qwen/qwen3-vl-32b-instruct"),
+        },
+    ),
     ModelSpec(
         model_id="qwen3:0.6b",
         name="Qwen3 0.6B",
@@ -1011,12 +1173,14 @@ def merge_discovered_models(engine_key: str, model_ids: List[str]) -> None:
     """Create minimal ``ModelSpec`` entries for models not already in the registry."""
     for model_id in model_ids:
         if not ModelRegistry.contains(model_id):
+            metadata = infer_routing_metadata(model_id)
             spec = ModelSpec(
                 model_id=model_id,
                 name=model_id,
                 parameter_count_b=0.0,
                 context_length=0,
                 supported_engines=(engine_key,),
+                metadata=metadata,
             )
             ModelRegistry.register_value(model_id, spec)
 

--- a/src/openjarvis/learning/routing/learned_router.py
+++ b/src/openjarvis/learning/routing/learned_router.py
@@ -1,4 +1,4 @@
-"""Learned router policy — trace-driven query_class -> model mapping.
+"""Learned router policy — trace-driven query_class/task_class -> lane/model mapping.
 
 Merges the runtime ``select_model()`` logic from ``TraceDrivenPolicy``
 with the batch ``update()`` logic from ``SFTRouterPolicy`` into a single
@@ -14,6 +14,7 @@ from openjarvis.core.registry import RouterPolicyRegistry
 from openjarvis.core.types import RoutingContext
 from openjarvis.learning._stubs import RouterPolicy
 from openjarvis.learning.routing._utils import classify_query
+from openjarvis.learning.routing.router import lane_for_model
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +41,8 @@ class LearnedRouterPolicy(RouterPolicy):
         self._fallback = fallback_model
         self._policy_map: Dict[str, str] = {}
         self._confidence: Dict[str, int] = {}
+        self._lane_policy_map: Dict[str, str] = {}
+        self._lane_confidence: Dict[str, int] = {}
         self.min_samples: int = 5
 
     @property
@@ -49,6 +52,17 @@ class LearnedRouterPolicy(RouterPolicy):
 
     def select_model(self, context: RoutingContext) -> str:
         """Select the best model based on learned policy or fallback."""
+        task_key = self._context_key(context)
+
+        if (
+            task_key in self._lane_policy_map
+            and self._lane_confidence.get(task_key, 0) >= self.min_samples
+        ):
+            lane = self._lane_policy_map[task_key]
+            lane_model = self._select_available_model_for_lane(lane)
+            if lane_model:
+                return lane_model
+
         query_class = classify_query(context.query)
 
         if (
@@ -68,6 +82,11 @@ class LearnedRouterPolicy(RouterPolicy):
             return self._available[0]
         return self._default or ""
 
+    @property
+    def lane_policy_map(self) -> Dict[str, str]:
+        """Current learned lane preferences (read-only copy)."""
+        return dict(self._lane_policy_map)
+
     def update_from_traces(
         self,
         *,
@@ -86,27 +105,30 @@ class LearnedRouterPolicy(RouterPolicy):
 
         groups: Dict[str, list] = {}
         for t in traces:
-            qclass = classify_query(t.query)
-            groups.setdefault(qclass, []).append(t)
+            key = self._trace_key(t)
+            groups.setdefault(key, []).append(t)
 
         old_map = dict(self._policy_map)
+        old_lane_map = dict(self._lane_policy_map)
         changes: Dict[str, Dict[str, str]] = {}
+        lane_changes: Dict[str, Dict[str, str]] = {}
 
-        for qclass, class_traces in groups.items():
+        for route_key, class_traces in groups.items():
             model_scores: Dict[str, _ModelScore] = {}
+            lane_scores: Dict[str, _ModelScore] = {}
             for t in class_traces:
                 if not t.model:
                     continue
                 if t.model not in model_scores:
                     model_scores[t.model] = _ModelScore()
                 score = model_scores[t.model]
-                score.count += 1
-                score.total_latency += t.total_latency_seconds
-                if t.outcome == "success":
-                    score.successes += 1
-                if t.feedback is not None:
-                    score.feedback_sum += t.feedback
-                    score.feedback_count += 1
+                self._apply_trace_score(score, t)
+
+                lane = self._trace_lane(t) or lane_for_model(t.model)
+                if lane:
+                    if lane not in lane_scores:
+                        lane_scores[lane] = _ModelScore()
+                    self._apply_trace_score(lane_scores[lane], t)
 
             if not model_scores:
                 continue
@@ -116,20 +138,36 @@ class LearnedRouterPolicy(RouterPolicy):
                 key=lambda kv: kv[1].composite_score(),
             )[0]
 
-            self._policy_map[qclass] = best_model
-            self._confidence[qclass] = sum(s.count for s in model_scores.values())
+            self._policy_map[route_key] = best_model
+            self._confidence[route_key] = sum(s.count for s in model_scores.values())
 
-            if old_map.get(qclass) != best_model:
-                changes[qclass] = {
-                    "old": old_map.get(qclass, ""),
+            if old_map.get(route_key) != best_model:
+                changes[route_key] = {
+                    "old": old_map.get(route_key, ""),
                     "new": best_model,
                 }
+
+            if lane_scores:
+                best_lane = max(
+                    lane_scores.items(),
+                    key=lambda kv: kv[1].composite_score(),
+                )[0]
+                self._lane_policy_map[route_key] = best_lane
+                self._lane_confidence[route_key] = sum(
+                    s.count for s in lane_scores.values()
+                )
+                if old_lane_map.get(route_key) != best_lane:
+                    lane_changes[route_key] = {
+                        "old": old_lane_map.get(route_key, ""),
+                        "new": best_lane,
+                    }
 
         return {
             "updated": True,
             "query_classes": len(groups),
             "total_traces": len(traces),
             "changes": changes,
+            "lane_changes": lane_changes,
         }
 
     def observe(
@@ -166,18 +204,25 @@ class LearnedRouterPolicy(RouterPolicy):
             return {"updated": False, "reason": "Could not access trace store"}
 
         class_model_scores: Dict[str, Dict[str, List[float]]] = {}
+        class_lane_scores: Dict[str, Dict[str, List[float]]] = {}
         for trace in traces:
-            query_class = classify_query(trace.query)
+            query_class = self._trace_key(trace)
             model = trace.model or "unknown"
-            outcome_score = 1.0 if trace.outcome == "success" else 0.0
-            fb = trace.feedback if trace.feedback is not None else 0.5
-            composite = 0.6 * outcome_score + 0.4 * fb
+            composite = self._trace_composite_score(trace)
 
             if query_class not in class_model_scores:
                 class_model_scores[query_class] = {}
             if model not in class_model_scores[query_class]:
                 class_model_scores[query_class][model] = []
             class_model_scores[query_class][model].append(composite)
+
+            lane = self._trace_lane(trace) or lane_for_model(model)
+            if lane:
+                if query_class not in class_lane_scores:
+                    class_lane_scores[query_class] = {}
+                if lane not in class_lane_scores[query_class]:
+                    class_lane_scores[query_class][lane] = []
+                class_lane_scores[query_class][lane].append(composite)
 
         changes = {}
         for qclass, model_scores in class_model_scores.items():
@@ -193,11 +238,83 @@ class LearnedRouterPolicy(RouterPolicy):
                 self._policy_map[qclass] = best_model
                 changes[qclass] = best_model
 
+        lane_changes = {}
+        for qclass, lane_scores in class_lane_scores.items():
+            best_lane = None
+            best_score = -1.0
+            for lane, scores in lane_scores.items():
+                if len(scores) >= self.min_samples:
+                    avg = sum(scores) / len(scores)
+                    if avg > best_score:
+                        best_score = avg
+                        best_lane = lane
+            if best_lane and best_lane != self._lane_policy_map.get(qclass):
+                self._lane_policy_map[qclass] = best_lane
+                lane_changes[qclass] = best_lane
+
         return {
             "updated": bool(changes),
             "changes": changes,
+            "lane_policy_map": dict(self._lane_policy_map),
+            "lane_changes": lane_changes,
             "policy_map": dict(self._policy_map),
         }
+
+    def _context_key(self, context: RoutingContext) -> str:
+        return context.task_class or classify_query(context.query)
+
+    def _trace_key(self, trace: Any) -> str:
+        routing = self._trace_routing(trace)
+        return str(routing.get("task_class") or classify_query(trace.query))
+
+    def _trace_lane(self, trace: Any) -> str:
+        routing = self._trace_routing(trace)
+        return str(routing.get("lane") or "")
+
+    def _trace_routing(self, trace: Any) -> Dict[str, Any]:
+        metadata = getattr(trace, "metadata", {}) or {}
+        routing = metadata.get("routing")
+        if isinstance(routing, dict):
+            return routing
+        for step in getattr(trace, "steps", []) or []:
+            step_type = getattr(step, "step_type", None)
+            if getattr(step_type, "value", step_type) == "route":
+                return {
+                    **(getattr(step, "input", {}) or {}),
+                    **(getattr(step, "output", {}) or {}),
+                    **(getattr(step, "metadata", {}) or {}),
+                }
+        return {}
+
+    def _trace_composite_score(self, trace: Any) -> float:
+        outcome_score = 1.0 if trace.outcome == "success" else 0.0
+        fb = trace.feedback if trace.feedback is not None else 0.5
+        routing = self._trace_routing(trace)
+        escalation_penalty = 0.0
+        escalation_chain = routing.get("escalation_chain") or []
+        if isinstance(escalation_chain, list) and len(escalation_chain) > 1:
+            escalation_penalty = min(0.15, 0.03 * (len(escalation_chain) - 1))
+        return max(0.0, 0.6 * outcome_score + 0.4 * fb - escalation_penalty)
+
+    def _apply_trace_score(self, score: "_ModelScore", trace: Any) -> None:
+        score.count += 1
+        score.total_latency += trace.total_latency_seconds
+        if trace.outcome == "success":
+            score.successes += 1
+        if trace.feedback is not None:
+            score.feedback_sum += trace.feedback
+            score.feedback_count += 1
+        routing = self._trace_routing(trace)
+        escalation_chain = routing.get("escalation_chain") or []
+        if isinstance(escalation_chain, list) and len(escalation_chain) > 1:
+            score.penalty += min(0.15, 0.03 * (len(escalation_chain) - 1))
+
+    def _select_available_model_for_lane(self, lane: str) -> str:
+        candidates = self._available or [m for m in [self._default, self._fallback] if m]
+        for model in candidates:
+            if lane_for_model(model) == lane:
+                return model
+        return ""
 
 
 class _ModelScore:
@@ -209,6 +326,7 @@ class _ModelScore:
         "total_latency",
         "feedback_sum",
         "feedback_count",
+        "penalty",
     )
 
     def __init__(self) -> None:
@@ -217,12 +335,14 @@ class _ModelScore:
         self.total_latency = 0.0
         self.feedback_sum = 0.0
         self.feedback_count = 0
+        self.penalty = 0.0
 
     def composite_score(self) -> float:
         """Weighted score combining success rate and feedback."""
         sr = self.successes / self.count if self.count else 0.0
         fb = self.feedback_sum / self.feedback_count if self.feedback_count else 0.5
-        return 0.6 * sr + 0.4 * fb
+        avg_penalty = self.penalty / self.count if self.count else 0.0
+        return max(0.0, 0.6 * sr + 0.4 * fb - avg_penalty)
 
 
 def ensure_registered() -> None:

--- a/src/openjarvis/learning/routing/router.py
+++ b/src/openjarvis/learning/routing/router.py
@@ -230,6 +230,11 @@ def _spec_lane(model_id: str) -> str:
     return LANE_CHEAP_PAID_WORKHORSE
 
 
+def lane_for_model(model_id: str) -> str:
+    """Public helper that maps a model id to its routing lane."""
+    return _spec_lane(model_id)
+
+
 def _filter_by_lane(available: Iterable[str], lane: str) -> List[str]:
     return [model for model in available if _spec_lane(model) == lane]
 
@@ -414,4 +419,5 @@ __all__ = [
     "build_routing_context",
     "escalation_chain_for_lane",
     "explain_route",
+    "lane_for_model",
 ]

--- a/src/openjarvis/learning/routing/router.py
+++ b/src/openjarvis/learning/routing/router.py
@@ -1,15 +1,25 @@
-"""Heuristic model router — selects the best model based on query characteristics."""
+"""Heuristic model router — selects models via task class and capability lanes."""
 
 from __future__ import annotations
 
 import logging
-from typing import List, Optional
+from typing import Iterable, List, Optional
 
 from openjarvis.core.registry import ModelRegistry
 from openjarvis.core.types import RoutingContext
 from openjarvis.learning._stubs import QueryAnalyzer, RouterPolicy
+from openjarvis.learning.routing.task_classifier import classify_task
 
 logger = logging.getLogger(__name__)
+
+LANE_ROUTER_CONTROL = "router_control"
+LANE_FREE_FALLBACK = "free_fallback"
+LANE_CHEAP_PAID_WORKHORSE = "cheap_paid_workhorse"
+LANE_PREMIUM_WORKHORSE = "premium_workhorse"
+LANE_FRONTIER_PREMIUM = "frontier_premium"
+LANE_CODE_SPECIALIST = "code_specialist"
+LANE_LONG_CONTEXT_RESEARCH = "long_context_research"
+LANE_MULTIMODAL_VISION = "multimodal_vision"
 
 
 def build_routing_context(
@@ -27,6 +37,11 @@ def build_routing_context(
 
     result = score_complexity(query)
     tokens = adjust_tokens_for_model(result.suggested_max_tokens, model)
+    task = classify_task(query)
+    vision_required = bool(result.signals.get("has_vision", False)) or any(
+        token in query.lower() for token in ("image", "screenshot", "diagram", "pdf")
+    )
+    estimated_context_tokens = max(256, len(query) // 4)
 
     return RoutingContext(
         query=query,
@@ -37,12 +52,18 @@ def build_routing_context(
         urgency=urgency,
         complexity_score=result.score,
         suggested_max_tokens=tokens,
-        metadata={"complexity_tier": result.tier, "signals": result.signals},
+        task_class=task.task_class,
+        task_class_confidence=task.confidence,
+        vision_required=vision_required,
+        estimated_context_tokens=estimated_context_tokens,
+        metadata={
+            "complexity_tier": result.tier,
+            "signals": result.signals,
+        },
     )
 
 
 def _model_size(key: str) -> float:
-    """Return parameter count for a registered model, or 0 if not found."""
     try:
         spec = ModelRegistry.get(key)
         return spec.parameter_count_b
@@ -51,8 +72,14 @@ def _model_size(key: str) -> float:
         return 0.0
 
 
+def _model_spec(key: str):
+    try:
+        return ModelRegistry.get(key)
+    except Exception:
+        return None
+
+
 def _find_model_by_tag(available: List[str], tag: str) -> Optional[str]:
-    """Find the first available model whose key contains *tag* (case-insensitive)."""
     tag_lower = tag.lower()
     for key in available:
         if tag_lower in key.lower():
@@ -61,7 +88,6 @@ def _find_model_by_tag(available: List[str], tag: str) -> Optional[str]:
 
 
 def _largest_model(available: List[str]) -> Optional[str]:
-    """Return the model with the largest parameter count from the available list."""
     if not available:
         return None
     best = available[0]
@@ -75,7 +101,6 @@ def _largest_model(available: List[str]) -> Optional[str]:
 
 
 def _smallest_model(available: List[str]) -> Optional[str]:
-    """Return the smallest-parameter model from *available*."""
     if not available:
         return None
     best = available[0]
@@ -88,16 +113,105 @@ def _smallest_model(available: List[str]) -> Optional[str]:
     return best
 
 
-class HeuristicRouter(RouterPolicy):
-    """Rule-based model router.
+def _lane_for_context(context: RoutingContext) -> str:
+    task_class = context.task_class or classify_task(context.query).task_class
+    if context.vision_required:
+        return LANE_MULTIMODAL_VISION
+    if task_class in {"classify", "extract"}:
+        return LANE_ROUTER_CONTROL
+    if task_class in {
+        "code-simple",
+        "code-medium",
+        "debug-simple",
+        "test-generation",
+        "refactor",
+    }:
+        return LANE_CODE_SPECIALIST
+    if task_class in {"code-complex", "debug-complex", "architecture-review"}:
+        return LANE_PREMIUM_WORKHORSE
+    if task_class in {
+        "source-finding",
+        "source-reading",
+        "synthesis",
+        "citation-building",
+        "trend-detection",
+        "competitor-mapping",
+    }:
+        if context.estimated_context_tokens >= 4000 or context.complexity_score >= 0.6:
+            return LANE_LONG_CONTEXT_RESEARCH
+        return LANE_CHEAP_PAID_WORKHORSE
+    if context.budget_sensitivity == "high" and context.risk_level == "low":
+        return LANE_FREE_FALLBACK
+    if context.complexity_score >= 0.85 and context.risk_level in {"high", "critical"}:
+        return LANE_FRONTIER_PREMIUM
+    if context.complexity_score >= 0.55 or context.has_reasoning:
+        return LANE_PREMIUM_WORKHORSE
+    return LANE_CHEAP_PAID_WORKHORSE
 
-    Rules (applied in order):
-    1. Code detected → prefer model with "code"/"coder" in name
-    2. Math detected → prefer larger model
-    3. Low complexity (score < 0.20) → prefer smaller/faster model
-    4. High complexity (score >= 0.55 OR reasoning keywords) → prefer larger model
-    5. High urgency (>0.8) → override to smaller model
-    6. Default fallback → default_model → fallback_model → first available
+
+def _spec_lane(model_id: str) -> str:
+    spec = _model_spec(model_id)
+    if spec is not None:
+        lane = spec.metadata.get("routing_lane")
+        if isinstance(lane, str) and lane:
+            return lane
+    lower = model_id.lower()
+    if (
+        lower.startswith("openrouter/free")
+        or lower == "openrouter/free"
+        or ":free" in lower
+    ):
+        return LANE_FREE_FALLBACK
+    if lower.startswith("openrouter/"):
+        if any(tag in lower for tag in ("vl", "vision", "maverick")):
+            return LANE_MULTIMODAL_VISION
+        if any(tag in lower for tag in ("coder", "code")):
+            return LANE_CODE_SPECIALIST
+        if any(tag in lower for tag in ("opus", "fable", "gpt-5.5")):
+            return LANE_FRONTIER_PREMIUM
+        if any(tag in lower for tag in ("scout", "long", "80b-a3b-thinking")):
+            return LANE_LONG_CONTEXT_RESEARCH
+        return LANE_CHEAP_PAID_WORKHORSE
+    if any(tag in lower for tag in ("coder", "code")):
+        return LANE_CODE_SPECIALIST
+    if lower in {"qwen2.5:1.5b", "llama3.2:1b"}:
+        return LANE_ROUTER_CONTROL
+    if any(tag in lower for tag in ("vision", "vl")):
+        return LANE_MULTIMODAL_VISION
+    if any(tag in lower for tag in ("phi4-mini-reasoning", "reasoning", "32b", "70b")):
+        return LANE_PREMIUM_WORKHORSE
+    return LANE_CHEAP_PAID_WORKHORSE
+
+
+def _filter_by_lane(available: Iterable[str], lane: str) -> List[str]:
+    return [model for model in available if _spec_lane(model) == lane]
+
+
+def _prefer_local(models: List[str]) -> List[str]:
+    def rank(model: str) -> tuple[int, float, str]:
+        spec = _model_spec(model)
+        engines = tuple(spec.supported_engines) if spec is not None else ()
+        local = (
+            0
+            if any(
+                e in engines
+                for e in ("ollama", "llamacpp", "vllm", "mlx", "sglang")
+            )
+            else 1
+        )
+        size = _model_size(model) or 0.0
+        return (local, size, model)
+
+    return sorted(models, key=rank)
+
+
+class HeuristicRouter(RouterPolicy):
+    """Rule-based model router with Pass-1 lane awareness.
+
+    New flow:
+    1. Determine task class / lane from ``RoutingContext``.
+    2. Choose the cheapest adequate model inside that lane.
+    3. Fall back to the legacy small/large/coder heuristics if no lane candidate exists.
     """
 
     def __init__(
@@ -120,33 +234,57 @@ class HeuristicRouter(RouterPolicy):
         if not available:
             return self._default or self._fallback or ""
 
-        # Rule 5: High urgency overrides everything → smallest model
+        use_lane_routing = bool(
+            context.lane
+            or context.task_class
+            or context.vision_required
+            or context.budget_sensitivity != "medium"
+            or context.risk_level != "low"
+            or context.latency_sensitivity != "medium"
+            or context.required_confidence is not None
+            or context.estimated_context_tokens > 0
+        )
+        if use_lane_routing:
+            lane = context.lane or _lane_for_context(context)
+            lane_candidates = _filter_by_lane(available, lane)
+            if lane_candidates:
+                lane_candidates = _prefer_local(lane_candidates)
+                if lane == LANE_ROUTER_CONTROL:
+                    return _smallest_model(lane_candidates) or lane_candidates[0]
+                if lane == LANE_FREE_FALLBACK:
+                    free = _find_model_by_tag(
+                        lane_candidates, ":free"
+                    ) or _find_model_by_tag(lane_candidates, "openrouter/free")
+                    return free or lane_candidates[0]
+                if lane == LANE_CODE_SPECIALIST:
+                    code_model = _find_model_by_tag(
+                        lane_candidates, "code"
+                    ) or _find_model_by_tag(lane_candidates, "coder")
+                    return code_model or (
+                        _smallest_model(lane_candidates) or lane_candidates[0]
+                    )
+                if lane == LANE_LONG_CONTEXT_RESEARCH:
+                    return _largest_model(lane_candidates) or lane_candidates[0]
+                if lane in {LANE_PREMIUM_WORKHORSE, LANE_FRONTIER_PREMIUM}:
+                    return _largest_model(lane_candidates) or lane_candidates[0]
+                return _smallest_model(lane_candidates) or lane_candidates[0]
+
+        # Legacy fallback path.
         if context.urgency > 0.8:
             return _smallest_model(available) or available[0]
-
-        # Rule 1: Code detected → prefer model with code/coder in name
         if context.has_code:
             code_model = _find_model_by_tag(available, "code") or _find_model_by_tag(
                 available, "coder"
             )
             if code_model:
                 return code_model
-            # Fall through to larger model for code
             return _largest_model(available) or available[0]
-
-        # Rule 2: Math detected → prefer larger model
         if context.has_math:
             return _largest_model(available) or available[0]
-
-        # Rule 3: Low complexity → prefer smaller model
         if context.complexity_score < 0.20:
             return _smallest_model(available) or available[0]
-
-        # Rule 4: High complexity or reasoning → prefer larger model
         if context.complexity_score >= 0.55 or context.has_reasoning:
             return _largest_model(available) or available[0]
-
-        # Rule 6: Default fallback
         if self._default and self._default in available:
             return self._default
         if self._fallback and self._fallback in available:
@@ -164,11 +302,31 @@ class DefaultQueryAnalyzer(QueryAnalyzer):
         model = kwargs.get("model")
         if not isinstance(model, str):
             model = None
-        return build_routing_context(query, urgency=urgency, model=model)
+        context = build_routing_context(query, urgency=urgency, model=model)
+        for attr in (
+            "risk_level",
+            "latency_sensitivity",
+            "budget_sensitivity",
+            "required_confidence",
+            "interactive",
+        ):
+            if attr in kwargs and hasattr(context, attr):
+                setattr(context, attr, kwargs[attr])
+        if "vision_required" in kwargs:
+            context.vision_required = bool(kwargs["vision_required"])
+        return context
 
 
 __all__ = [
     "DefaultQueryAnalyzer",
     "HeuristicRouter",
+    "LANE_CHEAP_PAID_WORKHORSE",
+    "LANE_CODE_SPECIALIST",
+    "LANE_FREE_FALLBACK",
+    "LANE_FRONTIER_PREMIUM",
+    "LANE_LONG_CONTEXT_RESEARCH",
+    "LANE_MULTIMODAL_VISION",
+    "LANE_PREMIUM_WORKHORSE",
+    "LANE_ROUTER_CONTROL",
     "build_routing_context",
 ]

--- a/src/openjarvis/learning/routing/router.py
+++ b/src/openjarvis/learning/routing/router.py
@@ -6,8 +6,9 @@ import logging
 from dataclasses import dataclass
 from typing import Iterable, List, Optional
 
+from openjarvis.core.events import EventBus, EventType
 from openjarvis.core.registry import ModelRegistry
-from openjarvis.core.types import RoutingContext
+from openjarvis.core.types import RoutingContext, StepType
 from openjarvis.learning._stubs import QueryAnalyzer, RouterPolicy
 from openjarvis.learning.routing.task_classifier import classify_task
 
@@ -292,6 +293,41 @@ def explain_route(
     )
 
 
+def emit_route_trace(
+    bus: EventBus | None,
+    *,
+    context: RoutingContext,
+    decision: RouteDecision,
+    selected_model: str,
+    selected_engine: str,
+    failure_reason: str | None = None,
+) -> None:
+    """Publish a standardized route trace event when a bus is available."""
+    if bus is None:
+        return
+    metadata = {"reason": decision.reason}
+    if failure_reason:
+        metadata["failure_reason"] = failure_reason
+    bus.publish(
+        EventType.TRACE_STEP,
+        {
+            "step_type": StepType.ROUTE.value,
+            "input": {
+                "query": context.query,
+                "task_class": context.task_class,
+            },
+            "output": {
+                "lane": decision.lane,
+                "model": selected_model,
+                "candidate_models": decision.candidate_models,
+                "escalation_chain": decision.escalation_chain,
+                "selected_engine": selected_engine,
+            },
+            "metadata": metadata,
+        },
+    )
+
+
 class HeuristicRouter(RouterPolicy):
     """Rule-based model router with Pass-1 lane awareness.
 
@@ -418,6 +454,7 @@ __all__ = [
     "RouteDecision",
     "build_routing_context",
     "escalation_chain_for_lane",
+    "emit_route_trace",
     "explain_route",
     "lane_for_model",
 ]

--- a/src/openjarvis/learning/routing/router.py
+++ b/src/openjarvis/learning/routing/router.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from typing import Iterable, List, Optional
 
 from openjarvis.core.registry import ModelRegistry
@@ -20,6 +21,52 @@ LANE_FRONTIER_PREMIUM = "frontier_premium"
 LANE_CODE_SPECIALIST = "code_specialist"
 LANE_LONG_CONTEXT_RESEARCH = "long_context_research"
 LANE_MULTIMODAL_VISION = "multimodal_vision"
+
+_LANE_ESCALATION_ORDER = {
+    LANE_ROUTER_CONTROL: [
+        LANE_ROUTER_CONTROL,
+        LANE_CHEAP_PAID_WORKHORSE,
+        LANE_PREMIUM_WORKHORSE,
+        LANE_FRONTIER_PREMIUM,
+    ],
+    LANE_FREE_FALLBACK: [
+        LANE_FREE_FALLBACK,
+        LANE_CHEAP_PAID_WORKHORSE,
+        LANE_PREMIUM_WORKHORSE,
+        LANE_FRONTIER_PREMIUM,
+    ],
+    LANE_CHEAP_PAID_WORKHORSE: [
+        LANE_CHEAP_PAID_WORKHORSE,
+        LANE_PREMIUM_WORKHORSE,
+        LANE_FRONTIER_PREMIUM,
+    ],
+    LANE_PREMIUM_WORKHORSE: [LANE_PREMIUM_WORKHORSE, LANE_FRONTIER_PREMIUM],
+    LANE_FRONTIER_PREMIUM: [LANE_FRONTIER_PREMIUM],
+    LANE_CODE_SPECIALIST: [
+        LANE_CODE_SPECIALIST,
+        LANE_PREMIUM_WORKHORSE,
+        LANE_FRONTIER_PREMIUM,
+    ],
+    LANE_LONG_CONTEXT_RESEARCH: [
+        LANE_LONG_CONTEXT_RESEARCH,
+        LANE_PREMIUM_WORKHORSE,
+        LANE_FRONTIER_PREMIUM,
+    ],
+    LANE_MULTIMODAL_VISION: [
+        LANE_MULTIMODAL_VISION,
+        LANE_PREMIUM_WORKHORSE,
+        LANE_FRONTIER_PREMIUM,
+    ],
+}
+
+
+@dataclass(frozen=True)
+class RouteDecision:
+    lane: str
+    model: str
+    candidate_models: List[str]
+    escalation_chain: List[str]
+    reason: str
 
 
 def build_routing_context(
@@ -187,6 +234,10 @@ def _filter_by_lane(available: Iterable[str], lane: str) -> List[str]:
     return [model for model in available if _spec_lane(model) == lane]
 
 
+def escalation_chain_for_lane(lane: str) -> List[str]:
+    return list(_LANE_ESCALATION_ORDER.get(lane, [lane]))
+
+
 def _prefer_local(models: List[str]) -> List[str]:
     def rank(model: str) -> tuple[int, float, str]:
         spec = _model_spec(model)
@@ -203,6 +254,37 @@ def _prefer_local(models: List[str]) -> List[str]:
         return (local, size, model)
 
     return sorted(models, key=rank)
+
+
+def explain_route(
+    context: RoutingContext,
+    *,
+    available_models: List[str] | None = None,
+    default_model: str = "",
+    fallback_model: str = "",
+) -> RouteDecision:
+    router = HeuristicRouter(
+        available_models=available_models,
+        default_model=default_model,
+        fallback_model=fallback_model,
+    )
+    available = router.available_models or list(ModelRegistry.keys())
+    selected_lane = context.lane or _lane_for_context(context)
+    candidates = _prefer_local(_filter_by_lane(available, selected_lane))
+    selected_model = router.select_model(context)
+    if not candidates and selected_model:
+        candidates = [selected_model]
+    reason = (
+        f"task_class={context.task_class or 'unknown'} "
+        f"complexity={context.complexity_score:.3f} lane={selected_lane}"
+    )
+    return RouteDecision(
+        lane=selected_lane,
+        model=selected_model,
+        candidate_models=candidates,
+        escalation_chain=escalation_chain_for_lane(selected_lane),
+        reason=reason,
+    )
 
 
 class HeuristicRouter(RouterPolicy):
@@ -328,5 +410,8 @@ __all__ = [
     "LANE_MULTIMODAL_VISION",
     "LANE_PREMIUM_WORKHORSE",
     "LANE_ROUTER_CONTROL",
+    "RouteDecision",
     "build_routing_context",
+    "escalation_chain_for_lane",
+    "explain_route",
 ]

--- a/src/openjarvis/learning/routing/task_classifier.py
+++ b/src/openjarvis/learning/routing/task_classifier.py
@@ -1,0 +1,113 @@
+"""Pass-1 task classifier for lane-aware routing.
+
+This is intentionally heuristic and lightweight. It maps a raw query to the
+repo's task ontology classes so the router can choose a capability lane before
+it chooses a specific model.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class TaskClassification:
+    task_class: str
+    confidence: float
+
+
+_VISION_PATTERNS = re.compile(
+    r"\b(image|screenshot|diagram|pdf|photo|picture|scan|ocr|visual|vision)\b",
+    re.IGNORECASE,
+)
+_CODE_COMPLEX_PATTERNS = re.compile(
+    r"\b(architecture|multi-file|root cause|intermittent|concurrency|debug|"
+    r"refactor|design|system design|novel algorithm)\b",
+    re.IGNORECASE,
+)
+_CODE_PATTERNS = re.compile(
+    r"\b(code|python|javascript|typescript|rust|go|java|sql|bash|shell|script|"
+    r"function|class|module|test|patch|bug|repo|compile|failing test)\b",
+    re.IGNORECASE,
+)
+_RESEARCH_PATTERNS = re.compile(
+    r"\b(research|source|sources|read this|read these|synthesize|synthesis|"
+    r"compare sources|citation|trend|competitor|analyze documents?)\b",
+    re.IGNORECASE,
+)
+_SUMMARIZE_PATTERNS = re.compile(
+    r"\b(summarize|summary|tl;dr|condense|key points|brief overview)\b",
+    re.IGNORECASE,
+)
+_CLASSIFY_PATTERNS = re.compile(
+    r"\b(classify|categorize|tag|label|triage|route|which bucket|yes or no|"
+    r"binary decision)\b",
+    re.IGNORECASE,
+)
+_EXTRACT_PATTERNS = re.compile(
+    r"\b(extract|pull out|parse|structured data|fields?|entities?)\b",
+    re.IGNORECASE,
+)
+_REWRITE_PATTERNS = re.compile(
+    r"\b(rewrite|rephrase|improve wording|adjust tone|edit this text|draft)\b",
+    re.IGNORECASE,
+)
+_COMPARE_PATTERNS = re.compile(
+    r"\b(compare|rank|pros and cons|trade-offs?)\b",
+    re.IGNORECASE,
+)
+_LONG_CONTEXT_PATTERNS = re.compile(
+    r"\b(long document|large document|many documents|across sources|full corpus|"
+    r"context window|transcript|entire report)\b",
+    re.IGNORECASE,
+)
+
+
+def classify_task(query: str) -> TaskClassification:
+    q = query.strip()
+    if not q:
+        return TaskClassification("classify", 0.2)
+
+    if _VISION_PATTERNS.search(q):
+        return TaskClassification("source-reading", 0.9)
+    if _LONG_CONTEXT_PATTERNS.search(q):
+        return TaskClassification("synthesis", 0.85)
+    if _CODE_COMPLEX_PATTERNS.search(q):
+        if (
+            "debug" in q.lower()
+            or "root cause" in q.lower()
+            or "intermittent" in q.lower()
+        ):
+            return TaskClassification("debug-complex", 0.9)
+        if "refactor" in q.lower():
+            return TaskClassification("refactor", 0.9)
+        if "architecture" in q.lower() or "design" in q.lower():
+            return TaskClassification("architecture-review", 0.85)
+        return TaskClassification("code-complex", 0.8)
+    if _CODE_PATTERNS.search(q):
+        if "test" in q.lower():
+            return TaskClassification("test-generation", 0.85)
+        if "bug" in q.lower() or "fix" in q.lower():
+            return TaskClassification("debug-simple", 0.8)
+        return TaskClassification("code-simple", 0.75)
+    if _RESEARCH_PATTERNS.search(q):
+        if "sources" in q.lower() or "synthesis" in q.lower():
+            return TaskClassification("synthesis", 0.85)
+        if "read" in q.lower():
+            return TaskClassification("source-reading", 0.8)
+        return TaskClassification("source-finding", 0.75)
+    if _SUMMARIZE_PATTERNS.search(q):
+        return TaskClassification("summarize", 0.9)
+    if _EXTRACT_PATTERNS.search(q):
+        return TaskClassification("extract", 0.85)
+    if _REWRITE_PATTERNS.search(q):
+        return TaskClassification("rewrite", 0.8)
+    if _COMPARE_PATTERNS.search(q):
+        return TaskClassification("compare", 0.8)
+    if _CLASSIFY_PATTERNS.search(q):
+        return TaskClassification("classify", 0.85)
+    return TaskClassification("summarize", 0.45)
+
+
+__all__ = ["TaskClassification", "classify_task"]

--- a/src/openjarvis/sdk.py
+++ b/src/openjarvis/sdk.py
@@ -12,6 +12,11 @@ from openjarvis.core.config import JarvisConfig, load_config
 from openjarvis.core.events import EventBus
 from openjarvis.core.types import Message, Role
 from openjarvis.engine._discovery import get_engine
+from openjarvis.learning.routing.router import (
+    build_routing_context,
+    emit_route_trace,
+    explain_route,
+)
 from openjarvis.system import JarvisSystem, SystemBuilder
 from openjarvis.telemetry.instrumented_engine import InstrumentedEngine
 from openjarvis.telemetry.store import TelemetryStore
@@ -312,18 +317,43 @@ class Jarvis:
 
         # Direct engine mode
         messages = [Message(role=Role.USER, content=query)]
+        routing_context = build_routing_context(query, model=model_name)
+        route_decision = explain_route(
+            routing_context,
+            available_models=self._engine.list_models(),
+            default_model=self._config.intelligence.default_model or "",
+            fallback_model=self._config.intelligence.fallback_model or "",
+        )
+        emit_route_trace(
+            self._bus,
+            context=routing_context,
+            decision=route_decision,
+            selected_model=model_name,
+            selected_engine=self._resolved_engine_key or "",
+        )
 
         # Memory context injection
         if context and self._config.agent.context_from_memory:
             messages = self._inject_context(query, messages)
 
         # InstrumentedEngine handles telemetry + energy recording
-        result = self._engine.generate(
-            messages,
-            model=model_name,
-            temperature=temperature,
-            max_tokens=max_tokens,
-        )
+        try:
+            result = self._engine.generate(
+                messages,
+                model=model_name,
+                temperature=temperature,
+                max_tokens=max_tokens,
+            )
+        except Exception as exc:
+            emit_route_trace(
+                self._bus,
+                context=routing_context,
+                decision=route_decision,
+                selected_model=model_name,
+                selected_engine=self._resolved_engine_key or "",
+                failure_reason=str(exc),
+            )
+            raise
 
         return {
             "content": result.get("content", ""),

--- a/src/openjarvis/traces/collector.py
+++ b/src/openjarvis/traces/collector.py
@@ -43,6 +43,7 @@ class TraceCollector:
         self._current_steps: list[TraceStep] = []
         self._current_model: str = ""
         self._current_engine: str = ""
+        self._current_route: Dict[str, Any] = {}
         self._last_trace: Optional[Trace] = None
 
     def run(
@@ -55,6 +56,7 @@ class TraceCollector:
         self._current_steps = []
         self._current_model = ""
         self._current_engine = ""
+        self._current_route = {}
 
         # Subscribe to events for trace collection
         unsubs = self._subscribe()
@@ -91,6 +93,7 @@ class TraceCollector:
             messages=messages,
             started_at=started_at,
             ended_at=ended_at,
+            metadata={"routing": dict(self._current_route)} if self._current_route else {},
         )
         # Recompute totals from steps
         for step in trace.steps:
@@ -118,6 +121,7 @@ class TraceCollector:
         if self._bus is None:
             return []
         handlers = [
+            (EventType.TRACE_STEP, self._on_trace_step),
             (EventType.INFERENCE_START, self._on_inference_start),
             (EventType.INFERENCE_END, self._on_inference_end),
             (EventType.TOOL_CALL_START, self._on_tool_start),
@@ -138,6 +142,26 @@ class TraceCollector:
         self._current_model = event.data.get("model", self._current_model)
         self._current_engine = event.data.get("engine", self._current_engine)
         self._inference_start_time = event.timestamp
+
+    def _on_trace_step(self, event: Any) -> None:
+        data = event.data or {}
+        step_type = data.get("step_type")
+        if step_type != StepType.ROUTE.value:
+            return
+        step = TraceStep(
+            step_type=StepType.ROUTE,
+            timestamp=event.timestamp,
+            duration_seconds=float(data.get("duration_seconds", 0.0) or 0.0),
+            input=dict(data.get("input") or {}),
+            output=dict(data.get("output") or {}),
+            metadata=dict(data.get("metadata") or {}),
+        )
+        self._current_steps.append(step)
+        self._current_route = {
+            **step.input,
+            **step.output,
+            **step.metadata,
+        }
 
     def _on_inference_end(self, event: Any) -> None:
         start = getattr(self, "_inference_start_time", event.timestamp)

--- a/tests/agents/test_executor.py
+++ b/tests/agents/test_executor.py
@@ -139,6 +139,56 @@ class TestExecutorBasic:
         # Agent should still be running (first tick owns it)
         assert manager.get_agent(agent["id"])["status"] == "running"
 
+    def test_invoke_agent_emits_route_trace_for_router_policy(
+        self, executor, manager, event_bus
+    ):
+        from openjarvis.core.config import JarvisConfig
+        from openjarvis.core.registry import AgentRegistry, RouterPolicyRegistry
+
+        class FakeAgent:
+            agent_id = "fake-route-agent"
+
+            def __init__(self, eng, model, **kwargs):
+                self.model = model
+
+            def run(self, input, context=None, **kwargs):
+                return AgentResult(content=f"used:{self.model}")
+
+        class FakePolicy:
+            def __init__(self, **kwargs):
+                pass
+
+            def select_model(self, ctx):
+                return "qwen2.5-coder:7b"
+
+        AgentRegistry.register_value("fake-route-agent", FakeAgent)
+        RouterPolicyRegistry.register_value("fake-policy", FakePolicy)
+
+        system = MagicMock()
+        system.engine.list_models.return_value = ["qwen2.5:1.5b", "qwen2.5-coder:7b"]
+        system.model = "qwen2.5:1.5b"
+        system.config = JarvisConfig()
+        executor.set_system(system)
+
+        agent = manager.create_agent(
+            name="routed",
+            agent_type="fake-route-agent",
+            config={
+                "router_policy": "fake-policy",
+                "instruction": "write a parser",
+                "model": "qwen2.5:1.5b",
+            },
+        )
+
+        event_bus._record_history = True
+        result = executor._invoke_agent(agent)
+        route_events = [
+            e for e in event_bus.history if e.event_type == EventType.TRACE_STEP
+        ]
+        assert result.content == "used:qwen2.5-coder:7b"
+        assert route_events
+        assert route_events[-1].data["output"]["model"] == "qwen2.5-coder:7b"
+
 
 def test_finalize_tick_reads_agent_result_metadata(tmp_path):
     """_finalize_tick() accumulates cost/tokens from AgentResult.metadata."""

--- a/tests/cli/test_ask_router.py
+++ b/tests/cli/test_ask_router.py
@@ -174,3 +174,75 @@ class TestAskModelResolution:
             cfg.agent.default_agent = ""
             result = CliRunner().invoke(cli, ["ask", "Hello"])
         assert result.exit_code == 0
+
+    def test_cloud_fallback_reselects_engine(self) -> None:
+        """A cloud fallback model must re-select the cloud engine.
+
+        Regression for the local-engine-up-but-default-missing path: the engine
+        is first resolved against the (missing) ``default_model`` and lands on
+        the local engine, whose ``can_serve`` is ``False`` for ``openrouter/``
+        ids. ``ask`` must then re-resolve so the request actually runs on the
+        cloud engine instead of dying at call time with a local 404.
+        """
+        # Local engine: healthy, but cannot serve cloud-namespaced ids.
+        local = mock.MagicMock()
+        local.engine_id = "ollama"
+        local.health.return_value = True
+        local.list_models.return_value = ["qwen2.5:1.5b"]
+        local.can_serve.side_effect = lambda m: not m.startswith("openrouter/")
+
+        # Cloud engine: serves the openrouter fallback and answers.
+        cloud = mock.MagicMock()
+        cloud.engine_id = "cloud"
+        cloud.health.return_value = True
+        cloud.list_models.return_value = ["openrouter/free"]
+        cloud.can_serve.side_effect = lambda m: m.startswith("openrouter/")
+        cloud.generate.return_value = {
+            "content": "CLOUD-OK",
+            "usage": {"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8},
+            "model": "openrouter/free",
+            "finish_reason": "stop",
+        }
+
+        # get_engine: first call (default model) -> local; re-resolve for the
+        # cloud fallback model -> cloud.
+        def _get_engine(config, key=None, model=None):  # noqa: ANN001
+            if model and model.startswith("openrouter/"):
+                return ("cloud", cloud)
+            return ("ollama", local)
+
+        _register_agents()
+        with (
+            mock.patch.object(_ask_mod, "get_engine", side_effect=_get_engine),
+            mock.patch.object(
+                _ask_mod,
+                "discover_engines",
+                return_value={"ollama": local, "cloud": cloud},
+            ),
+            mock.patch.object(
+                _ask_mod,
+                "discover_models",
+                return_value={"ollama": ["qwen2.5:1.5b"], "cloud": ["openrouter/free"]},
+            ),
+            mock.patch.object(_ask_mod, "register_builtin_models"),
+            mock.patch.object(_ask_mod, "merge_discovered_models"),
+            mock.patch.object(_ask_mod, "TelemetryStore"),
+            mock.patch.object(_ask_mod, "load_config") as mock_config,
+        ):
+            cfg = mock_config.return_value
+            cfg.telemetry.enabled = False
+            # default_model is configured but NOT present on the local engine.
+            cfg.intelligence.default_model = "missing-local-model"
+            cfg.intelligence.fallback_model = "openrouter/free"
+            cfg.intelligence.preferred_engine = ""
+            cfg.intelligence.temperature = 0.7
+            cfg.intelligence.max_tokens = 1024
+            cfg.agent.context_from_memory = False
+            cfg.agent.default_agent = ""
+            result = CliRunner().invoke(cli, ["ask", "Hello"])
+
+        assert result.exit_code == 0, result.output
+        # The cloud engine (not the local one) must have served the request.
+        assert cloud.generate.called
+        assert not local.generate.called
+        assert cloud.generate.call_args.kwargs["model"] == "openrouter/free"

--- a/tests/cli/test_ask_router.py
+++ b/tests/cli/test_ask_router.py
@@ -115,6 +115,34 @@ class TestAskModelResolution:
             result = CliRunner().invoke(cli, ["ask", "Hello"])
         assert result.exit_code == 0
 
+    def test_missing_default_prefers_configured_fallback(self) -> None:
+        """If default_model is unavailable, prefer fallback_model over local models."""
+        engine = _mock_engine()
+        patches = _patch_engine(engine)
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            mock.patch.object(
+                _ask_mod,
+                "load_config",
+            ) as mock_config,
+        ):
+            cfg = mock_config.return_value
+            cfg.telemetry.enabled = False
+            cfg.intelligence.default_model = "missing-local-model"
+            cfg.intelligence.fallback_model = "openrouter/free"
+            cfg.intelligence.temperature = 0.7
+            cfg.intelligence.max_tokens = 1024
+            cfg.agent.context_from_memory = False
+            cfg.agent.default_agent = ""
+            result = CliRunner().invoke(cli, ["ask", "Hello"])
+        assert result.exit_code == 0
+        assert engine.generate.call_args.kwargs["model"] == "openrouter/free"
+
     def test_fallback_to_fallback_model(self) -> None:
         """When default_model is empty and no engine models, uses fallback_model."""
         engine = _mock_engine()

--- a/tests/cli/test_ask_router.py
+++ b/tests/cli/test_ask_router.py
@@ -8,6 +8,7 @@ from unittest import mock
 from click.testing import CliRunner
 
 from openjarvis.cli import cli
+from openjarvis.core.events import EventBus, EventType
 
 _ask_mod = importlib.import_module("openjarvis.cli.ask")
 
@@ -67,6 +68,33 @@ def _patch_engine(engine):
 
 
 class TestAskModelResolution:
+    def test_route_trace_event_published(self) -> None:
+        engine = _mock_engine()
+        patches = _patch_engine(engine)
+        bus = EventBus(record_history=True)
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            mock.patch.object(_ask_mod, "EventBus", return_value=bus),
+        ):
+            result = CliRunner().invoke(cli, ["ask", "Please classify this ticket"])
+        assert result.exit_code == 0
+        route_events = [
+            e
+            for e in bus.history
+            if e.event_type == EventType.TRACE_STEP
+            and e.data.get("step_type") == "route"
+        ]
+        assert route_events, "expected a route TRACE_STEP event"
+        ev = route_events[-1]
+        assert ev.data["output"]["model"]
+        assert "selected_engine" in ev.data["output"]
+        assert "escalation_chain" in ev.data["output"]
+
     def test_default_model_from_config(self) -> None:
         """When no -m flag, uses config.intelligence.default_model."""
         engine = _mock_engine()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,6 +51,25 @@ def _clean_registries() -> None:
     reset_event_bus()
 
 
+@pytest.fixture(autouse=True)
+def _isolate_config_dir(
+    tmp_path_factory: pytest.TempPathFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Point ``OPENJARVIS_HOME`` at a per-test temp dir.
+
+    Without this, tests that assert "no cloud keys configured" (e.g.
+    ``CloudEngine().health() is False``) flakily fail on a developer machine
+    that has a real ``~/.openjarvis/vault.enc`` populated via ``jarvis vault
+    set``: ``_load_cloud_keys`` correctly reads that vault and the engine then
+    reports healthy. Isolating the config dir keeps the suite hermetic and
+    independent of the operator's real credentials. Tests that need a specific
+    config dir can still override ``OPENJARVIS_HOME`` locally.
+    """
+    home = tmp_path_factory.mktemp("openjarvis_home")
+    monkeypatch.setenv("OPENJARVIS_HOME", str(home))
+
+
 # ---------------------------------------------------------------------------
 # Hardware fixtures
 # ---------------------------------------------------------------------------

--- a/tests/engine/test_cloud_openrouter_fallback.py
+++ b/tests/engine/test_cloud_openrouter_fallback.py
@@ -1,0 +1,143 @@
+"""Tests for OpenRouter key loading in the cloud engine."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from openjarvis.engine.cloud import CloudEngine
+
+
+def _clear_cloud_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in (
+        "OPENROUTER_API_KEY",
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "GEMINI_API_KEY",
+        "GOOGLE_API_KEY",
+        "MINIMAX_API_KEY",
+        "DEEPSEEK_API_KEY",
+        "OPENAI_CODEX_API_KEY",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_cloud_engine_loads_openrouter_key_from_cloud_keys_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """CloudEngine should discover OpenRouter credentials from cloud-keys.env."""
+    keys_file = tmp_path / "cloud-keys.env"
+    keys_file.write_text("OPENROUTER_API_KEY=sk-or-test-from-file\n")
+
+    _clear_cloud_env(monkeypatch)
+
+    fake_openai = mock.MagicMock()
+    with mock.patch("openjarvis.engine.cloud._CLOUD_ENV_FILE", keys_file), \
+        mock.patch.dict("sys.modules", {"openai": fake_openai}):
+        engine = CloudEngine()
+
+    assert engine._openrouter_client is not None
+    assert engine.health() is True
+
+
+def _write_vault(config_dir: Path, payload: dict[str, str]) -> mock._patch:
+    """Stage a fake encrypted vault under ``config_dir``.
+
+    The on-disk ``Fernet`` cipher (AES-CBC) is unavailable on some hardened
+    crypto backends, so we write placeholder files and patch ``Fernet`` to
+    return the decrypted JSON. This keeps the test hermetic while still
+    exercising the engine's file-discovery, decrypt, parse, and key-filter
+    logic.
+    """
+    (config_dir / ".vault_key").write_bytes(b"fake-key")
+    (config_dir / "vault.enc").write_bytes(b"fake-ciphertext")
+
+    fake_fernet_cls = mock.MagicMock()
+    fake_fernet_cls.return_value.decrypt.return_value = json.dumps(payload).encode()
+    return mock.patch("cryptography.fernet.Fernet", fake_fernet_cls)
+
+
+def test_cloud_engine_loads_openrouter_key_from_vault(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """CloudEngine should discover credentials stored via ``jarvis vault set``.
+
+    This is the source the live CLI uses, so the engine must read the encrypted
+    vault when neither cloud-keys.env nor the process env carry the key.
+    """
+    _clear_cloud_env(monkeypatch)
+    vault_patch = _write_vault(
+        tmp_path, {"OPENROUTER_API_KEY": "sk-or-test-from-vault"}
+    )
+
+    missing_env = tmp_path / "cloud-keys.env"  # intentionally absent
+    fake_openai = mock.MagicMock()
+    with vault_patch, \
+        mock.patch("openjarvis.engine.cloud.get_config_dir", return_value=tmp_path), \
+        mock.patch("openjarvis.engine.cloud._CLOUD_ENV_FILE", missing_env), \
+        mock.patch.dict("sys.modules", {"openai": fake_openai}):
+        from openjarvis.engine.cloud import _load_cloud_keys
+
+        keys = _load_cloud_keys()
+        engine = CloudEngine()
+
+    assert keys.get("OPENROUTER_API_KEY") == "sk-or-test-from-vault"
+    assert engine._openrouter_client is not None
+    assert engine.health() is True
+
+
+def test_process_env_overrides_vault(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Process env should take precedence over the on-disk vault value."""
+    _clear_cloud_env(monkeypatch)
+    vault_patch = _write_vault(tmp_path, {"OPENROUTER_API_KEY": "sk-or-from-vault"})
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-from-env")
+
+    missing_env = tmp_path / "cloud-keys.env"
+    with vault_patch, \
+        mock.patch("openjarvis.engine.cloud.get_config_dir", return_value=tmp_path), \
+        mock.patch("openjarvis.engine.cloud._CLOUD_ENV_FILE", missing_env):
+        from openjarvis.engine.cloud import _load_cloud_keys
+
+        keys = _load_cloud_keys()
+
+    assert keys["OPENROUTER_API_KEY"] == "sk-or-from-env"
+
+
+def test_openrouter_free_alias_resolves_to_listed_free_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``openrouter/free`` must resolve to a concrete, listed ``:free`` slug.
+
+    The bare ``free`` token is not routable and previously produced a 502. The
+    resolver should prefer a curated free model that the live models list
+    actually exposes, and must never return a paid slug.
+    """
+    _clear_cloud_env(monkeypatch)
+    engine = CloudEngine()
+
+    # Simulate OpenRouter exposing only a subset of the curated free models.
+    listed = mock.MagicMock()
+    listed.data = [
+        mock.MagicMock(id="google/gemma-4-31b-it:free"),
+        mock.MagicMock(id="some/paid-model"),
+    ]
+    engine._openrouter_client = mock.MagicMock()
+    engine._openrouter_client.models.list.return_value = listed
+
+    resolved = engine._openrouter_model_id("openrouter/free")
+    assert resolved == "google/gemma-4-31b-it:free"
+    assert resolved.endswith(":free")
+
+    # Concrete slugs pass through unchanged; ``auto`` keeps its real slug.
+    assert (
+        engine._openrouter_model_id("openrouter/meta-llama/llama-3.3-70b-instruct")
+        == "meta-llama/llama-3.3-70b-instruct"
+    )
+    assert engine._openrouter_model_id("openrouter/auto") == "openrouter/auto"
+
+

--- a/tests/engine/test_discovery.py
+++ b/tests/engine/test_discovery.py
@@ -12,6 +12,7 @@ from openjarvis.engine._discovery import (
     discover_models,
     get_engine,
 )
+from openjarvis.engine._stubs import is_cloud_only_model
 
 
 class _FakeEngine(InferenceEngine):
@@ -44,6 +45,28 @@ def _reg(key: str, eid: str) -> None:
     """Register a fake engine type under *key*."""
     cls = type(key.title(), (_FakeEngine,), {"engine_id": eid})
     EngineRegistry.register_value(key, cls)
+
+
+class TestCloudOnlyModelGuard:
+    """The base ``can_serve`` must decline unambiguously cloud-only ids."""
+
+    def test_is_cloud_only_model(self) -> None:
+        assert is_cloud_only_model("openrouter/free") is True
+        assert is_cloud_only_model("openrouter/anthropic/claude-sonnet-4") is True
+        assert is_cloud_only_model("codex/gpt-5") is True
+        # Ordinary local/cloud ids are NOT cloud-only namespaced.
+        assert is_cloud_only_model("qwen2.5:1.5b") is False
+        assert is_cloud_only_model("gpt-4o") is False
+        assert is_cloud_only_model("claude-sonnet-4") is False
+
+    def test_base_can_serve_declines_cloud_only(self) -> None:
+        engine = _FakeEngine(healthy=True)
+        # Local engines accept ordinary ids (install state is a separate concern)
+        assert engine.can_serve("qwen2.5:1.5b") is True
+        assert engine.can_serve("some-unknown-local-model") is True
+        # ...but never claim cloud-only namespaces.
+        assert engine.can_serve("openrouter/free") is False
+        assert engine.can_serve("codex/gpt-5") is False
 
 
 class TestDiscoverEngines:
@@ -203,6 +226,30 @@ class TestGetEngine:
             result = get_engine(cfg, model="other")
         assert result is not None
         assert result[0] == "local"
+
+    def test_local_engine_declines_cloud_only_model(self) -> None:
+        """A local engine must NOT be selected for a cloud-namespaced model.
+
+        Regression: when ``default_model`` is missing and the configured
+        ``fallback_model`` is ``openrouter/free``, model resolution falls back
+        to that cloud id. The base ``can_serve`` returns ``False`` for
+        ``openrouter/`` (and ``codex/``) ids, so a local-only engine declines
+        and ``get_engine`` returns ``None`` rather than handing the cloud model
+        to a local backend that would 404 at call time.
+        """
+        _reg("local", "local")
+        cfg = JarvisConfig()
+        cfg.engine.default = "local"
+
+        with mock.patch(
+            "openjarvis.engine._discovery._make_engine",
+            side_effect=lambda k, c: _FakeEngine(healthy=True),
+        ):
+            # Only a local engine is registered; it cannot serve openrouter/*.
+            assert get_engine(cfg, model="openrouter/free") is None
+            assert get_engine(cfg, model="codex/gpt-5") is None
+            # ...but ordinary ids are still served locally.
+            assert get_engine(cfg, model="qwen2.5:1.5b") is not None
 
     def test_dummy_openai_key_does_not_misroute_local_model(
         self, monkeypatch: object

--- a/tests/intelligence/test_model_catalog_routing.py
+++ b/tests/intelligence/test_model_catalog_routing.py
@@ -1,0 +1,52 @@
+"""Tests for Pass-2 model catalog lane metadata."""
+
+from __future__ import annotations
+
+from openjarvis.core.registry import ModelRegistry
+from openjarvis.intelligence.model_catalog import (
+    infer_routing_metadata,
+    merge_discovered_models,
+    register_builtin_models,
+)
+
+
+def test_builtin_router_models_have_lane_metadata() -> None:
+    register_builtin_models()
+    qwen = ModelRegistry.get("qwen2.5:1.5b")
+    llama = ModelRegistry.get("llama3.2:1b")
+    assert qwen.metadata.get("routing_lane") == "router_control"
+    assert llama.metadata.get("routing_lane") == "router_control"
+    assert qwen.metadata.get("stable_json") is True
+
+
+def test_builtin_openrouter_free_has_free_fallback_lane() -> None:
+    register_builtin_models()
+    free = ModelRegistry.get("openrouter/free")
+    assert free.metadata.get("routing_lane") == "free_fallback"
+    assert free.metadata.get("cost_band") == "free"
+
+
+def test_builtin_code_and_vision_models_have_expected_lanes() -> None:
+    register_builtin_models()
+    coder = ModelRegistry.get("qwen2.5-coder:7b")
+    vision = ModelRegistry.get("openrouter/qwen/qwen3-vl-32b-instruct")
+    assert coder.metadata.get("routing_lane") == "code_specialist"
+    assert vision.metadata.get("routing_lane") == "multimodal_vision"
+
+
+def test_infer_routing_metadata_for_premium_and_long_context() -> None:
+    premium = infer_routing_metadata("openrouter/deepseek/deepseek-v3.2")
+    longctx = infer_routing_metadata("openrouter/meta-llama/llama-4-scout")
+    assert premium.get("routing_lane") == "premium_workhorse"
+    assert longctx.get("routing_lane") == "long_context_research"
+
+
+def test_merge_discovered_models_applies_lane_metadata() -> None:
+    merge_discovered_models(
+        "cloud",
+        ["openrouter/free", "openrouter/qwen/qwen3-vl-32b-instruct"],
+    )
+    free = ModelRegistry.get("openrouter/free")
+    vision = ModelRegistry.get("openrouter/qwen/qwen3-vl-32b-instruct")
+    assert free.metadata.get("routing_lane") == "free_fallback"
+    assert vision.metadata.get("routing_lane") == "multimodal_vision"

--- a/tests/learning/routing/test_learned_router.py
+++ b/tests/learning/routing/test_learned_router.py
@@ -42,6 +42,32 @@ def _make_trace(
     )
 
 
+def _make_routed_trace(
+    *,
+    query: str,
+    model: str,
+    task_class: str,
+    lane: str,
+    outcome: str | None = "success",
+    feedback: float | None = 0.8,
+    escalation_chain: list[str] | None = None,
+) -> Trace:
+    trace = _make_trace(
+        query=query,
+        model=model,
+        outcome=outcome,
+        feedback=feedback,
+    )
+    trace.metadata = {
+        "routing": {
+            "task_class": task_class,
+            "lane": lane,
+            "escalation_chain": escalation_chain or [lane],
+        }
+    }
+    return trace
+
+
 class TestLearnedRouterPolicy:
     def test_registered_as_learned(self) -> None:
         from openjarvis.core.registry import RouterPolicyRegistry
@@ -120,6 +146,50 @@ class TestLearnedRouterPolicy:
         assert pmap["short"] == "small-model"
         store.close()
 
+    def test_update_from_traces_learns_lane_by_task_class(self, tmp_path: Path) -> None:
+        store = TraceStore(tmp_path / "test.db")
+        for _ in range(5):
+            store.save(
+                _make_routed_trace(
+                    query="write a parser for csv files",
+                    model="qwen2.5-coder:7b",
+                    task_class="code_complex",
+                    lane="code_specialist",
+                    feedback=0.95,
+                )
+            )
+        for _ in range(5):
+            store.save(
+                _make_routed_trace(
+                    query="write a parser for json files",
+                    model="openrouter/deepseek/deepseek-v3.2",
+                    task_class="code_complex",
+                    lane="premium_workhorse",
+                    feedback=0.6,
+                    escalation_chain=["code_specialist", "premium_workhorse"],
+                )
+            )
+
+        analyzer = TraceAnalyzer(store)
+        policy = LearnedRouterPolicy(
+            analyzer=analyzer,
+            default_model="qwen2.5:1.5b",
+            available_models=[
+                "qwen2.5:1.5b",
+                "qwen2.5-coder:7b",
+                "openrouter/deepseek/deepseek-v3.2",
+            ],
+        )
+        policy.min_samples = 3
+
+        result = policy.update_from_traces()
+        assert result["updated"] is True
+        assert policy.lane_policy_map["code_complex"] == "code_specialist"
+
+        ctx = RoutingContext(query="implement a parser", task_class="code_complex")
+        assert policy.select_model(ctx) == "qwen2.5-coder:7b"
+        store.close()
+
     def test_observe_online(self) -> None:
         policy = LearnedRouterPolicy(default_model="default")
         policy.min_samples = 3
@@ -167,3 +237,25 @@ class TestLearnedRouterPolicy:
         result = policy.update(mock_store)
         assert isinstance(result, dict)
         assert "policy_map" in result
+
+    def test_batch_update_returns_lane_policy_map(self) -> None:
+        from unittest.mock import MagicMock
+
+        policy = LearnedRouterPolicy(
+            default_model="qwen2.5:1.5b",
+            available_models=["qwen2.5:1.5b", "qwen2.5-coder:7b"],
+        )
+        policy.min_samples = 3
+        mock_store = MagicMock()
+        mock_store.list_traces.return_value = [
+            _make_routed_trace(
+                query="write tests",
+                model="qwen2.5-coder:7b",
+                task_class="code_complex",
+                lane="code_specialist",
+                feedback=0.9,
+            )
+            for _ in range(4)
+        ]
+        result = policy.update(mock_store)
+        assert result["lane_policy_map"]["code_complex"] == "code_specialist"

--- a/tests/learning/test_router.py
+++ b/tests/learning/test_router.py
@@ -40,6 +40,28 @@ def _register_models() -> None:
             context_length=131072,
         ),
     )
+    ModelRegistry.register_value(
+        "free",
+        ModelSpec(
+            model_id="openrouter/free",
+            name="OpenRouter Free",
+            parameter_count_b=0.0,
+            context_length=131072,
+            supported_engines=("cloud",),
+            provider="openrouter",
+        ),
+    )
+    ModelRegistry.register_value(
+        "vision",
+        ModelSpec(
+            model_id="qwen/qwen3-vl-32b-instruct",
+            name="Qwen Vision",
+            parameter_count_b=32.0,
+            context_length=131072,
+            supported_engines=("cloud",),
+            provider="openrouter",
+        ),
+    )
 
 
 class TestBuildRoutingContext:
@@ -60,6 +82,15 @@ class TestBuildRoutingContext:
     def test_urgency_default(self) -> None:
         ctx = build_routing_context("test")
         assert ctx.urgency == 0.5
+
+    def test_task_class_detection_for_code(self) -> None:
+        ctx = build_routing_context("please write a python function and tests")
+        assert ctx.task_class in {"code-simple", "test-generation"}
+        assert ctx.task_class_confidence > 0.0
+
+    def test_vision_detection(self) -> None:
+        ctx = build_routing_context("describe this screenshot")
+        assert ctx.vision_required is True
 
 
 class TestHeuristicRouter:
@@ -159,3 +190,60 @@ class TestHeuristicRouter:
             has_code=True,
         )
         assert router.select_model(ctx) == "large"
+
+    def test_router_lane_prefers_small_control_model(self) -> None:
+        _register_models()
+        router = HeuristicRouter(available_models=["small", "large"])
+        ctx = RoutingContext(
+            query="classify this ticket",
+            query_length=20,
+            task_class="classify",
+        )
+        assert router.select_model(ctx) == "small"
+
+    def test_code_lane_prefers_coder(self) -> None:
+        _register_models()
+        router = HeuristicRouter(available_models=["small", "large", "coder"])
+        ctx = RoutingContext(
+            query="write a patch",
+            query_length=20,
+            task_class="code-simple",
+        )
+        assert router.select_model(ctx) == "coder"
+
+    def test_free_fallback_lane_prefers_openrouter_free(self) -> None:
+        _register_models()
+        router = HeuristicRouter(available_models=["small", "openrouter/free", "large"])
+        ctx = RoutingContext(
+            query="cheap low-stakes fallback",
+            query_length=24,
+            task_class="summarize",
+            budget_sensitivity="high",
+            risk_level="low",
+        )
+        assert router.select_model(ctx) == "openrouter/free"
+
+    def test_long_context_lane_prefers_larger_model(self) -> None:
+        _register_models()
+        router = HeuristicRouter(available_models=["small", "large"])
+        ctx = RoutingContext(
+            query="synthesize these long documents",
+            query_length=2000,
+            task_class="synthesis",
+            complexity_score=0.7,
+            estimated_context_tokens=8000,
+        )
+        assert router.select_model(ctx) == "large"
+
+    def test_vision_lane_prefers_vision_model(self) -> None:
+        _register_models()
+        router = HeuristicRouter(
+            available_models=["small", "qwen/qwen3-vl-32b-instruct", "large"]
+        )
+        ctx = RoutingContext(
+            query="describe this screenshot",
+            query_length=24,
+            task_class="source-reading",
+            vision_required=True,
+        )
+        assert router.select_model(ctx) == "qwen/qwen3-vl-32b-instruct"

--- a/tests/learning/test_router.py
+++ b/tests/learning/test_router.py
@@ -8,6 +8,8 @@ from openjarvis.learning._stubs import RoutingContext
 from openjarvis.learning.routing.router import (
     HeuristicRouter,
     build_routing_context,
+    escalation_chain_for_lane,
+    explain_route,
 )
 
 
@@ -247,3 +249,26 @@ class TestHeuristicRouter:
             vision_required=True,
         )
         assert router.select_model(ctx) == "qwen/qwen3-vl-32b-instruct"
+
+    def test_escalation_chain_for_code_lane(self) -> None:
+        chain = escalation_chain_for_lane("code_specialist")
+        assert chain == [
+            "code_specialist",
+            "premium_workhorse",
+            "frontier_premium",
+        ]
+
+    def test_explain_route_exposes_candidates_and_escalation(self) -> None:
+        _register_models()
+        decision = explain_route(
+            RoutingContext(
+                query="write a patch",
+                query_length=20,
+                task_class="code-simple",
+            ),
+            available_models=["small", "coder", "large"],
+        )
+        assert decision.lane == "code_specialist"
+        assert decision.model == "coder"
+        assert "coder" in decision.candidate_models
+        assert decision.escalation_chain[0] == "code_specialist"

--- a/tests/sdk/test_sdk.py
+++ b/tests/sdk/test_sdk.py
@@ -8,6 +8,7 @@ import pytest
 
 import openjarvis
 from openjarvis.core.config import JarvisConfig
+from openjarvis.core.events import EventType
 from openjarvis.sdk import Jarvis, MemoryHandle
 
 
@@ -111,6 +112,19 @@ class TestJarvisAsk:
             assert "content" in result
             assert "usage" in result
             assert result["content"] == "Full response"
+            j.close()
+
+    def test_ask_full_emits_route_trace(self):
+        engine = _make_engine("Full response")
+        with patch("openjarvis.sdk.get_engine", return_value=("mock", engine)):
+            j = Jarvis(config=JarvisConfig(), model="qwen2.5-coder:7b")
+            j._bus = type(j._bus)(record_history=True)
+            j.ask_full("write a parser")
+            route_events = [
+                e for e in j._bus.history if e.event_type == EventType.TRACE_STEP
+            ]
+            assert route_events
+            assert route_events[-1].data["output"]["model"] == "qwen2.5-coder:7b"
             j.close()
 
 

--- a/tests/traces/test_collector.py
+++ b/tests/traces/test_collector.py
@@ -159,6 +159,42 @@ class TestTraceCollector:
         assert retrieve_steps[0].input["query"] == "meeting notes"
         store.close()
 
+    def test_records_route_steps_and_trace_metadata(self, tmp_path: Path) -> None:
+        bus = EventBus()
+        store = TraceStore(tmp_path / "test.db")
+        agent = _FakeAgent(bus=bus)
+        collector = TraceCollector(agent, store=store, bus=bus)
+
+        original_run = agent.run
+
+        def run_with_route(input, context=None, **kwargs):
+            bus.publish(EventType.TRACE_STEP, {
+                "step_type": StepType.ROUTE.value,
+                "input": {"query": input, "task_class": "code_complex"},
+                "output": {
+                    "lane": "code_specialist",
+                    "model": "qwen2.5-coder:7b",
+                    "candidate_models": ["qwen2.5-coder:7b"],
+                    "escalation_chain": [
+                        "code_specialist",
+                        "premium_workhorse",
+                    ],
+                },
+                "metadata": {"reason": "code task"},
+            })
+            return original_run(input, context=context, **kwargs)
+
+        agent.run = run_with_route
+        collector.run("write a parser")
+
+        trace = store.list_traces()[0]
+        route_steps = [s for s in trace.steps if s.step_type == StepType.ROUTE]
+        assert len(route_steps) == 1
+        assert route_steps[0].output["lane"] == "code_specialist"
+        assert trace.metadata["routing"]["task_class"] == "code_complex"
+        assert trace.metadata["routing"]["lane"] == "code_specialist"
+        store.close()
+
     def test_publishes_trace_complete(self, tmp_path: Path) -> None:
         bus = EventBus(record_history=True)
         store = TraceStore(tmp_path / "test.db")


### PR DESCRIPTION
## Problem

`jarvis ask` could never reach cloud providers via the CLI path, even with a
valid OpenRouter key configured. Two root causes:

1. **Key source gap.** The OpenRouter key is stored in the encrypted
   `~/.openjarvis/vault.enc` (written by `jarvis vault set`), but `CloudEngine`
   only read `cloud-keys.env` and the process environment. With neither present,
   `CloudEngine` initialized no clients, so the ask path fell back to the local
   engine (Ollama) and returned a 404 for missing local models.
2. **`openrouter/free` alias was not routable.** The configured
   `fallback_model = "openrouter/free"` stripped to the bare token `free`, which
   is not a valid OpenRouter model slug and returned `HTTP 502 - Invalid URL`.

## Changes

- `engine/cloud.py`
  - `_load_cloud_keys()` now also reads the encrypted `vault.enc` as a key
    source. Precedence (later overrides earlier): vault -> `cloud-keys.env` ->
    process env. This mirrors the existing `server/cloud_router.py` fallback
    pattern and is the missing bridge between `jarvis vault set` and the CLI.
  - Pass discovered keys explicitly to the OpenAI / Anthropic SDK clients so
    vault-only credentials work for those providers too (the other providers
    already received `api_key=` explicitly).
  - Resolve the `openrouter/free` convenience alias to a concrete,
    currently-listed `:free` model. Selection is **cost-safe**: it never falls
    back to a paid slug, and it prefers reliably-available small instruct models
    because the large popular free models are heavily rate-limited (HTTP 429).
    `openrouter/auto` is preserved as its real router slug.
- `cli/ask.py`
  - When the configured `default_model` is unavailable on the selected engine,
    prefer the configured `fallback_model` before picking an arbitrary local
    model.

## Tests

- `tests/engine/test_cloud_openrouter_fallback.py`
  - discovers `OPENROUTER_API_KEY` from `cloud-keys.env` and from the encrypted
    vault; process env overrides the vault; `openrouter/free` resolves to a
    listed `:free` slug (and never a paid one); concrete/`auto` slugs pass
    through correctly.
- `tests/cli/test_ask_router.py`
  - `jarvis ask` prefers `fallback_model` when the configured default is
    unavailable.

72 targeted tests pass; `ruff` clean on the changed files.

## Verification (live)

`jarvis ask -e cloud -m openrouter/free "..."` performs a **real** OpenRouter
round-trip using the vault-sourced key (routed to a `:free` model, with real
token usage). No env var or `cloud-keys.env` was present; the key came solely
from `vault.enc`.