### PR TITLE
fix(engine): guard None content in estimate_prompt_tokens (#276)

### DIFF
--- a/src/openjarvis/engine/_base.py
+++ b/src/openjarvis/engine/_base.py
@@ -55,7 +55,7 @@ def estimate_prompt_tokens(messages: Sequence[Message]) -> int:
     Uses ~4 characters per token (standard BPE average for English) plus
     a small per-message overhead for role markers and separators.
     """
-    total_chars = sum(len(m.content) for m in messages)
+    total_chars = sum(len(m.content or "") for m in messages)
     # ~4 tokens overhead per message for role markers / separators
     overhead = len(messages) * 4
     return max(1, total_chars // 4 + overhead)

--- a/tests/engine/test_base.py
+++ b/tests/engine/test_base.py
@@ -1,0 +1,36 @@
+"""Tests for openjarvis.engine._base utility helpers."""
+
+from __future__ import annotations
+
+from openjarvis.core.types import Message, Role
+from openjarvis.engine._base import estimate_prompt_tokens
+
+
+class TestEstimatePromptTokens:
+    def test_counts_basic_messages(self):
+        # 25 content chars // 4  +  2 messages * 4 overhead
+        msgs = [
+            Message(role=Role.USER, content="hello there"),
+            Message(role=Role.ASSISTANT, content="general kenobi"),
+        ]
+        assert estimate_prompt_tokens(msgs) == 14
+
+    def test_handles_none_content(self):
+        # A tool-call assistant turn legitimately carries content=None per the
+        # OpenAI chat schema; Qwen3 on Ollama produces exactly this shape. The
+        # next turn's prompt estimate must not crash. Regression for the
+        # "TypeError: object of type 'NoneType' has no len()" in issue #276.
+        msgs = [
+            Message(role=Role.USER, content="What is 17 * 23?"),  # 16 chars
+            Message(role=Role.ASSISTANT, content=None),
+        ]
+        # 16 // 4  +  2 messages * 4 overhead = 4 + 8
+        assert estimate_prompt_tokens(msgs) == 12
+
+    def test_none_message_adds_only_overhead(self):
+        # A None-content message must contribute its per-message overhead and
+        # zero content chars. Pins the fix so a future `len(m.content)`
+        # regression (which would re-raise the #276 TypeError) is caught.
+        base = [Message(role=Role.USER, content="What is 17 * 23?")]
+        with_none = base + [Message(role=Role.ASSISTANT, content=None)]
+        assert estimate_prompt_tokens(with_none) - estimate_prompt_tokens(base) == 4


### PR DESCRIPTION
## Summary

Agents on Ollama with Qwen3-Coder crash mid-conversation with `TypeError: object of type 'NoneType' has no len()`.

A tool-call assistant turn legitimately carries `content=None` (OpenAI chat schema), and Qwen3 on Ollama produces exactly this — text routes through the thinking channel, so `content` comes back empty and the assistant message is stored with `content=None`. On the **next** turn, `estimate_prompt_tokens` sums `len(m.content)` over the history with no None guard and raises.

Guard with `len(m.content or "")` — a None-content message contributes 0 chars, the correct estimate for a tool-call-only turn. One line; no change for existing string-content messages.

Closes #276.

## Testing

`tests/engine/test_base.py` — `estimate_prompt_tokens` had no coverage:
- a None-content assistant message no longer raises (exact token count asserted)
- a delta test pins that a None message adds only per-message overhead, so a future `len(m.content)` regression re-raises here
- a basic multi-message count

Reproduced the crash deterministically and against a real Qwen3 model on Ollama before the fix; green after. Full engine suite passes (439), `ruff check` + `ruff format --check` clean.

## Follow-ups

Found while fixing this, filed separately to keep the PR to one change:
- #607 — `native_openhands.py` has an identical `sum(len(m.content) ...)` (same crash, different agent)
- #608 — `estimate_prompt_tokens` undercounts tool-call turns (`tool_calls` args / `reasoning_content` uncounted); `Message.content` typed `str` but holds `None`