### PR TITLE
feat(scan): add application data-boundary diagnostic mode

### DIFF
--- a/docs/user-guide/data-boundary-scan.md
+++ b/docs/user-guide/data-boundary-scan.md
@@ -1,0 +1,165 @@
+# Data-boundary scan
+
+`jarvis scan --data-boundaries` reports application-level data boundaries in the
+current OpenJarvis configuration. It complements the existing host/environment
+scan, which checks OS posture such as disk encryption, cloud-sync agents, remote
+access tools, and exposed engine ports.
+
+The data-boundary scan is a configuration diagnostic. It is not a vulnerability
+scanner, a legal privacy assessment, a network monitor, or an OAuth-scope audit.
+
+## Run the scan
+
+```bash
+jarvis scan --data-boundaries
+jarvis scan --data-boundaries --json
+jarvis scan --data-boundaries --json --show-paths
+jarvis scan --data-boundaries --strict
+```
+
+`--strict` exits with status code `1` when the report contains either a `fail`
+or a `warn` finding. Use it when CI or pre-demo checks need to enforce a
+conservative local-only posture.
+
+Without `--strict`, the command always exits `0` even when fail or warn findings
+are present. This is useful for exploratory review.
+
+On a fresh `jarvis init` configuration, common warn findings include
+`server.host = "0.0.0.0"` and `telemetry.enabled = true`. Running
+`jarvis scan --data-boundaries --strict` after init therefore exits `1` until
+those defaults are tightened.
+
+Absolute paths and connector file basenames are redacted by default so JSON
+reports can be pasted into issues without revealing local usernames, mount
+points, or account labels. Use `--show-paths` only for local debugging.
+
+## What it checks
+
+The scan inspects configuration values, environment-variable presence, and the
+existence of known local runtime files. It does not read private content from
+memory databases, trace databases, connector credentials, prompt files, logs, or
+OAuth token files.
+
+The current checks cover:
+
+- cloud-capable model provider, engine, and default model settings
+- local memory context injection combined with cloud-capable inference
+- traces, telemetry, learning, training, and spec-search settings
+- automatic memory service (`tools.storage.enabled` / `[memory].enabled`)
+- deep research engine and model settings
+- security bypass flags when cloud inference is configured
+- unset `security.profile` (informational)
+- web search, browser, local file, shell, code, and MCP tool surfaces
+- server binding and unauthenticated A2A exposure
+- channel enablement, channel credential fields, and channel credential env vars
+- skills, skill auto-sync, digest sources, and cloud speech backends
+- local stores such as `memory.db`, `traces.db`, `telemetry.db`, `scheduler.db`,
+  embeddings, skill index, `.vault_key`, and memory files
+- connector credential files under `connectors/*.json`, without reading them
+- API-key environment variables such as `OPENAI_API_KEY` and `TAVILY_API_KEY`
+- a scope note for frontend credential storage when cloud/API-key surfaces exist
+
+Configured database paths (for example `traces.db_path` or `memory.db_path`)
+are resolved from config when set, not only the default locations under the
+OpenJarvis home directory.
+
+## Status levels
+
+| Status | Meaning |
+| --- | --- |
+| `fail` | A configuration composition is likely incompatible with strict local-only use. |
+| `warn` | A configured surface may send data outside the local runtime or persist sensitive data. |
+| `info` | A relevant setting or local store exists, with no immediate fail or warn condition. |
+
+The command reports potential data paths. It does not prove that a path has been
+used during a specific run.
+
+JSON output includes `"schema_version": 1` for stable downstream parsing.
+
+## Strict local-only checklist
+
+For a conservative local-only setup, review these settings:
+
+```toml
+[analytics]
+enabled = false
+
+[traces]
+enabled = false
+
+[telemetry]
+enabled = false
+
+[agent]
+context_from_memory = false
+
+[intelligence]
+provider = ""
+preferred_engine = ""
+default_model = ""  # local model name only
+
+[engine]
+default = "ollama"  # or another local engine
+
+[tools]
+enabled = ""
+
+[tools.storage]
+enabled = false
+
+[tools.mcp]
+enabled = false
+servers = ""
+
+[channel]
+enabled = false
+
+[learning]
+enabled = false
+auto_update = false
+training_enabled = false
+
+[learning.spec_search]
+enabled = false
+
+[server]
+host = "127.0.0.1"
+
+[security]
+profile = "personal"
+
+[a2a]
+enabled = false
+```
+
+Also unset cloud and channel credentials from the process environment when they
+are not needed.
+
+## Scope and non-goals
+
+The scan intentionally avoids reading private data. In particular, it does not:
+
+- read connector JSON contents or OAuth scopes
+- inspect browser `localStorage` or Tauri secure storage
+- inspect frontend credential storage directly
+- inspect installed skill source code
+- intercept runtime network traffic
+- classify provider retention or training policies
+- prove that a configured path was used at runtime
+
+Frontend credential storage is tracked separately from this CLI diagnostic. If a
+cloud/API-key surface is present, the scan emits an informational scope note so
+users know that browser/Tauri credential storage must be reviewed separately.
+
+## Configuration resolution
+
+The scan follows the same explicit configuration override used by the runtime:
+if `OPENJARVIS_CONFIG` is set, that file is audited. Otherwise the scan uses
+the default OpenJarvis config path under the resolved OpenJarvis home. If the
+home directory cannot be resolved, the command reports a `config-root-error`
+finding instead of crashing.
+
+## See also
+
+- [Security](security.md) — three-layer security model (host scan, config scan, BoundaryGuard)
+- [Configuration](../getting-started/configuration.md) — full config reference

--- a/docs/user-guide/security.md
+++ b/docs/user-guide/security.md
@@ -2,6 +2,20 @@
 
 OpenJarvis includes a security layer that scans prompts and model outputs for secrets, personally identifiable information (PII), and sensitive file paths. The system is designed to be composable: scanners run as a pipeline, and the `GuardrailsEngine` wrapper drops in front of any inference backend without changing how the rest of your code works.
 
