### PR TITLE
docs: point the Project Site link to openjarvis.stanford.edu

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <p><i>Personal AI, On Personal Devices.</i></p>
 
   <p>
-    <a href="https://scalingintelligence.stanford.edu/blogs/openjarvis/"><img src="https://img.shields.io/badge/project-OpenJarvis-blue" alt="Project"></a>
+    <a href="https://openjarvis.stanford.edu/"><img src="https://img.shields.io/badge/project-OpenJarvis-blue" alt="Project"></a>
     <a href="https://open-jarvis.github.io/OpenJarvis/"><img src="https://img.shields.io/badge/docs-mkdocs-blue" alt="Docs"></a>
     <img src="https://img.shields.io/badge/python-%3E%3D3.10-blue" alt="Python">
     <img src="https://img.shields.io/badge/license-Apache%202.0-green" alt="License">
@@ -23,7 +23,7 @@
 
 > **[Documentation](https://open-jarvis.github.io/OpenJarvis/)**
 >
-> **[Project Site](https://scalingintelligence.stanford.edu/blogs/openjarvis/)**
+> **[Project Site](https://openjarvis.stanford.edu/)**
 >
 > **[Paper](https://arxiv.org/abs/2605.17172)**
 >

--- a/docs/index.md
+++ b/docs/index.md
@@ -215,7 +215,7 @@ OpenJarvis is built around five composable layers. Each has a clean interface an
 
 OpenJarvis is part of [Intelligence Per Watt](https://www.intelligence-per-watt.ai/), a research initiative studying the efficiency of on-device AI systems. Developed at [Hazy Research](https://hazyresearch.stanford.edu/) and the [Scaling Intelligence Lab](https://scalingintelligence.stanford.edu/) at [Stanford SAIL](https://ai.stanford.edu/).
 
-Read the [blog post](https://scalingintelligence.stanford.edu/blogs/openjarvis/) for the full research motivation, architecture details, and experimental results.
+Read the [blog post](https://openjarvis.stanford.edu/) for the full research motivation, architecture details, and experimental results.
 
 ## Citation
 

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -805,7 +805,7 @@ export function SettingsPage() {
               </p>
               <div className="flex gap-3 mt-3 text-xs">
                 <a
-                  href="https://scalingintelligence.stanford.edu/blogs/openjarvis/"
+                  href="https://openjarvis.stanford.edu/"
                   target="_blank"
                   rel="noopener noreferrer"
                   style={{ color: 'var(--color-accent)' }}

--- a/src/openjarvis/recipes/data/operators/openjarvis_twitter_bot_prompt.md
+++ b/src/openjarvis/recipes/data/operators/openjarvis_twitter_bot_prompt.md
@@ -15,7 +15,7 @@ HARD RULE: Every reply MUST be ≤280 characters. Count before sending.
 - GitHub: https://github.com/open-jarvis/OpenJarvis
 - Docs: https://open-jarvis.github.io/OpenJarvis/
 - Discord: https://discord.gg/wfXEkpPX
-- Blog: https://scalingintelligence.stanford.edu/blogs/openjarvis/
+- Blog: https://openjarvis.stanford.edu/
 - Install: `git clone https://github.com/open-jarvis/OpenJarvis.git && cd OpenJarvis && uv sync`
 - CLI commands (ONLY these exist):
   - `jarvis init` — auto-detects hardware, configures engine


### PR DESCRIPTION
## Summary

The project's canonical site is now **https://openjarvis.stanford.edu/** (previously the Scaling Intelligence Lab blog at `scalingintelligence.stanford.edu/blogs/openjarvis/`). This updates the "Project Site" link and every other reference to that old URL.

## Changes (all references to the old project-site URL → the new one)

- **README** — the `Project` badge and the **Project Site** link
- **docs/index.md** — the research write-up link
- **frontend/src/pages/SettingsPage.tsx** — the desktop Settings "Project site" link
- **Twitter-bot operator prompt** — the `Blog:` reference

## Deliberately left unchanged

- The bare **Scaling Intelligence Lab** homepage links (`scalingintelligence.stanford.edu/`, README:148 / docs/index.md:216) — those point to the *lab*, not the project site.
- The `open-jarvis.github.io/...` **documentation** and **installer** URLs — different, functional infrastructure.

## Verified

- New URL resolves (HTTP 200).
- Old `.../blogs/openjarvis/` URL no longer appears in the changed files; Lab homepage links intact.

## Possible follow-ups (not in this PR — your call)

- The GitHub repo's **Website** field is currently the docs site (`open-jarvis.github.io/OpenJarvis/`); could be pointed at the new project site if you want it as the repo's headline link.
- `pyproject.toml [project.urls]` has `Homepage` (repo) + `Documentation` (docs) but no project-site entry — could add one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)