+## Three layers of security review
+
+OpenJarvis separates host posture, application data boundaries, and runtime prompt guardrails:
+
+| Layer | Command / component | What it checks |
+| --- | --- | --- |
+| Host scan | `jarvis scan` | Disk encryption, cloud-sync agents, exposed engine ports, remote-access tools |
+| Data-boundary scan | `jarvis scan --data-boundaries` | Configured inference, memory, traces, channels, tools, and local stores |
+| Runtime guardrails | `GuardrailsEngine` / BoundaryGuard | Secrets, PII, and file-policy violations in live prompts and outputs |
+
+Use the host scan before storing sensitive data on the machine. Use the data-boundary scan to verify whether your `config.toml` is local-only, cloud-capable, or mixed. Use BoundaryGuard during inference when you need live redaction or blocking.
+
+See [Data Boundary Scan](data-boundary-scan.md) for the application config diagnostic and [BoundaryGuard](#guardrailsengine) below for runtime scanning.
+
 ---
 
 ## Overview
@@ -446,8 +460,27 @@ guarded = GuardrailsEngine(
 
 ---
 
+## Privacy and data-boundary diagnostics
+
+OpenJarvis provides three complementary security layers:
+
+1. **Host scan** — `jarvis scan` (without flags) checks OS posture: disk encryption,
+   cloud-sync agents, remote-access tools, and exposed engine ports.
+2. **Config scan** — `jarvis scan --data-boundaries` audits application configuration,
+   environment-variable presence, and known local runtime stores without reading
+   private file contents. Use `--strict` in CI to fail on warn/fail findings.
+3. **BoundaryGuard** — runtime guardrails (`GuardrailsEngine`, scanners, file policy)
+   that redact or block secrets, PII, and sensitive paths during inference.
+
+The host and config scans are offline diagnostics. BoundaryGuard enforces policy
+during live agent runs. See [Data Boundary Scan](data-boundary-scan.md) for the
+full config-scan reference.
+
+---
+
 ## See Also
 
+- [Data Boundary Scan](data-boundary-scan.md) — application config and local-store diagnostic (`jarvis scan --data-boundaries`)
 - [Architecture: Security](../architecture/security.md) — pipeline design, event flow, and file policy integration
 - [API Reference: Security](../api-reference/openjarvis/security/index.md) — full class and function signatures
 - [Tools](tools.md) — how `FileReadTool` uses file policy

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -197,6 +197,7 @@ nav:
       - Evaluations: user-guide/evaluations.md
       - Benchmarks: user-guide/benchmarks.md
       - Security: user-guide/security.md
+      - Data Boundary Scan: user-guide/data-boundary-scan.md
       - LLM-guided spec search: user-guide/llm-guided-spec-search.md
   - Leaderboard: leaderboard.md
   - Roadmap: development/roadmap.md

--- a/scripts/apply_data_boundary_scan_patch.ps1
+++ b/scripts/apply_data_boundary_scan_patch.ps1
@@ -1,0 +1,56 @@
+# Apply data-boundary scan files from the PR package into the OpenJarvis repo.
+# Run from the repository root:
+#   powershell -ExecutionPolicy Bypass -File scripts/apply_data_boundary_scan_patch.ps1 -PackageDir C:\path\to\openjarvis_data_boundary_scan_pr_package_v5
+
+param(
+    [string]$PackageDir = (Join-Path $PSScriptRoot "..\..\Downloads\openjarvis_data_boundary_scan_pr_package_v5")
+)
+
+$ErrorActionPreference = "Stop"
+$RepoDir = (Get-Location).Path
+
+$required = @(
+    "pyproject.toml",
+    "src\openjarvis\cli\scan_cmd.py",
+    "src\openjarvis\cli\__init__.py"
+)
+foreach ($item in $required) {
+    if (-not (Test-Path (Join-Path $RepoDir $item))) {
+        throw "Expected to run from the OpenJarvis repository root; missing $item"
+    }
+}
+
+$NewFiles = Join-Path $PackageDir "new_files"
+if (-not (Test-Path $NewFiles)) {
+    throw "Package new_files directory not found: $NewFiles"
+}
+
+$dirs = @(
+    "src\openjarvis\security",
+    "tests\security",
+    "tests\cli",
+    "docs\user-guide",
+    "scripts"
+)
+foreach ($dir in $dirs) {
+    New-Item -ItemType Directory -Force -Path (Join-Path $RepoDir $dir) | Out-Null
+}
+
+$copyMap = @{
+    "src\openjarvis\security\data_boundary_audit.py" = "src\openjarvis\security\data_boundary_audit.py"
+    "src\openjarvis\cli\scan_cmd.py" = "src\openjarvis\cli\scan_cmd.py"
+    "src\openjarvis\cli\__init__.py" = "src\openjarvis\cli\__init__.py"
+    "tests\security\test_data_boundary_audit.py" = "tests\security\test_data_boundary_audit.py"
+    "tests\cli\test_scan_data_boundaries.py" = "tests\cli\test_scan_data_boundaries.py"
+    "docs\user-guide\data-boundary-scan.md" = "docs\user-guide\data-boundary-scan.md"
+}
+
+foreach ($entry in $copyMap.GetEnumerator()) {
+    $source = Join-Path $NewFiles $entry.Key
+    $dest = Join-Path $RepoDir $entry.Value
+    Copy-Item -Path $source -Destination $dest -Force
+}
+
+Write-Host "Applied data-boundary scan files from package."
+Write-Host "Note: mkdocs.yml nav entry and security.md cross-link must be merged manually if not already present."
+Write-Host "Inspect with: git diff"

--- a/src/openjarvis/cli/__init__.py
+++ b/src/openjarvis/cli/__init__.py
@@ -43,6 +43,13 @@ from openjarvis.cli.vault_cmd import vault
 from openjarvis.cli.workflow_cmd import workflow
 
 
+def _should_skip_update_check(ctx: click.Context, argv: list[str]) -> bool:
+    """Return true for commands whose diagnostics should remain local-only."""
+    if "--research" in argv:
+        return True
+    return ctx.invoked_subcommand == "scan" and "--data-boundaries" in argv
+
+
 @click.group(
     help="OpenJarvis — modular AI assistant backend",
     invoke_without_command=True,
@@ -63,11 +70,13 @@ def cli(ctx: click.Context, verbose: bool, quiet: bool) -> None:
     # Check for updates on interactive commands. The banner is noise in
     # demo recordings of ``jarvis ask --research``, so skip it whenever
     # the research flag is in argv (cheap argv sniff — Click hasn't
-    # parsed the subcommand's args yet at this point).
+    # parsed the subcommand's args yet at this point). Also skip
+    # ``jarvis scan --data-boundaries`` because it is intended to be a
+    # local application-data diagnostic with no outbound calls.
     import sys
 
-    research_mode_active = "--research" in sys.argv
-    if not quiet and ctx.invoked_subcommand and not research_mode_active:
+    skip_update_check = _should_skip_update_check(ctx, sys.argv[1:])
+    if not quiet and ctx.invoked_subcommand and not skip_update_check:
         import threading
 
         from openjarvis.cli._version_check import check_for_updates

--- a/src/openjarvis/cli/scan_cmd.py
+++ b/src/openjarvis/cli/scan_cmd.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -11,7 +12,11 @@ from typing import Callable, List
 
 import click
 
-from openjarvis.core.paths import get_config_dir
+from openjarvis.core.paths import get_config_dir, get_config_path
+from openjarvis.security.data_boundary_audit import (
+    DataBoundaryReport,
+    build_data_boundary_report,
+)
 
 # Engine ports that should only be listening on localhost.
 _ENGINE_PORTS = {11434, 8080, 8000, 30000, 1234, 52415, 18181}
@@ -441,8 +446,37 @@ _RICH_ICONS = {
     "ok": "[green]\u2713[/green]",
     "warn": "[yellow]![/yellow]",
     "fail": "[red]\u2717[/red]",
+    "info": "[blue]i[/blue]",
     "skip": "[dim]-[/dim]",
 }
+
+
+def _resolve_data_boundary_config_path() -> Path:
+    env_config = os.environ.get("OPENJARVIS_CONFIG")
+    if env_config:
+        return Path(env_config).expanduser().resolve()
+    return get_config_path()
+
+
+def _load_data_boundary_config():
+    """Load config without treating missing config as active."""
+    from openjarvis.core.config import JarvisConfig, load_config
+
+    root = None
+    root_error = ""
+    try:
+        root = get_config_dir()
+        config_path = _resolve_data_boundary_config_path()
+    except Exception as exc:
+        config_path = None
+        root_error = f"{type(exc).__name__}: {exc}"
+
+    if config_path is None or not config_path.exists():
+        return JarvisConfig(), root, False, "", root_error
+    try:
+        return load_config(config_path), root, True, "", root_error
+    except Exception as exc:
+        return JarvisConfig(), root, False, f"{type(exc).__name__}: {exc}", root_error
 
 
 def _render_results(results: List[ScanResult]) -> None:
@@ -494,17 +528,125 @@ def _render_results(results: List[ScanResult]) -> None:
         console.print()
 
 
+def _render_data_boundary_report(
+    report: DataBoundaryReport,
+    *,
+    show_paths: bool,
+) -> None:
+    """Render application data-boundary findings as a Rich table."""
+    from rich.console import Console
+    from rich.table import Table
+
+    console = Console()
+    console.print()
+    console.print("[bold]OpenJarvis Data-Boundary Scan[/bold]")
+    console.print(f"Verdict: [bold]{report.verdict}[/bold]")
+    console.print()
+
+    table = Table(show_header=True, header_style="bold", show_lines=True)
+    table.add_column("", width=3, justify="center")
+    table.add_column("Finding")
+    table.add_column("Recommendation")
+
+    for finding in report.findings:
+        icon = _RICH_ICONS.get(finding.status, "?")
+        style = {"fail": "red", "warn": "yellow", "info": "blue"}.get(
+            finding.status,
+            "white",
+        )
+        details = [f"[{style}]{finding.title}[/{style}]"]
+        details.append(f"[dim]{finding.potential_data_path}[/dim]")
+        if finding.location:
+            location = (
+                finding.absolute_location if show_paths else finding.location
+            )
+            details.append(f"[dim]Location: {location}[/dim]")
+        table.add_row(icon, "\n".join(details), finding.recommendation)
+
+    console.print(table)
+    summary = report.summary()
+    console.print()
+    console.print(
+        f"  [red]{summary['fail']} fail[/red], "
+        f"[yellow]{summary['warn']} warning(s)[/yellow], "
+        f"[blue]{summary['info']} info[/blue]"
+    )
+    if not show_paths:
+        console.print(
+            "  [dim]Absolute paths and connector basenames are redacted by default. "
+            "Use --show-paths for local debugging.[/dim]"
+        )
+    console.print()
+
+
+def _emit_data_boundary_json(
+    report: DataBoundaryReport,
+    *,
+    show_paths: bool,
+) -> None:
+    click.echo(json.dumps(report.to_dict(show_paths=show_paths), indent=2))
+
+
 @click.command()
 @click.option("--quick", is_flag=True, default=False, help="Run only critical checks.")
 @click.option("--json", "as_json", is_flag=True, default=False, help="Output as JSON.")
-def scan(quick: bool, as_json: bool) -> None:
+@click.option(
+    "--data-boundaries",
+    is_flag=True,
+    default=False,
+    help="Run application data-boundary checks instead of host checks.",
+)
+@click.option(
+    "--strict",
+    is_flag=True,
+    default=False,
+    help="Exit non-zero if data-boundary fail or warn findings are present.",
+)
+@click.option(
+    "--show-paths",
+    is_flag=True,
+    default=False,
+    help="Show absolute paths in data-boundary output.",
+)
+def scan(
+    quick: bool,
+    as_json: bool,
+    data_boundaries: bool,
+    strict: bool,
+    show_paths: bool,
+) -> None:
     """Audit your environment for privacy and security risks."""
+    if data_boundaries:
+        if quick:
+            raise click.UsageError("--quick cannot be combined with --data-boundaries.")
+        config, root, config_loaded, config_error, root_error = (
+            _load_data_boundary_config()
+        )
+        report = build_data_boundary_report(
+            config,
+            root,
+            config_loaded=config_loaded,
+            config_error=config_error,
+            root_error=root_error,
+        )
+        if as_json:
+            _emit_data_boundary_json(report, show_paths=show_paths)
+        else:
+            _render_data_boundary_report(report, show_paths=show_paths)
+        summary = report.summary()
+        if strict and (summary["fail"] or summary["warn"]):
+            raise click.exceptions.Exit(1)
+        return
+
+    if strict or show_paths:
+        raise click.UsageError(
+            "--strict and --show-paths are only supported with --data-boundaries."
+        )
+
     scanner = PrivacyScanner()
     results: List[ScanResult] = scanner.run_quick() if quick else scanner.run_all()
 
     if as_json:
-        import json as json_mod
-
         output = [
             {
                 "name": r.name,
@@ -514,7 +656,7 @@ def scan(quick: bool, as_json: bool) -> None:
             }
             for r in results
         ]
-        click.echo(json_mod.dumps(output, indent=2))
+        click.echo(json.dumps(output, indent=2))
         return
 
     if not results:

--- a/src/openjarvis/security/data_boundary_audit.py
+++ b/src/openjarvis/security/data_boundary_audit.py
@@ -1,0 +1,1355 @@
+"""Application data-boundary diagnostics for OpenJarvis.
+
+The report builder intentionally limits itself to configuration values,
+environment-key presence, and file existence. It never reads private user
+content from connector credential files, memory files, trace databases, logs, or
+other local runtime stores.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Literal
+
+Status = Literal["fail", "warn", "info"]
+
+CLOUD_PROVIDER_KEYS = {
+    "anthropic",
+    "claude",
+    "cloud",
+    "codex",
+    "deepseek",
+    "gemini",
+    "google",
+    "litellm",
+    "minimax",
+    "openai",
+    "openrouter",
+}
+
+LOCAL_ENGINE_KEYS = {
+    "apple_fm",
+    "exo",
+    "gemma_cpp",
+    "lemonade",
+    "llamacpp",
+    "lmstudio",
+    "mlx",
+    "nexa",
+    "ollama",
+    "sglang",
+    "uzu",
+    "vllm",
+}
+
+API_KEY_ENV_VARS = {
+    "ANTHROPIC_API_KEY": ("Anthropic cloud inference", {"anthropic", "claude"}),
+    "DEEPSEEK_API_KEY": ("DeepSeek cloud inference", {"deepseek"}),
+    "GOOGLE_API_KEY": ("Google/Gemini cloud inference", {"google", "gemini"}),
+    "MINIMAX_API_KEY": ("MiniMax cloud inference", {"minimax"}),
+    "OPENAI_API_KEY": ("OpenAI cloud inference", {"openai", "gpt"}),
+    "OPENROUTER_API_KEY": ("OpenRouter cloud inference", {"openrouter"}),
+    "TAVILY_API_KEY": ("Tavily web search", {"tavily", "web_search"}),
+}
+
+CHANNEL_SECRET_FIELDS: tuple[tuple[str, str, str], ...] = (
+    ("channel.telegram.bot_token", "Telegram bot token", "Telegram"),
+    ("channel.discord.bot_token", "Discord bot token", "Discord"),
+    ("channel.slack.bot_token", "Slack bot token", "Slack"),
+    ("channel.slack.app_token", "Slack app token", "Slack"),
+    ("channel.webhook.secret", "Webhook secret", "generic webhook"),
+    ("channel.email.password", "Email password", "email"),
+    ("channel.whatsapp.access_token", "WhatsApp access token", "WhatsApp"),
+    ("channel.irc.password", "IRC password", "IRC"),
+    ("channel.teams.app_password", "Teams app password", "Teams"),
+    ("channel.matrix.access_token", "Matrix access token", "Matrix"),
+    ("channel.mattermost.token", "Mattermost token", "Mattermost"),
+    ("channel.feishu.app_secret", "Feishu app secret", "Feishu"),
+    ("channel.bluebubbles.password", "BlueBubbles password", "BlueBubbles"),
+)
+
+CHANNEL_REFERENCE_FIELDS: tuple[tuple[str, str, str], ...] = (
+    ("channel.webhook.url", "Webhook URL", "generic webhook"),
+    ("channel.email.smtp_host", "Email SMTP host", "email"),
+    ("channel.email.imap_host", "Email IMAP host", "email"),
+    ("channel.email.username", "Email username", "email"),
+    ("channel.whatsapp.phone_number_id", "WhatsApp phone number ID", "WhatsApp"),
+    ("channel.signal.api_url", "Signal API URL", "Signal"),
+    ("channel.signal.phone_number", "Signal phone number", "Signal"),
+    ("channel.google_chat.webhook_url", "Google Chat webhook URL", "Google Chat"),
+    ("channel.irc.server", "IRC server", "IRC"),
+    ("channel.irc.nick", "IRC nick", "IRC"),
+    ("channel.teams.app_id", "Teams app ID", "Teams"),
+    ("channel.teams.service_url", "Teams service URL", "Teams"),
+    ("channel.matrix.homeserver", "Matrix homeserver", "Matrix"),
+    ("channel.mattermost.url", "Mattermost URL", "Mattermost"),
+    ("channel.feishu.app_id", "Feishu app ID", "Feishu"),
+    ("channel.bluebubbles.url", "BlueBubbles URL", "BlueBubbles"),
+)
+
+CHANNEL_SECRET_ENV_VARS = {
+    "BLUEBUBBLES_PASSWORD": "BlueBubbles channel",
+    "DISCORD_BOT_TOKEN": "Discord channel",
+    "FEISHU_APP_SECRET": "Feishu channel",
+    "MATTERMOST_TOKEN": "Mattermost channel",
+    "MATRIX_ACCESS_TOKEN": "Matrix channel",
+    "SLACK_APP_TOKEN": "Slack channel",
+    "SLACK_BOT_TOKEN": "Slack channel",
+    "TEAMS_APP_PASSWORD": "Teams channel",
+    "TELEGRAM_BOT_TOKEN": "Telegram channel",
+    "WHATSAPP_ACCESS_TOKEN": "WhatsApp channel",
+}
+
+CHANNEL_REFERENCE_ENV_VARS = {
+    "BLUEBUBBLES_URL": "BlueBubbles channel",
+    "FEISHU_APP_ID": "Feishu channel",
+    "GOOGLE_CHAT_WEBHOOK_URL": "Google Chat channel",
+    "MATTERMOST_URL": "Mattermost channel",
+    "MATRIX_HOMESERVER": "Matrix channel",
+    "SIGNAL_PHONE_NUMBER": "Signal channel",
+    "TEAMS_APP_ID": "Teams channel",
+    "WHATSAPP_PHONE_NUMBER_ID": "WhatsApp channel",
+}
+
+LOCAL_STORE_CANDIDATES: tuple[tuple[str, str, str, Status], ...] = (
+    ("config-file", "Configuration file", "config.toml", "info"),
+    ("memory-db", "Memory index database", "memory.db", "warn"),
+    ("memory-facts", "Persistent memory facts", "memory_facts.jsonl", "warn"),
+    ("traces-db", "Trace database", "traces.db", "warn"),
+    ("telemetry-db", "Telemetry database", "telemetry.db", "info"),
+    ("audit-db", "Security audit database", "audit.db", "info"),
+    ("sessions-db", "Session database", "sessions.db", "warn"),
+    ("agents-db", "Agent manager database", "agents.db", "warn"),
+    ("optimize-db", "Optimization database", "optimize.db", "warn"),
+    ("scheduler-db", "Scheduler database", "scheduler.db", "warn"),
+    ("skill-index", "Skill index directory", "skill-index", "info"),
+    ("vault-key", "Vault encryption key", ".vault_key", "warn"),
+    ("embeddings-store", "Embeddings store", "embeddings", "warn"),
+    ("soul-file", "SOUL memory file", "SOUL.md", "warn"),
+    ("memory-file", "MEMORY memory file", "MEMORY.md", "warn"),
+    ("user-file", "USER memory file", "USER.md", "warn"),
+)
+
+_CONFIG_STORE_PATHS: tuple[tuple[str, str, str, Status], ...] = (
+    ("memory-db", "Memory index database", "tools.storage.db_path", "warn"),
+    ("memory-facts", "Persistent memory facts", "tools.storage.facts_path", "warn"),
+    ("traces-db", "Trace database", "traces.db_path", "warn"),
+    ("telemetry-db", "Telemetry database", "telemetry.db_path", "info"),
+    ("audit-db", "Security audit database", "security.audit_log_path", "info"),
+    ("sessions-db", "Session database", "sessions.db_path", "warn"),
+    ("agents-db", "Agent manager database", "agents.db_path", "warn"),
+    ("optimize-db", "Optimization database", "optimize.db_path", "warn"),
+    ("vault-key", "Vault encryption key", "security.vault_key_path", "warn"),
+    ("scheduler-db", "Scheduler database", "scheduler.db_path", "warn"),
+    ("skill-index", "Skill index directory", "skills.index_dir", "info"),
+)
+
+PERSONAL_DIGEST_SOURCES = {
+    "apple_health",
+    "dropbox",
+    "gcalendar",
+    "gcontacts",
+    "gdrive",
+    "github",
+    "gmail",
+    "google_tasks",
+    "imessage",
+    "notion",
+    "obsidian",
+    "oura",
+    "outlook",
+    "slack",
+    "spotify",
+    "strava",
+    "whatsapp",
+}
+
+WEB_SEARCH_TOOLS = {"web_search", "search", "tavily_search"}
+BROWSER_TOOLS = {"browser", "browser_open", "browser_search", "web_browser"}
+LOCAL_ACCESS_TOOLS = {"code_interpreter", "file_read", "shell_exec"}
+
+
+@dataclass(frozen=True, slots=True)
+class DataBoundaryFinding:
+    """One application data-boundary finding."""
+
+    id: str
+    status: Status
+    title: str
+    potential_data_path: str
+    evidence: str
+    recommendation: str
+    location: str = ""
+    absolute_location: str = ""
+
+    def to_dict(self, *, show_paths: bool = False) -> dict[str, str]:
+        """Return a stable JSON-serializable representation.
+
+        Absolute paths and connector basenames are redacted by default. When
+        ``show_paths`` is true, the location field exposes the absolute path for
+        local debugging.
+        """
+        payload = {
+            "id": self.id,
+            "status": self.status,
+            "title": self.title,
+            "potential_data_path": self.potential_data_path,
+            "evidence": self.evidence,
+            "recommendation": self.recommendation,
+        }
+        if self.absolute_location:
+            payload["location"] = (
+                self.absolute_location if show_paths else self.location
+            )
+        elif self.location:
+            payload["location"] = self.location
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
+class DataBoundaryReport:
+    """Structured result returned by the data-boundary audit."""
+
+    verdict: str
+    root: str
+    config_loaded: bool
+    findings: tuple[DataBoundaryFinding, ...]
+
+    def summary(self) -> dict[str, int]:
+        """Count findings by status."""
+        counts = {"fail": 0, "warn": 0, "info": 0}
+        for finding in self.findings:
+            counts[finding.status] += 1
+        return counts
+
+    def to_dict(self, *, show_paths: bool = False) -> dict[str, Any]:
+        """Return a stable JSON-serializable representation."""
+        return {
+            "schema_version": 1,
+            "verdict": self.verdict,
+            "root": self.root if show_paths else _redact_root(self.root),
+            "config_loaded": self.config_loaded,
+            "summary": self.summary(),
+            "findings": [
+                finding.to_dict(show_paths=show_paths)
+                for finding in self.findings
+            ],
+        }
+
+
+class _FindingBuilder:
+    """Small helper that preserves insertion order and deduplicates by id."""
+
+    def __init__(self) -> None:
+        self._findings: list[DataBoundaryFinding] = []
+        self._seen: set[str] = set()
+
+    def add(
+        self,
+        *,
+        finding_id: str,
+        status: Status,
+        title: str,
+        potential_data_path: str,
+        evidence: str,
+        recommendation: str,
+        location: str = "",
+        absolute_location: str = "",
+    ) -> None:
+        if finding_id in self._seen:
+            return
+        self._seen.add(finding_id)
+        self._findings.append(
+            DataBoundaryFinding(
+                id=finding_id,
+                status=status,
+                title=title,
+                potential_data_path=potential_data_path,
+                evidence=evidence,
+                recommendation=recommendation,
+                location=location,
+                absolute_location=absolute_location,
+            )
+        )
+
+    def build(self) -> tuple[DataBoundaryFinding, ...]:
+        return tuple(self._findings)
+
+
+def build_data_boundary_report(
+    config: Any,
+    root: Path | None,
+    *,
+    config_loaded: bool = True,
+    config_error: str = "",
+    root_error: str = "",
+) -> DataBoundaryReport:
+    """Build a data-boundary report from config and runtime paths.
+
+    The function is side-effect-free. It uses defensive ``getattr`` access so
+    the command remains robust across configuration additions.
+    """
+
+    builder = _FindingBuilder()
+    root_path: Path | None = None
+    root_label = "<unresolved-openjarvis-home>"
+    if root is not None:
+        try:
+            root_path = root.expanduser().resolve()
+            root_label = str(root_path)
+        except Exception as exc:  # pragma: no cover - defensive path handling
+            root_error = f"{type(exc).__name__}: {exc}"
+
+    if root_error:
+        builder.add(
+            finding_id="config-root-error",
+            status="fail",
+            title="OpenJarvis home directory could not be resolved",
+            potential_data_path="runtime state root -> local store checks",
+            evidence=_truncate(root_error),
+            recommendation=(
+                "Fix OPENJARVIS_HOME or XDG_DATA_HOME before relying on "
+                "local-store data-boundary checks."
+            ),
+        )
+
+    if config_error:
+        builder.add(
+            finding_id="config-load-error",
+            status="fail",
+            title="OpenJarvis config could not be loaded",
+            potential_data_path="config.toml -> data-boundary report",
+            evidence=_truncate(config_error),
+            recommendation=(
+                "Fix the configuration file before relying on config-derived "
+                "data-boundary checks. Local store and environment checks still run."
+            ),
+        )
+    elif config_loaded:
+        _audit_outbound_settings(config, builder)
+        _audit_telemetry_settings(config, builder)
+        _audit_memory_cloud_composition(config, builder)
+        _audit_memory_service(config, builder)
+        _audit_deep_research_settings(config, builder)
+        _audit_trace_and_learning_settings(config, builder)
+        _audit_tool_surfaces(config, builder)
+        _audit_server_exposure(config, builder)
+        _audit_channel_settings(config, builder)
+        _audit_skills_and_digest(config, builder)
+        _audit_speech_settings(config, builder)
+    elif not root_error:
+        builder.add(
+            finding_id="config-file-missing",
+            status="info",
+            title="OpenJarvis config file was not found",
+            potential_data_path="configuration defaults -> data-boundary report",
+            evidence="config_loaded = false",
+            recommendation=(
+                "Run `jarvis init` before relying on config-derived checks. "
+                "Local store and environment checks still run."
+            ),
+        )
+
+    active_tools = (
+        _configured_tools(config)
+        if config_loaded and not config_error
+        else set()
+    )
+    active_config = config if config_loaded and not config_error else None
+    if active_config is not None:
+        _audit_security_settings(
+            active_config,
+            builder,
+            has_cloud_surface=_has_cloud_or_api_surface(active_config, active_tools),
+        )
+
+    if root_path is not None:
+        _audit_local_stores(root_path, builder, config=active_config)
+        _audit_connector_credentials(root_path, builder)
+        if active_config is not None:
+            _audit_local_channel_credential_dirs(active_config, root_path, builder)
+    _audit_environment_credentials(
+        active_config,
+        builder,
+        active_tools=active_tools,
+    )
+    _audit_channel_environment_credentials(active_config, builder)
+    if _has_cloud_or_api_surface(active_config, active_tools):
+        _audit_frontend_storage_scope(builder)
+
+    findings = builder.build()
+    return DataBoundaryReport(
+        verdict=_derive_verdict(findings),
+        root=root_label,
+        config_loaded=config_loaded and not bool(config_error),
+        findings=findings,
+    )
+
+
+def _audit_outbound_settings(config: Any, builder: _FindingBuilder) -> None:
+    if bool(_get(config, "analytics.enabled", False)):
+        builder.add(
+            finding_id="analytics-enabled",
+            status="info",
+            title="Outbound usage analytics are enabled",
+            potential_data_path="runtime usage events -> analytics endpoint",
+            evidence="analytics.enabled = true",
+            recommendation=(
+                "Set analytics.enabled = false for no outbound usage analytics. "
+                "This finding does not assert that prompt content is sent."
+            ),
+        )
+
+    provider = _get(config, "intelligence.provider", "")
+    if _is_cloud_value(provider):
+        builder.add(
+            finding_id="cloud-provider-configured",
+            status="warn",
+            title="Cloud model provider configured",
+            potential_data_path=(
+                "prompts, memory context, and tool outputs -> cloud provider"
+            ),
+            evidence=f"intelligence.provider = {_quote(provider)}",
+            recommendation=(
+                "Review what context is sent before enabling cloud inference, "
+                "or use a local provider for local-only operation."
+            ),
+        )
+
+    default_model = _get(config, "intelligence.default_model", "")
+    if _looks_like_cloud_model(default_model):
+        builder.add(
+            finding_id="cloud-default-model-configured",
+            status="warn",
+            title="Cloud default model configured",
+            potential_data_path="model requests -> default cloud model",
+            evidence=f"intelligence.default_model = {_quote(default_model)}",
+            recommendation=(
+                "Use a local default model for local-only operation."
+            ),
+        )
+
+    preferred_engine = _get(config, "intelligence.preferred_engine", "")
+    if _is_cloud_value(preferred_engine):
+        builder.add(
+            finding_id="cloud-preferred-engine-configured",
+            status="warn",
+            title="Cloud preferred engine configured",
+            potential_data_path="model requests -> preferred cloud engine",
+            evidence=f"intelligence.preferred_engine = {_quote(preferred_engine)}",
+            recommendation="Use a local preferred engine for local-only operation.",
+        )
+
+    default_engine = _get(config, "engine.default", "")
+    if _is_cloud_value(default_engine):
+        builder.add(
+            finding_id="cloud-default-engine-configured",
+            status="warn",
+            title="Cloud default engine configured",
+            potential_data_path="model requests -> default cloud engine",
+            evidence=f"engine.default = {_quote(default_engine)}",
+            recommendation="Use a local default engine for local-only operation.",
+        )
+
+    optimize_provider = _get(config, "optimize.optimizer_provider", "")
+    if _is_cloud_value(optimize_provider):
+        builder.add(
+            finding_id="cloud-optimizer-provider-configured",
+            status="info",
+            title="Cloud optimizer provider is configured",
+            potential_data_path="optimization context -> optimizer provider",
+            evidence=f"optimize.optimizer_provider = {_quote(optimize_provider)}",
+            recommendation=(
+                "Before running optimization, review whether examples, traces, "
+                "or prompts may be sent to this provider."
+            ),
+        )
+
+    judge_model = _get(config, "optimize.judge_model", "")
+    if _looks_like_cloud_model(judge_model):
+        builder.add(
+            finding_id="cloud-judge-model-configured",
+            status="info",
+            title="Cloud judge model appears configured",
+            potential_data_path="optimization examples/results -> judge model",
+            evidence=f"optimize.judge_model = {_quote(judge_model)}",
+            recommendation="Use a local judge model for local-only optimization.",
+        )
+
+
+def _audit_telemetry_settings(config: Any, builder: _FindingBuilder) -> None:
+    if bool(_get(config, "telemetry.enabled", False)):
+        builder.add(
+            finding_id="telemetry-enabled",
+            status="warn",
+            title="Telemetry capture is enabled",
+            potential_data_path=(
+                "runtime metrics and inference events -> telemetry database"
+            ),
+            evidence="telemetry.enabled = true",
+            recommendation=(
+                "Disable telemetry when local-only metrics collection is not "
+                "needed. Treat telemetry.db as sensitive when enabled."
+            ),
+        )
+
+
+def _audit_memory_service(config: Any, builder: _FindingBuilder) -> None:
+    if not bool(_get(config, "tools.storage.enabled", False)):
+        return
+    cloud_signals = [
+        _get(config, "intelligence.provider", ""),
+        _get(config, "intelligence.preferred_engine", ""),
+        _get(config, "engine.default", ""),
+        _get(config, "intelligence.default_model", ""),
+    ]
+    has_cloud = any(
+        _is_cloud_value(value) or _looks_like_cloud_model(value)
+        for value in cloud_signals
+    )
+    evidence = "tools.storage.enabled = true"
+    if has_cloud:
+        evidence += "; cloud inference surface detected"
+    builder.add(
+        finding_id="memory-service-enabled",
+        status="warn",
+        title="Automatic memory service is enabled",
+        potential_data_path=(
+            "conversation content -> extracted facts -> local memory store"
+        ),
+        evidence=evidence,
+        recommendation=(
+            "Review what conversations are persisted before enabling the "
+            "background memory service on sensitive workloads."
+        ),
+    )
+
+
+def _audit_deep_research_settings(config: Any, builder: _FindingBuilder) -> None:
+    engine = _get(config, "deep_research.engine", "")
+    model = _get(config, "deep_research.model", "")
+    cloud_engine = _is_cloud_value(engine)
+    cloud_model = _looks_like_cloud_model(model)
+    if not cloud_engine and not cloud_model:
+        return
+    evidence_parts = []
+    if cloud_engine:
+        evidence_parts.append(f"deep_research.engine = {_quote(engine)}")
+    if cloud_model:
+        evidence_parts.append(f"deep_research.model = {_quote(model)}")
+    builder.add(
+        finding_id="deep-research-cloud-configured",
+        status="warn",
+        title="Cloud deep-research engine or model configured",
+        potential_data_path="research planner context -> cloud engine/model",
+        evidence="; ".join(evidence_parts),
+        recommendation=(
+            "Use local deep-research engine and model settings for local-only "
+            "operation."
+        ),
+    )
+
+
+def _audit_security_settings(
+    config: Any,
+    builder: _FindingBuilder,
+    *,
+    has_cloud_surface: bool,
+) -> None:
+    profile = str(_get(config, "security.profile", "") or "").strip()
+    if not profile:
+        builder.add(
+            finding_id="security-profile-unset",
+            status="info",
+            title="Security profile is not set",
+            potential_data_path="security defaults -> guardrails and server posture",
+            evidence="security.profile is empty",
+            recommendation=(
+                "Set security.profile to personal, shared, or server to apply "
+                "a documented guardrails preset."
+            ),
+        )
+
+    if not has_cloud_surface:
+        return
+
+    if bool(_get(config, "security.local_engine_bypass", False)):
+        builder.add(
+            finding_id="security-local-engine-bypass-enabled",
+            status="warn",
+            title="Local engine guardrail bypass is enabled with cloud surfaces",
+            potential_data_path=(
+                "cloud-bound prompts/outputs -> guardrails bypass for local engines"
+            ),
+            evidence=(
+                "security.local_engine_bypass = true with cloud-capable settings"
+            ),
+            recommendation=(
+                "Disable local_engine_bypass unless the cloud surface is intentional "
+                "and reviewed."
+            ),
+        )
+
+    if bool(_get(config, "security.local_tool_bypass", False)):
+        builder.add(
+            finding_id="security-local-tool-bypass-enabled",
+            status="warn",
+            title="Local tool guardrail bypass is enabled with cloud surfaces",
+            potential_data_path=(
+                "cloud-bound tool arguments/results -> guardrails bypass"
+            ),
+            evidence=(
+                "security.local_tool_bypass = true with cloud-capable settings"
+            ),
+            recommendation=(
+                "Disable local_tool_bypass unless the cloud surface is intentional "
+                "and reviewed."
+            ),
+        )
+
+
+def _audit_memory_cloud_composition(
+    config: Any,
+    builder: _FindingBuilder,
+) -> None:
+    context_from_memory = bool(_get(config, "agent.context_from_memory", False))
+    cloud_signals = [
+        _get(config, "intelligence.provider", ""),
+        _get(config, "intelligence.preferred_engine", ""),
+        _get(config, "engine.default", ""),
+        _get(config, "intelligence.default_model", ""),
+    ]
+    active_cloud = [
+        str(value)
+        for value in cloud_signals
+        if _is_cloud_value(value) or _looks_like_cloud_model(value)
+    ]
+
+    if context_from_memory and active_cloud:
+        builder.add(
+            finding_id="memory-context-to-cloud-risk",
+            status="fail",
+            title="Local memory may be injected into cloud-bound prompts",
+            potential_data_path=(
+                "indexed local memory -> prompt context -> cloud inference provider"
+            ),
+            evidence=(
+                "agent.context_from_memory = true; cloud setting(s) = "
+                + ", ".join(active_cloud)
+            ),
+            recommendation=(
+                "Disable agent.context_from_memory before using cloud inference, "
+                "or use local engines when indexed memory contains sensitive data."
+            ),
+        )
+    elif context_from_memory:
+        builder.add(
+            finding_id="memory-context-injection-enabled",
+            status="info",
+            title="Memory context injection is enabled",
+            potential_data_path="indexed local memory -> future prompt context",
+            evidence="agent.context_from_memory = true",
+            recommendation=(
+                "Keep indexed memory scoped to data that may safely appear in future "
+                "prompts, especially if cloud engines are enabled later."
+            ),
+        )
+
+
+def _audit_trace_and_learning_settings(
+    config: Any,
+    builder: _FindingBuilder,
+) -> None:
+    if bool(_get(config, "traces.enabled", False)):
+        builder.add(
+            finding_id="traces-enabled",
+            status="warn",
+            title="Trace capture is enabled",
+            potential_data_path=(
+                "prompts, outputs, tool calls, and tool results -> traces database"
+            ),
+            evidence="traces.enabled = true",
+            recommendation=(
+                "Disable traces when debugging or trace-driven learning is not "
+                "needed. Treat traces.db as sensitive when enabled."
+            ),
+        )
+
+    if bool(_get(config, "learning.enabled", False)):
+        builder.add(
+            finding_id="learning-enabled",
+            status="warn",
+            title="Learning from local runtime data is enabled",
+            potential_data_path=(
+                "local traces/telemetry/feedback -> routing, agent, skill, or "
+                "model updates"
+            ),
+            evidence="learning.enabled = true",
+            recommendation=(
+                "Review active learning sub-policies before using sensitive traces."
+            ),
+        )
+
+    if bool(_get(config, "learning.training_enabled", False)):
+        builder.add(
+            finding_id="training-enabled",
+            status="warn",
+            title="Training pipeline is enabled",
+            potential_data_path="trace-derived examples -> model adapters",
+            evidence="learning.training_enabled = true",
+            recommendation=(
+                "Disable training unless trace reuse for model updates is intentional."
+            ),
+        )
+
+    if bool(_get(config, "learning.auto_update", False)):
+        builder.add(
+            finding_id="learning-auto-update-enabled",
+            status="warn",
+            title="Automatic learning updates are enabled",
+            potential_data_path="runtime feedback/traces -> automatic updates",
+            evidence="learning.auto_update = true",
+            recommendation=(
+                "Use manual updates when explicit review is needed before "
+                "trace-derived changes."
+            ),
+        )
+
+    spec_search_enabled = bool(_get(config, "learning.spec_search.enabled", False))
+    teacher_engine = _get(config, "learning.spec_search.teacher_engine", "")
+    teacher_model = _get(config, "learning.spec_search.teacher_model", "")
+    if spec_search_enabled and _is_cloud_value(teacher_engine):
+        builder.add(
+            finding_id="spec-search-cloud-teacher-enabled",
+            status="fail",
+            title="LLM-guided spec search uses a cloud teacher engine",
+            potential_data_path=(
+                "diagnostics/spec-search context -> cloud teacher model"
+            ),
+            evidence=(
+                "learning.spec_search.enabled = true; "
+                f"teacher_engine = {_quote(teacher_engine)}; "
+                f"teacher_model = {_quote(teacher_model)}"
+            ),
+            recommendation=(
+                "Use a local teacher engine/model or keep spec search disabled for "
+                "local-only operation."
+            ),
+        )
+
+
+def _audit_tool_surfaces(config: Any, builder: _FindingBuilder) -> None:
+    tools = _configured_tools(config)
+
+    if tools & WEB_SEARCH_TOOLS:
+        builder.add(
+            finding_id="web-search-tool-configured",
+            status="warn",
+            title="Web search tool is configured",
+            potential_data_path="user or agent search query -> external search service",
+            evidence=f"configured tool(s) = {_format_tools(tools & WEB_SEARCH_TOOLS)}",
+            recommendation=(
+                "Review search queries before using web search with sensitive prompts."
+            ),
+        )
+
+    if tools & BROWSER_TOOLS:
+        builder.add(
+            finding_id="browser-tool-configured",
+            status="warn",
+            title="Browser automation tool is configured",
+            potential_data_path="agent browser actions -> external web pages",
+            evidence=f"configured tool(s) = {_format_tools(tools & BROWSER_TOOLS)}",
+            recommendation=(
+                "Use browser automation only when web interactions are intentional."
+            ),
+        )
+
+    local_access = tools & LOCAL_ACCESS_TOOLS
+    if local_access:
+        builder.add(
+            finding_id="local-access-tools-configured",
+            status="info",
+            title="Local file, shell, or code tools are configured",
+            potential_data_path="local files/process output -> agent context",
+            evidence=f"configured tool(s) = {_format_tools(local_access)}",
+            recommendation=(
+                "Review tool permissions and prompts before giving the agent access "
+                "to sensitive local files or command output."
+            ),
+        )
+
+    mcp_enabled = bool(_get(config, "tools.mcp.enabled", False))
+    mcp_servers = str(_get(config, "tools.mcp.servers", "") or "").strip()
+    if mcp_enabled and mcp_servers:
+        builder.add(
+            finding_id="mcp-servers-configured",
+            status="warn",
+            title="External MCP servers are configured",
+            potential_data_path="agent tool calls/context -> configured MCP servers",
+            evidence="tools.mcp.enabled = true; tools.mcp.servers is non-empty",
+            recommendation=(
+                "Review MCP server trust, transport, and tool schemas before sending "
+                "sensitive prompts or tool arguments."
+            ),
+        )
+
+
+def _iter_local_store_targets(
+    root: Path,
+    config: Any | None,
+) -> Iterable[tuple[str, str, Path, str, Status]]:
+    """Yield store targets as (finding_id, title, path, location_label, status)."""
+    targets: dict[str, tuple[str, Path, str, Status]] = {}
+
+    for finding_id, title, relative_path, status in LOCAL_STORE_CANDIDATES:
+        targets[finding_id] = (title, root / relative_path, relative_path, status)
+
+    if config is not None:
+        for finding_id, title, dotted_path, status in _CONFIG_STORE_PATHS:
+            raw = str(_get(config, dotted_path, "") or "").strip()
+            if not raw:
+                if finding_id == "scheduler-db":
+                    path = root / "scheduler.db"
+                    location = "scheduler.db"
+                else:
+                    continue
+            else:
+                path = Path(raw).expanduser()
+                if not path.is_absolute():
+                    path = root / path
+                try:
+                    path = path.resolve()
+                except OSError:
+                    pass
+                location = _location_label(path, root)
+
+            existing = targets.get(finding_id)
+            if existing is not None and existing[1].exists() and not path.exists():
+                continue
+            targets[finding_id] = (title, path, location, status)
+
+    seen_resolved: set[str] = set()
+    for finding_id, (title, path, location, status) in targets.items():
+        try:
+            resolved_key = str(path.resolve())
+        except OSError:
+            resolved_key = str(path)
+        if resolved_key in seen_resolved:
+            continue
+        seen_resolved.add(resolved_key)
+        yield finding_id, title, path, location, status
+
+
+def _audit_local_stores(
+    root: Path,
+    builder: _FindingBuilder,
+    *,
+    config: Any | None = None,
+) -> None:
+    if not root.exists():
+        return
+    for finding_id, title, path, location, status in _iter_local_store_targets(
+        root,
+        config,
+    ):
+        if not path.exists():
+            continue
+        builder.add(
+            finding_id=f"local-store-{finding_id}",
+            status=status,
+            title=f"{title} exists locally",
+            potential_data_path=f"local runtime state -> {location}",
+            evidence=f"path exists: {location}",
+            recommendation=(
+                "Review retention, backups, and filesystem permissions for this "
+                "local store."
+            ),
+            location=location,
+            absolute_location=str(path),
+        )
+        permission_note = _permission_note(path)
+        if permission_note:
+            builder.add(
+                finding_id=f"local-store-permissions-{finding_id}",
+                status="warn",
+                title=f"{title} permissions need review",
+                potential_data_path=f"local runtime state -> {location}",
+                evidence=permission_note,
+                recommendation=(
+                    "Restrict this file or directory to the current user before "
+                    "storing sensitive data."
+                ),
+                location=location,
+                absolute_location=str(path),
+            )
+
+
+def _audit_connector_credentials(root: Path, builder: _FindingBuilder) -> None:
+    connectors_dir = root / "connectors"
+    if not connectors_dir.exists():
+        return
+    for path in sorted(connectors_dir.glob("*.json")):
+        digest = hashlib.sha256(path.name.encode("utf-8")).hexdigest()[:8]
+        builder.add(
+            finding_id=f"connector-token-{digest}",
+            status="info",
+            title="Connector credential file is present",
+            potential_data_path="connector OAuth/API credentials -> local file",
+            evidence="credential file exists under connectors/*.json",
+            recommendation=(
+                "This audit did not read the file contents. Use --show-paths for "
+                "local debugging, and review account scopes and token rotation."
+            ),
+            location="connectors/<redacted>.json",
+            absolute_location=str(path),
+        )
+
+
+def _audit_environment_credentials(
+    config: Any | None,
+    builder: _FindingBuilder,
+    *,
+    active_tools: set[str],
+) -> None:
+    active_values: set[str] = set(active_tools)
+    if config is not None:
+        active_values.update(
+            {
+                str(_get(config, "intelligence.provider", "")).lower(),
+                str(_get(config, "intelligence.preferred_engine", "")).lower(),
+                str(_get(config, "engine.default", "")).lower(),
+                str(_get(config, "intelligence.default_model", "")).lower(),
+            }
+        )
+
+    for env_name, (purpose, aliases) in sorted(API_KEY_ENV_VARS.items()):
+        if not os.environ.get(env_name):
+            continue
+        active = any(alias in value for alias in aliases for value in active_values)
+        status: Status = "warn" if active else "info"
+        builder.add(
+            finding_id=f"env-credential-{env_name.lower()}",
+            status=status,
+            title=f"Cloud/API credential available in environment: {env_name}",
+            potential_data_path=f"process environment -> {purpose}",
+            evidence=f"{env_name} is set; value was not read or printed",
+            recommendation=(
+                "Unset this variable for local-only operation. The audit reports "
+                "only presence and never prints credential values."
+            ),
+        )
+
+
+def _audit_server_exposure(config: Any, builder: _FindingBuilder) -> None:
+    host = str(_get(config, "server.host", "") or "")
+    if host in {"0.0.0.0", "::"}:
+        builder.add(
+            finding_id="server-binds-all-interfaces",
+            status="warn",
+            title="Server is configured to bind all network interfaces",
+            potential_data_path="OpenJarvis HTTP server -> local network interfaces",
+            evidence=f"server.host = {_quote(host)}",
+            recommendation=(
+                "Use server.host = '127.0.0.1' unless LAN exposure is intentional."
+            ),
+        )
+
+    a2a_enabled = bool(_get(config, "a2a.enabled", False))
+    a2a_token = str(_get(config, "a2a.auth_token", "") or "")
+    if a2a_enabled and not a2a_token:
+        builder.add(
+            finding_id="a2a-enabled-without-auth-token",
+            status="fail",
+            title="A2A server is enabled without an auth token",
+            potential_data_path="inbound A2A requests -> OpenJarvis agent runtime",
+            evidence="a2a.enabled = true; a2a.auth_token is empty",
+            recommendation=(
+                "Set a2a.auth_token or disable A2A unless the network is trusted."
+            ),
+        )
+
+
+def _audit_channel_settings(config: Any, builder: _FindingBuilder) -> None:
+    channel_enabled = bool(_get(config, "channel.enabled", False))
+    default_channel = str(_get(config, "channel.default_channel", "") or "")
+    configured_secrets = _non_empty_paths(config, CHANNEL_SECRET_FIELDS)
+    configured_refs = _non_empty_paths(config, CHANNEL_REFERENCE_FIELDS)
+
+    if channel_enabled:
+        evidence = "channel.enabled = true"
+        if default_channel:
+            evidence += f"; default_channel = {_quote(default_channel)}"
+        has_channel_surface = bool(
+            default_channel or configured_secrets or configured_refs
+        )
+        status: Status = "warn" if has_channel_surface else "info"
+        builder.add(
+            finding_id="channels-enabled",
+            status=status,
+            title="Messaging channels are enabled",
+            potential_data_path=(
+                "user messages and assistant replies -> configured channel services"
+            ),
+            evidence=evidence,
+            recommendation=(
+                "Review active channel credentials and account scopes before "
+                "routing sensitive conversations through external services."
+            ),
+        )
+
+    for dotted_path, label, service in configured_secrets:
+        status = "warn" if channel_enabled else "info"
+        normalized = dotted_path.replace(".", "-").replace("_", "-")
+        builder.add(
+            finding_id=f"channel-secret-{normalized}",
+            status=status,
+            title=f"Channel secret configured: {label}",
+            potential_data_path=f"OpenJarvis channel messages -> {service}",
+            evidence=f"{dotted_path} is non-empty; value was not printed",
+            recommendation=(
+                "Use dedicated bot/service credentials and rotate them after tests. "
+                "The audit reports only presence and never prints secret values."
+            ),
+        )
+
+    for dotted_path, label, service in configured_refs:
+        status = "warn" if channel_enabled else "info"
+        normalized = dotted_path.replace(".", "-").replace("_", "-")
+        builder.add(
+            finding_id=f"channel-reference-{normalized}",
+            status=status,
+            title=f"Channel endpoint or identifier configured: {label}",
+            potential_data_path=f"OpenJarvis channel messages -> {service}",
+            evidence=f"{dotted_path} is non-empty; value was not printed",
+            recommendation=(
+                "Review configured channel endpoints and identifiers before "
+                "routing sensitive conversations through external services."
+            ),
+        )
+
+
+def _audit_channel_environment_credentials(
+    config: Any | None,
+    builder: _FindingBuilder,
+) -> None:
+    channel_enabled = bool(_get(config, "channel.enabled", False)) if config else False
+    for env_name, purpose in sorted(CHANNEL_SECRET_ENV_VARS.items()):
+        if not os.environ.get(env_name):
+            continue
+        status: Status = "warn" if channel_enabled else "info"
+        builder.add(
+            finding_id=f"channel-env-secret-{env_name.lower()}",
+            status=status,
+            title=f"Channel secret available in environment: {env_name}",
+            potential_data_path=f"process environment -> {purpose}",
+            evidence=f"{env_name} is set; value was not read or printed",
+            recommendation=(
+                "Unset channel secrets when external messaging is not in use. "
+                "The audit reports only presence and never prints secret values."
+            ),
+        )
+
+    for env_name, purpose in sorted(CHANNEL_REFERENCE_ENV_VARS.items()):
+        if not os.environ.get(env_name):
+            continue
+        status = "warn" if channel_enabled else "info"
+        builder.add(
+            finding_id=f"channel-env-reference-{env_name.lower()}",
+            status=status,
+            title=f"Channel endpoint or identifier in environment: {env_name}",
+            potential_data_path=f"process environment -> {purpose}",
+            evidence=f"{env_name} is set; value was not read or printed",
+            recommendation=(
+                "Unset channel endpoint variables when external messaging is not "
+                "in use. The audit reports only presence."
+            ),
+        )
+
+
+def _audit_local_channel_credential_dirs(
+    config: Any,
+    root: Path,
+    builder: _FindingBuilder,
+) -> None:
+    auth_dir_value = str(
+        _get(config, "channel.whatsapp_baileys.auth_dir", "") or ""
+    ).strip()
+    candidates: list[Path] = []
+    if auth_dir_value:
+        candidates.append(Path(auth_dir_value).expanduser())
+    candidates.append(root / "whatsapp_auth")
+
+    seen: set[Path] = set()
+    for path in candidates:
+        try:
+            resolved = path.resolve()
+        except OSError:
+            resolved = path
+        if resolved in seen or not path.exists():
+            continue
+        seen.add(resolved)
+        path_digest = hashlib.sha256(str(resolved).encode("utf-8")).hexdigest()[:8]
+        builder.add(
+            finding_id=f"channel-local-credential-dir-whatsapp-baileys-{path_digest}",
+            status="info",
+            title="WhatsApp Baileys credential directory is present",
+            potential_data_path="WhatsApp session credentials -> local directory",
+            evidence="credential directory exists; contents were not inspected",
+            recommendation=(
+                "Review permissions and retention for local messaging session "
+                "credentials."
+            ),
+            location="whatsapp_auth" if path.name == "whatsapp_auth" else "<redacted>",
+            absolute_location=str(resolved),
+        )
+
+
+def _audit_frontend_storage_scope(builder: _FindingBuilder) -> None:
+    builder.add(
+        finding_id="frontend-credential-storage-not-inspected",
+        status="info",
+        title="Frontend credential storage is outside this CLI scan",
+        potential_data_path="desktop/web frontend storage -> cloud API keys",
+        evidence="CLI scan cannot inspect browser localStorage or Tauri storage",
+        recommendation=(
+            "Review frontend credential-storage work separately. This finding is "
+            "a scope note for cloud/API-key deployments, not a detected leak."
+        ),
+    )
+
+
+def _audit_skills_and_digest(config: Any, builder: _FindingBuilder) -> None:
+    if bool(_get(config, "skills.enabled", False)):
+        builder.add(
+            finding_id="skills-enabled",
+            status="info",
+            title="Skills are enabled",
+            potential_data_path="agent-selected skills -> local files and tools",
+            evidence="skills.enabled = true",
+            recommendation=(
+                "Review installed skills, especially skills with file, shell, "
+                "browser, or network access."
+            ),
+        )
+
+    if bool(_get(config, "skills.auto_sync", False)):
+        builder.add(
+            finding_id="skills-auto-sync-enabled",
+            status="warn",
+            title="Skill auto-sync is enabled",
+            potential_data_path="configured skill source -> local skill directory",
+            evidence="skills.auto_sync = true",
+            recommendation="Review external skill sources before enabling auto-sync.",
+        )
+
+    if bool(_get(config, "digest.enabled", False)):
+        sources = sorted(set(_iter_digest_sources(config)) & PERSONAL_DIGEST_SOURCES)
+        builder.add(
+            finding_id="digest-enabled",
+            status="warn",
+            title="Morning digest is enabled",
+            potential_data_path="personal connectors -> digest generation context",
+            evidence=(
+                "digest.enabled = true; sources = "
+                + (", ".join(sources) or "configured sections")
+            ),
+            recommendation=(
+                "Review digest sources and connector scopes before enabling "
+                "personal-data digests."
+            ),
+        )
+
+
+def _audit_speech_settings(config: Any, builder: _FindingBuilder) -> None:
+    speech_backend = str(_get(config, "speech.backend", "") or "").lower()
+    if speech_backend in {"openai", "deepgram"}:
+        builder.add(
+            finding_id="cloud-speech-backend-configured",
+            status="warn",
+            title="Cloud speech backend configured",
+            potential_data_path="speech audio or transcripts -> cloud speech provider",
+            evidence=f"speech.backend = {_quote(speech_backend)}",
+            recommendation=(
+                "Use a local speech backend for local-only audio processing."
+            ),
+        )
+
+
+def _has_cloud_or_api_surface(config: Any | None, active_tools: set[str]) -> bool:
+    if any(os.environ.get(name) for name in API_KEY_ENV_VARS):
+        return True
+    if active_tools & WEB_SEARCH_TOOLS:
+        return True
+    if config is None:
+        return False
+    values = [
+        _get(config, "intelligence.provider", ""),
+        _get(config, "intelligence.preferred_engine", ""),
+        _get(config, "engine.default", ""),
+        _get(config, "intelligence.default_model", ""),
+        _get(config, "deep_research.engine", ""),
+        _get(config, "deep_research.model", ""),
+        _get(config, "learning.spec_search.teacher_engine", ""),
+        _get(config, "optimize.optimizer_provider", ""),
+        _get(config, "optimize.judge_model", ""),
+        _get(config, "speech.backend", ""),
+    ]
+    return any(
+        _is_cloud_value(value) or _looks_like_cloud_model(value) for value in values
+    )
+
+
+def _derive_verdict(findings: Iterable[DataBoundaryFinding]) -> str:
+    finding_ids = {finding.id for finding in findings}
+    statuses = {finding.status for finding in findings}
+
+    if "memory-context-to-cloud-risk" in finding_ids:
+        return "local memory may be sent to cloud inference"
+    if "config-root-error" in finding_ids:
+        return "OpenJarvis home must be fixed before full data-boundary review"
+    if "config-load-error" in finding_ids:
+        return "configuration must be fixed before full data-boundary review"
+    if "fail" in statuses:
+        return "attention required for application data boundaries"
+    if any(
+        fid in finding_ids
+        for fid in {
+            "cloud-provider-configured",
+            "cloud-preferred-engine-configured",
+            "cloud-default-engine-configured",
+            "cloud-default-model-configured",
+            "cloud-speech-backend-configured",
+            "deep-research-cloud-configured",
+        }
+    ):
+        return "cloud-capable data boundaries configured"
+    if "warn" in statuses:
+        return "local sensitive stores or optional data flows detected"
+    return "no fail or warn findings detected"
+
+
+def _configured_tools(config: Any) -> set[str]:
+    values: list[Any] = [
+        _get(config, "tools.enabled", ""),
+        _get(config, "agent.tools", ""),
+    ]
+    tools: set[str] = set()
+    for value in values:
+        if isinstance(value, str):
+            raw_items = value.split(",")
+        elif isinstance(value, Iterable):
+            raw_items = list(value)
+        else:
+            raw_items = []
+        for item in raw_items:
+            normalized = str(item).strip().lower().replace("-", "_")
+            if normalized:
+                tools.add(normalized)
+    return tools
+
+
+def _get(obj: Any, dotted_path: str, default: Any = None) -> Any:
+    current = obj
+    for part in dotted_path.split("."):
+        if current is None:
+            return default
+        current = getattr(current, part, default)
+    return current
+
+
+def _is_cloud_value(value: Any) -> bool:
+    if value is None:
+        return False
+    text = str(value).strip().lower()
+    if not text or text in LOCAL_ENGINE_KEYS:
+        return False
+    return any(key in text for key in CLOUD_PROVIDER_KEYS)
+
+
+def _looks_like_cloud_model(value: Any) -> bool:
+    if value is None:
+        return False
+    text = str(value).strip().lower()
+    if not text:
+        return False
+    return any(key in text for key in CLOUD_PROVIDER_KEYS) or text.startswith("gpt-")
+
+
+def _iter_digest_sources(config: Any) -> Iterable[str]:
+    digest = _get(config, "digest", None)
+    if digest is None:
+        return []
+    sections = _get(digest, "sections", []) or []
+    optional_sections = _get(digest, "optional_sections", []) or []
+    names = list(sections) + list(optional_sections)
+    sources: list[str] = []
+    for name in names:
+        section = getattr(digest, str(name), None)
+        if section is None:
+            continue
+        section_sources = getattr(section, "sources", []) or []
+        sources.extend(str(source) for source in section_sources)
+    return sources
+
+
+def _non_empty_paths(
+    config: Any,
+    fields: tuple[tuple[str, str, str], ...],
+) -> list[tuple[str, str, str]]:
+    results: list[tuple[str, str, str]] = []
+    for dotted_path, label, service in fields:
+        value = _get(config, dotted_path, "")
+        if str(value or "").strip():
+            results.append((dotted_path, label, service))
+    return results
+
+
+def _location_label(path: Path, root: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(root.resolve()))
+    except ValueError:
+        return "<redacted>"
+
+
+def _permission_note(path: Path) -> str:
+    try:
+        if path.is_symlink():
+            return "path is a symlink"
+        if os.name == "nt":
+            return ""
+        mode = path.stat().st_mode & 0o777
+    except OSError:
+        return "could not read filesystem metadata"
+    if mode & 0o077:
+        return f"permissions are {mode:03o}; group/other access is present"
+    return ""
+
+
+def _format_tools(tools: Iterable[str]) -> str:
+    return ", ".join(sorted(tools))
+
+
+def _quote(value: Any) -> str:
+    return repr(str(value))
+
+
+def _redact_root(root: str) -> str:
+    if root.startswith("<"):
+        return root
+    path = Path(root)
+    if path.name == ".openjarvis":
+        return "~/.openjarvis"
+    if path.name == "openjarvis":
+        return "<xdg-data-home>/openjarvis"
+    return "<openjarvis-home>"
+
+
+def _truncate(text: str, limit: int = 240) -> str:
+    clean = " ".join(str(text).split())
+    if len(clean) <= limit:
+        return clean
+    return clean[: limit - 1] + "…"

--- a/tests/cli/test_scan_data_boundaries.py
+++ b/tests/cli/test_scan_data_boundaries.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+import json
+
+from click.testing import CliRunner
+
+from openjarvis.cli.scan_cmd import PrivacyScanner, ScanResult, scan
+from openjarvis.core.config import JarvisConfig
+
+
+def _low_noise_config():
+    config = JarvisConfig()
+    config.analytics.enabled = False
+    config.traces.enabled = False
+    config.telemetry.enabled = False
+    config.agent.context_from_memory = False
+    config.skills.enabled = False
+    config.optimize.optimizer_provider = ""
+    config.optimize.judge_model = ""
+    config.security.profile = "personal"
+    return config
+
+
+def _patch_config(monkeypatch, tmp_path, config, config_loaded=True, error=""):
+    monkeypatch.setattr(
+        "openjarvis.cli.scan_cmd._load_data_boundary_config",
+        lambda: (config, tmp_path, config_loaded, error, ""),
+    )
+    monkeypatch.setattr("openjarvis.cli.scan_cmd.get_config_dir", lambda: tmp_path)
+
+
+def test_scan_data_boundaries_json_redacts_paths(monkeypatch, tmp_path):
+    config = _low_noise_config()
+    (tmp_path / "traces.db").write_text("", encoding="utf-8")
+    _patch_config(monkeypatch, tmp_path, config)
+
+    result = CliRunner().invoke(scan, ["--data-boundaries", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["schema_version"] == 1
+    assert payload["root"] != str(tmp_path.resolve())
+    assert str(tmp_path.resolve()) not in result.output
+    assert "findings" in payload
+
+
+def test_scan_data_boundaries_show_paths_json(monkeypatch, tmp_path):
+    config = _low_noise_config()
+    trace_db = tmp_path / "traces.db"
+    trace_db.write_text("", encoding="utf-8")
+    _patch_config(monkeypatch, tmp_path, config)
+
+    result = CliRunner().invoke(
+        scan,
+        ["--data-boundaries", "--json", "--show-paths"],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["root"] == str(tmp_path.resolve())
+    assert "traces.db" in result.output
+
+
+def test_scan_data_boundaries_handles_config_load_error(monkeypatch, tmp_path):
+    config = _low_noise_config()
+    _patch_config(
+        monkeypatch,
+        tmp_path,
+        config,
+        config_loaded=False,
+        error="TOMLDecodeError: invalid config",
+    )
+
+    result = CliRunner().invoke(scan, ["--data-boundaries", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["summary"]["fail"] == 1
+    assert payload["findings"][0]["id"] == "config-load-error"
+
+
+def test_scan_data_boundaries_strict_exits_nonzero_on_fail(
+    monkeypatch,
+    tmp_path,
+):
+    config = _low_noise_config()
+    config.intelligence.provider = "openai"
+    config.agent.context_from_memory = True
+    _patch_config(monkeypatch, tmp_path, config)
+
+    result = CliRunner().invoke(scan, ["--data-boundaries", "--strict"])
+
+    assert result.exit_code == 1
+    assert "local memory may be sent to cloud inference" in result.output
+
+
+def test_scan_data_boundaries_fail_exits_zero_without_strict(
+    monkeypatch,
+    tmp_path,
+):
+    config = _low_noise_config()
+    config.intelligence.provider = "openai"
+    config.agent.context_from_memory = True
+    _patch_config(monkeypatch, tmp_path, config)
+
+    result = CliRunner().invoke(scan, ["--data-boundaries"])
+
+    assert result.exit_code == 0
+    assert "local memory may be sent to cloud inference" in result.output
+
+
+def test_scan_data_boundaries_strict_exits_on_warning(
+    monkeypatch,
+    tmp_path,
+):
+    config = _low_noise_config()
+    config.tools.enabled = "web_search"
+    _patch_config(monkeypatch, tmp_path, config)
+
+    result = CliRunner().invoke(scan, ["--data-boundaries", "--strict"])
+
+    assert result.exit_code == 1
+    assert "Web search tool is configured" in result.output
+
+
+def test_scan_data_boundaries_strict_passes_with_info_only(
+    monkeypatch,
+    tmp_path,
+):
+    config = _low_noise_config()
+    config.agent.context_from_memory = True
+    _patch_config(monkeypatch, tmp_path, config)
+
+    result = CliRunner().invoke(scan, ["--data-boundaries", "--strict"])
+
+    assert result.exit_code == 0
+    assert "OpenJarvis Data-Boundary Scan" in result.output
+
+
+def test_scan_data_boundaries_init_defaults_strict_exits_on_warn(
+    monkeypatch,
+    tmp_path,
+):
+    config = _low_noise_config()
+    config.server.host = "0.0.0.0"
+    config.telemetry.enabled = True
+    _patch_config(monkeypatch, tmp_path, config)
+
+    result = CliRunner().invoke(scan, ["--data-boundaries", "--strict"])
+
+    assert result.exit_code == 1
+    assert "bind all" in result.output
+
+
+def test_scan_data_boundaries_rejects_quick(monkeypatch, tmp_path):
+    config = _low_noise_config()
+    _patch_config(monkeypatch, tmp_path, config)
+
+    result = CliRunner().invoke(scan, ["--quick", "--data-boundaries"])
+
+    assert result.exit_code != 0
+    assert "cannot be combined" in result.output
+
+
+def test_scan_rejects_strict_without_data_boundaries():
+    result = CliRunner().invoke(scan, ["--strict"])
+
+    assert result.exit_code != 0
+    assert "only supported with --data-boundaries" in result.output
+
+
+def test_existing_scan_json_still_works(monkeypatch):
+    monkeypatch.setattr(
+        PrivacyScanner,
+        "run_all",
+        lambda self: [
+            ScanResult(
+                name="Network Exposure",
+                status="ok",
+                message="No exposed ports.",
+                platform="all",
+            )
+        ],
+    )
+
+    result = CliRunner().invoke(scan, ["--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload[0]["name"] == "Network Exposure"
+    assert payload[0]["status"] == "ok"
+
+
+def test_existing_scan_quick_json_still_works(monkeypatch):
+    monkeypatch.setattr(
+        PrivacyScanner,
+        "run_quick",
+        lambda self: [
+            ScanResult(
+                name="Cloud Sync Agents",
+                status="ok",
+                message="No cloud-sync agents detected.",
+                platform="all",
+            )
+        ],
+    )
+
+    result = CliRunner().invoke(scan, ["--quick", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload[0]["name"] == "Cloud Sync Agents"
+
+
+def test_top_level_cli_registers_data_boundary_scan(monkeypatch, tmp_path):
+    from openjarvis.cli import cli
+
+    config = _low_noise_config()
+    _patch_config(monkeypatch, tmp_path, config)
+
+    result = CliRunner().invoke(cli, ["scan", "--data-boundaries", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["schema_version"] == 1
+    assert "summary" in payload
+
+
+def test_update_check_skip_helper_is_precise():
+    from click import Command, Context
+
+    from openjarvis.cli import _should_skip_update_check
+
+    ctx = Context(Command("jarvis"))
+    ctx.invoked_subcommand = "scan"
+    assert _should_skip_update_check(ctx, ["scan", "--data-boundaries"])
+
+    ctx.invoked_subcommand = "ask"
+    assert not _should_skip_update_check(ctx, ["ask", "scan", "--data-boundaries"])
+
+
+def test_existing_scan_quick_text_still_works(monkeypatch):
+    monkeypatch.setattr(
+        PrivacyScanner,
+        "run_quick",
+        lambda self: [
+            ScanResult(
+                name="Cloud Sync Agents",
+                status="ok",
+                message="No cloud-sync agents detected.",
+                platform="all",
+            )
+        ],
+    )
+
+    result = CliRunner().invoke(scan, ["--quick"])
+
+    assert result.exit_code == 0
+    assert "OpenJarvis Security Scan" in result.output
+
+
+def test_data_boundary_loader_honors_openjarvis_config(
+    monkeypatch,
+    tmp_path,
+):
+    from openjarvis.cli import scan_cmd
+    from openjarvis.core.config import load_config
+
+    config_path = tmp_path / "custom.toml"
+    config_path.write_text(
+        "[telemetry]\nenabled = false\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OPENJARVIS_CONFIG", str(config_path))
+    monkeypatch.setenv("OPENJARVIS_HOME", str(tmp_path / "home"))
+    load_config.cache_clear()
+
+    _config, _root, loaded, error, root_error = (
+        scan_cmd._load_data_boundary_config()
+    )
+
+    assert loaded is True
+    assert error == ""
+    assert root_error == ""
+
+
+def test_data_boundary_loader_reports_root_error(monkeypatch):
+    from openjarvis.cli import scan_cmd
+
+    monkeypatch.setattr(
+        "openjarvis.cli.scan_cmd.get_config_dir",
+        lambda: (_ for _ in ()).throw(RuntimeError("bad home")),
+    )
+
+    _config, root, loaded, error, root_error = (
+        scan_cmd._load_data_boundary_config()
+    )
+
+    assert root is None
+    assert loaded is False
+    assert error == ""
+    assert "bad home" in root_error

--- a/tests/security/test_data_boundary_audit.py
+++ b/tests/security/test_data_boundary_audit.py
@@ -1,0 +1,540 @@
+from __future__ import annotations
+
+import os
+
+from openjarvis.core.config import JarvisConfig, load_config
+from openjarvis.security.data_boundary_audit import build_data_boundary_report
+
+
+def _ids(report):
+    return {finding.id for finding in report.findings}
+
+
+def _low_noise_config():
+    config = JarvisConfig()
+    config.analytics.enabled = False
+    config.traces.enabled = False
+    config.telemetry.enabled = False
+    config.agent.context_from_memory = False
+    config.skills.enabled = False
+    config.optimize.optimizer_provider = ""
+    config.optimize.judge_model = ""
+    config.security.profile = "personal"
+    return config
+
+
+def test_missing_config_does_not_report_dataclass_defaults(tmp_path, monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    config = JarvisConfig()
+
+    report = build_data_boundary_report(config, tmp_path, config_loaded=False)
+
+    assert report.config_loaded is False
+    assert "config-file-missing" in _ids(report)
+    assert "analytics-enabled" not in _ids(report)
+    assert "traces-enabled" not in _ids(report)
+
+
+def test_config_error_returns_fail_finding_without_crashing(tmp_path):
+    config = JarvisConfig()
+
+    report = build_data_boundary_report(
+        config,
+        tmp_path,
+        config_loaded=False,
+        config_error="TOMLDecodeError: invalid config",
+    )
+
+    findings = {finding.id: finding for finding in report.findings}
+    assert report.config_loaded is False
+    assert findings["config-load-error"].status == "fail"
+    assert "configuration must be fixed" in report.verdict
+
+
+def test_memory_context_injection_is_info_without_cloud(tmp_path):
+    config = _low_noise_config()
+    config.agent.context_from_memory = True
+    config.intelligence.provider = ""
+    config.engine.default = "ollama"
+
+    report = build_data_boundary_report(config, tmp_path)
+
+    findings = {finding.id: finding for finding in report.findings}
+    assert findings["memory-context-injection-enabled"].status == "info"
+    assert report.verdict == "no fail or warn findings detected"
+
+
+def test_memory_plus_cloud_provider_is_fail(tmp_path):
+    config = _low_noise_config()
+    config.agent.context_from_memory = True
+    config.intelligence.provider = "openai"
+
+    report = build_data_boundary_report(config, tmp_path)
+
+    findings = {finding.id: finding for finding in report.findings}
+    assert findings["memory-context-to-cloud-risk"].status == "fail"
+    assert report.verdict == "local memory may be sent to cloud inference"
+
+
+def test_analytics_is_info_and_does_not_assert_prompt_capture(tmp_path):
+    config = _low_noise_config()
+    config.analytics.enabled = True
+
+    report = build_data_boundary_report(config, tmp_path)
+
+    findings = {finding.id: finding for finding in report.findings}
+    finding = findings["analytics-enabled"]
+    assert finding.status == "info"
+    assert "does not assert" in finding.recommendation
+
+
+def test_traces_enabled_flags_capture_setting(tmp_path):
+    config = _low_noise_config()
+    config.traces.enabled = True
+
+    report = build_data_boundary_report(config, tmp_path)
+
+    findings = {finding.id: finding for finding in report.findings}
+    assert findings["traces-enabled"].status == "warn"
+    assert "traces database" in findings["traces-enabled"].potential_data_path
+
+
+def test_telemetry_enabled_flags_capture_setting(tmp_path):
+    config = _low_noise_config()
+    config.telemetry.enabled = True
+
+    report = build_data_boundary_report(config, tmp_path)
+
+    findings = {finding.id: finding for finding in report.findings}
+    assert findings["telemetry-enabled"].status == "warn"
+    assert "telemetry.enabled = true" in findings["telemetry-enabled"].evidence
+
+
+def test_trace_database_presence_redacts_and_shows_paths(tmp_path):
+    config = _low_noise_config()
+    (tmp_path / "traces.db").write_text("", encoding="utf-8")
+
+    report = build_data_boundary_report(config, tmp_path)
+    payload = report.to_dict()
+    payload_with_paths = report.to_dict(show_paths=True)
+
+    findings = {finding.id: finding for finding in report.findings}
+    assert findings["local-store-traces-db"].status == "warn"
+    assert payload["schema_version"] == 1
+    assert str(tmp_path) not in str(payload)
+    assert "traces.db" in str(payload_with_paths)
+    assert findings["local-store-traces-db"].absolute_location.endswith("traces.db")
+
+
+def test_custom_traces_db_path_is_audited(tmp_path):
+    config = _low_noise_config()
+    custom_db = tmp_path / "custom" / "traces.db"
+    custom_db.parent.mkdir()
+    custom_db.write_text("", encoding="utf-8")
+    config.traces.db_path = str(custom_db)
+
+    report = build_data_boundary_report(config, tmp_path)
+
+    findings = {finding.id: finding for finding in report.findings}
+    assert findings["local-store-traces-db"].status == "warn"
+    assert str(custom_db) in findings["local-store-traces-db"].absolute_location
+
+
+def test_connector_json_basename_redacted_by_default(tmp_path):
+    config = _low_noise_config()
+    connector_dir = tmp_path / "connectors"
+    connector_dir.mkdir()
+    token_file = connector_dir / "alice-personal-gmail.json"
+    token_file.write_text('{"refresh_token":"secret-value"}', encoding="utf-8")
+
+    report = build_data_boundary_report(config, tmp_path)
+    redacted = report.to_dict()
+    shown = report.to_dict(show_paths=True)
+
+    assert "alice-personal-gmail" not in str(redacted)
+    assert "secret-value" not in str(shown)
+    assert token_file.name in str(shown)
+
+
+def test_spec_search_cloud_teacher_is_fail_only_when_enabled(tmp_path):
+    config = _low_noise_config()
+    config.learning.spec_search.enabled = False
+    config.learning.spec_search.teacher_engine = "cloud"
+
+    disabled_report = build_data_boundary_report(config, tmp_path)
+    assert "spec-search-cloud-teacher-enabled" not in _ids(disabled_report)
+
+    config.learning.spec_search.enabled = True
+    enabled_report = build_data_boundary_report(config, tmp_path)
+    findings = {finding.id: finding for finding in enabled_report.findings}
+    assert findings["spec-search-cloud-teacher-enabled"].status == "fail"
+
+
+def test_web_search_tool_and_tavily_env_are_correlated(
+    tmp_path,
+    monkeypatch,
+):
+    config = _low_noise_config()
+    config.tools.enabled = "web_search"
+    monkeypatch.setenv("TAVILY_API_KEY", "secret-value")
+
+    report = build_data_boundary_report(config, tmp_path)
+
+    findings = {finding.id: finding for finding in report.findings}
+    assert findings["web-search-tool-configured"].status == "warn"
+    assert findings["env-credential-tavily_api_key"].status == "warn"
+    assert "secret-value" not in str(report.to_dict(show_paths=True))
+
+
+def test_mcp_servers_are_flagged_when_non_empty(tmp_path):
+    config = _low_noise_config()
+    config.tools.mcp.enabled = True
+    config.tools.mcp.servers = '[{"name":"external"}]'
+
+    report = build_data_boundary_report(config, tmp_path)
+
+    findings = {finding.id: finding for finding in report.findings}
+    assert findings["mcp-servers-configured"].status == "warn"
+
+
+def test_local_file_shell_and_code_tools_are_info(tmp_path):
+    config = _low_noise_config()
+    config.tools.enabled = ["file_read", "shell_exec", "code_interpreter"]
+
+    report = build_data_boundary_report(config, tmp_path)
+
+    findings = {finding.id: finding for finding in report.findings}
+    assert findings["local-access-tools-configured"].status == "info"
+
+
+def test_google_env_warns_when_gemini_provider_active(tmp_path, monkeypatch):
+    config = _low_noise_config()
+    config.intelligence.provider = "gemini"
+    monkeypatch.setenv("GOOGLE_API_KEY", "secret-key")
+
+    report = build_data_boundary_report(config, tmp_path)
+
+    findings = {finding.id: finding for finding in report.findings}
+    assert findings["env-credential-google_api_key"].status == "warn"
+
+
+def test_environment_credentials_report_presence_only(tmp_path, monkeypatch):
+    config = _low_noise_config()
+    monkeypatch.setenv("OPENAI_API_KEY", "secret-key")
+
+    report = build_data_boundary_report(config, tmp_path)
+
+    findings = {finding.id: finding for finding in report.findings}
+    finding = findings["env-credential-openai_api_key"]
+    assert finding.status == "info"
+    assert "OPENAI_API_KEY is set" in finding.evidence
+    assert "secret-key" not in str(report.to_dict(show_paths=True))
+
+
+def test_server_all_interfaces_is_warn(tmp_path):
+    config = _low_noise_config()
+    config.server.host = "0.0.0.0"
+
+    report = build_data_boundary_report(config, tmp_path)
+
+    findings = {finding.id: finding for finding in report.findings}
+    assert findings["server-binds-all-interfaces"].status == "warn"
+
+
+def test_a2a_without_auth_token_is_fail(tmp_path):
+    config = _low_noise_config()
+    config.a2a.enabled = True
+    config.a2a.auth_token = ""
+
+    report = build_data_boundary_report(config, tmp_path)
+
+    findings = {finding.id: finding for finding in report.findings}
+    assert findings["a2a-enabled-without-auth-token"].status == "fail"
+
+
+def test_report_json_shape_is_stable(tmp_path, monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    config = _low_noise_config()
+
+    report = build_data_boundary_report(config, tmp_path)
+    payload = report.to_dict()
+
+    assert set(payload) == {
+        "schema_version",
+        "verdict",
+        "root",
+        "config_loaded",
+        "summary",
+        "findings",
+    }
+    assert payload["schema_version"] == 1
+    assert set(payload["summary"]) == {"fail", "warn", "info"}
+    assert isinstance(payload["findings"], list)
+
+
+def test_channel_enabled_and_credentials_are_flagged(tmp_path):
+    config = _low_noise_config()
+    config.channel.enabled = True
+    config.channel.telegram.bot_token = "telegram-secret"
+
+    report = build_data_boundary_report(config, tmp_path)
+
+    findings = {finding.id: finding for finding in report.findings}
+    assert findings["channels-enabled"].status == "warn"
+    channel_finding = findings["channel-secret-channel-telegram-bot-token"]
+    assert channel_finding.status == "warn"
+    assert "telegram-secret" not in str(report.to_dict(show_paths=True))
+
+
+def test_channel_reference_fields_are_flagged(tmp_path):
+    config = _low_noise_config()
+    config.channel.matrix.homeserver = "https://matrix.example.org"
+
+    report = build_data_boundary_report(config, tmp_path)
+
+    findings = {finding.id: finding for finding in report.findings}
+    ref = findings["channel-reference-channel-matrix-homeserver"]
+    assert ref.status == "info"
+    assert "Matrix homeserver" in ref.title
+
+
+def test_channel_env_credential_presence_only(tmp_path, monkeypatch):
+    config = _low_noise_config()
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "slack-secret")
+
+    report = build_data_boundary_report(config, tmp_path)
+
+    findings = {finding.id: finding for finding in report.findings}
+    finding = findings["channel-env-secret-slack_bot_token"]
+    assert finding.status == "info"
+    assert "SLACK_BOT_TOKEN is set" in finding.evidence
+    assert "slack-secret" not in str(report.to_dict(show_paths=True))
+
+
+def test_cloud_speech_backend_is_warn(tmp_path):
+    config = _low_noise_config()
+    config.speech.backend = "openai"
+
+    report = build_data_boundary_report(config, tmp_path)
+
+    findings = {finding.id: finding for finding in report.findings}
+    assert findings["cloud-speech-backend-configured"].status == "warn"
+
+
+def test_skills_auto_sync_is_warn(tmp_path):
+    config = _low_noise_config()
+    config.skills.auto_sync = True
+
+    report = build_data_boundary_report(config, tmp_path)
+
+    findings = {finding.id: finding for finding in report.findings}
+    assert findings["skills-auto-sync-enabled"].status == "warn"
+
+
+def test_digest_enabled_is_warn(tmp_path):
+    config = _low_noise_config()
+    config.digest.enabled = True
+
+    report = build_data_boundary_report(config, tmp_path)
+
+    findings = {finding.id: finding for finding in report.findings}
+    assert findings["digest-enabled"].status == "warn"
+
+
+def test_memory_service_enabled_warns_with_cloud_engine(tmp_path):
+    config = _low_noise_config()
+    config.tools.storage.enabled = True
+    config.intelligence.provider = "openai"
+
+    report = build_data_boundary_report(config, tmp_path)
+
+    findings = {finding.id: finding for finding in report.findings}
+    finding = findings["memory-service-enabled"]
+    assert finding.status == "warn"
+    assert "cloud inference surface detected" in finding.evidence
+
+
+def test_default_model_cloud_detection(tmp_path):
+    config = _low_noise_config()
+    config.intelligence.default_model = "gpt-4o"
+
+    report = build_data_boundary_report(config, tmp_path)
+
+    findings = {finding.id: finding for finding in report.findings}
+    assert findings["cloud-default-model-configured"].status == "warn"
+
+
+def test_deep_research_cloud_engine_and_model(tmp_path):
+    config = _low_noise_config()
+    config.deep_research.engine = "openai"
+    config.deep_research.model = "gpt-4o-mini"
+
+    report = build_data_boundary_report(config, tmp_path)
+
+    findings = {finding.id: finding for finding in report.findings}
+    assert findings["deep-research-cloud-configured"].status == "warn"
+    assert "deep_research.engine" in findings["deep-research-cloud-configured"].evidence
+    assert "deep_research.model" in findings["deep-research-cloud-configured"].evidence
+
+
+def test_security_bypass_warns_with_cloud_surface(tmp_path):
+    config = _low_noise_config()
+    config.intelligence.provider = "openai"
+    config.security.local_engine_bypass = True
+    config.security.local_tool_bypass = True
+
+    report = build_data_boundary_report(config, tmp_path)
+
+    findings = {finding.id: finding for finding in report.findings}
+    assert findings["security-local-engine-bypass-enabled"].status == "warn"
+    assert findings["security-local-tool-bypass-enabled"].status == "warn"
+
+
+def test_security_profile_unset_is_info(tmp_path):
+    config = _low_noise_config()
+    config.security.profile = ""
+
+    report = build_data_boundary_report(config, tmp_path)
+
+    findings = {finding.id: finding for finding in report.findings}
+    assert findings["security-profile-unset"].status == "info"
+    assert "security.profile" in findings["security-profile-unset"].recommendation
+
+
+def test_frontend_scope_note_appears_with_cloud_api_surface(
+    tmp_path,
+    monkeypatch,
+):
+    config = _low_noise_config()
+    monkeypatch.setenv("OPENAI_API_KEY", "secret-key")
+
+    report = build_data_boundary_report(config, tmp_path)
+
+    assert "frontend-credential-storage-not-inspected" in _ids(report)
+
+
+def test_config_root_error_returns_fail_without_local_store_scan(tmp_path):
+    config = _low_noise_config()
+
+    report = build_data_boundary_report(
+        config,
+        None,
+        root_error="ConfigurationError: bad OPENJARVIS_HOME",
+    )
+
+    findings = {finding.id: finding for finding in report.findings}
+    assert findings["config-root-error"].status == "fail"
+    assert report.root == "<unresolved-openjarvis-home>"
+
+
+def test_group_or_other_readable_local_store_warns(tmp_path):
+    if os.name == "nt":
+        import pytest
+
+        pytest.skip("Unix permission bits are not checked on Windows")
+
+    config = _low_noise_config()
+    trace_db = tmp_path / "traces.db"
+    trace_db.write_text("", encoding="utf-8")
+    trace_db.chmod(0o644)
+
+    report = build_data_boundary_report(config, tmp_path)
+
+    findings = {finding.id: finding for finding in report.findings}
+    assert findings["local-store-permissions-traces-db"].status == "warn"
+
+
+def test_symlink_local_store_permission_warns(tmp_path):
+    if os.name == "nt":
+        import pytest
+
+        pytest.skip("Symlink permission semantics differ on Windows")
+
+    config = _low_noise_config()
+    real_db = tmp_path / "real-traces.db"
+    real_db.write_text("", encoding="utf-8")
+    symlink = tmp_path / "traces.db"
+    symlink.symlink_to(real_db)
+    config.traces.db_path = str(symlink)
+
+    report = build_data_boundary_report(config, tmp_path)
+
+    findings = {finding.id: finding for finding in report.findings}
+    assert findings["local-store-permissions-traces-db"].status == "warn"
+    assert "symlink" in findings["local-store-permissions-traces-db"].evidence
+
+
+def test_whatsapp_baileys_local_auth_dir_is_reported(tmp_path):
+    config = _low_noise_config()
+    auth_dir = tmp_path / "whatsapp_auth"
+    auth_dir.mkdir()
+
+    report = build_data_boundary_report(config, tmp_path)
+
+    whatsapp_findings = [
+        finding
+        for finding in report.findings
+        if finding.id.startswith("channel-local-credential-dir-whatsapp-baileys")
+    ]
+    assert len(whatsapp_findings) == 1
+    assert whatsapp_findings[0].status == "info"
+
+
+def test_whatsapp_dual_auth_dirs_both_reported(tmp_path):
+    config = _low_noise_config()
+    default_dir = tmp_path / "whatsapp_auth"
+    default_dir.mkdir()
+    custom_dir = tmp_path / "custom_whatsapp_auth"
+    custom_dir.mkdir()
+    config.channel.whatsapp_baileys.auth_dir = str(custom_dir)
+
+    report = build_data_boundary_report(config, tmp_path)
+
+    whatsapp_findings = [
+        finding
+        for finding in report.findings
+        if finding.id.startswith("channel-local-credential-dir-whatsapp-baileys")
+    ]
+    assert len(whatsapp_findings) == 2
+    ids = {finding.id for finding in whatsapp_findings}
+    assert len(ids) == 2
+
+
+def test_channel_enabled_without_endpoint_is_info(tmp_path):
+    config = _low_noise_config()
+    config.channel.enabled = True
+
+    report = build_data_boundary_report(config, tmp_path)
+
+    findings = {finding.id: finding for finding in report.findings}
+    assert findings["channels-enabled"].status == "info"
+
+
+def test_init_template_config_snapshot(tmp_path):
+    init_like_toml = """
+[server]
+host = "0.0.0.0"
+
+[telemetry]
+enabled = true
+
+[traces]
+enabled = false
+
+[agent]
+context_from_memory = true
+
+[memory]
+enabled = false
+"""
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(init_like_toml, encoding="utf-8")
+    config = load_config(config_path)
+
+    report = build_data_boundary_report(config, tmp_path)
+
+    findings = {finding.id: finding for finding in report.findings}
+    assert findings["server-binds-all-interfaces"].status == "warn"
+    assert findings["telemetry-enabled"].status == "warn"
+    assert "traces-enabled" not in findings
+    assert findings["memory-context-injection-enabled"].status == "info"


### PR DESCRIPTION
## Summary
- Adds `jarvis scan --data-boundaries` for application-level config/store diagnostics
- Structured findings with redacted JSON (`schema_version: 1`), `--show-paths`, and `--strict`
- Skips update check only for `jarvis scan --data-boundaries`
- Covers cloud inference, memory composition, telemetry/traces, channels, tools, local stores, and env credentials

## Test plan
- [x] `ruff check` on changed files
- [x] `pytest tests/security/test_data_boundary_audit.py tests/cli/test_scan_data_boundaries.py -v` (53 passed, 2 POSIX skips on Windows)
- [ ] `jarvis scan --json` / `--quick --json` (host scan regression)
- [ ] `jarvis scan --data-boundaries [--json] [--strict] [--show-paths]`
