### PR TITLE
fix(memory): make auto-extracted facts recallable at inference

### DIFF
--- a/rust/crates/openjarvis-tools/src/storage/sqlite.rs
+++ b/rust/crates/openjarvis-tools/src/storage/sqlite.rs
@@ -144,16 +144,21 @@ impl MemoryBackend for SQLiteMemory {
     ) -> Result<Vec<RetrievalResult>, OpenJarvisError> {
         let conn = self.conn.lock();
 
+        // Wrap every term as a quoted FTS5 string literal. FTS5 metacharacters
+        // (apostrophes, quotes, parens, etc.) are otherwise interpreted as
+        // query syntax — an interior apostrophe like "dog's" is a syntax error
+        // that iteration silently swallows into zero results. Quoting makes each
+        // term a phrase whose tokenizer ignores the punctuation, so natural-
+        // language questions match. Embedded double quotes are doubled per the
+        // FTS5 escaping rule; terms that tokenize to nothing are dropped.
         let words: Vec<String> = query
             .split_whitespace()
-            .map(|w| w.trim_matches(|c: char| "?.,!;:'\"()[]{}/ ".contains(c)).to_string())
-            .filter(|w| !w.is_empty())
+            .map(|w| format!("\"{}\"", w.replace('"', "\"\"")))
             .collect();
-        let fts_query = if words.len() == 1 {
-            words[0].clone()
-        } else {
-            words.join(" OR ")
-        };
+        if words.is_empty() {
+            return Ok(Vec::new());
+        }
+        let fts_query = words.join(" OR ");
 
         let mut stmt = conn
             .prepare(
@@ -280,6 +285,32 @@ mod tests {
         let results = mem.retrieve("What medications does Micah take?", 5).unwrap();
         assert!(!results.is_empty(), "query with punctuation should still return results");
         assert!(results[0].score > 0.0);
+    }
+
+    #[test]
+    fn test_sqlite_apostrophe_in_query() {
+        let mem = SQLiteMemory::in_memory().unwrap();
+        mem.store("My dog is named Biscuit", "auto", None).unwrap();
+
+        // An interior apostrophe (possessive) is an FTS5 metacharacter; the raw
+        // term must be quoted or it silently yields zero results (#recall).
+        let results = mem.retrieve("What is my dog's name?", 5).unwrap();
+        assert!(
+            !results.is_empty(),
+            "query containing an apostrophe should still return results"
+        );
+        assert!(results[0].content.contains("Biscuit"));
+    }
+
+    #[test]
+    fn test_sqlite_punctuation_only_query_is_empty_not_error() {
+        let mem = SQLiteMemory::in_memory().unwrap();
+        mem.store("My dog is named Biscuit", "auto", None).unwrap();
+
+        // A query that reduces to nothing but punctuation must return an empty
+        // result set rather than propagating an FTS5 syntax error.
+        let results = mem.retrieve("??? !!! ...", 5).unwrap();
+        assert!(results.is_empty());
     }
 
     #[test]

--- a/src/openjarvis/memory/service.py
+++ b/src/openjarvis/memory/service.py
@@ -39,11 +39,16 @@ class MemoryService:
         extractor: FactExtractor,
         *,
         event_bus: EventBus | None = None,
+        retrieval_backend: Any | None = None,
         max_queue: int = 256,
     ) -> None:
         self._store = store
         self._extractor = extractor
         self._event_bus = event_bus
+        # Optional document/retrieval backend (e.g. SQLiteMemory). Newly stored
+        # facts are mirrored here so inference-time context injection can recall
+        # them — without this bridge the fact store is write-only.
+        self._retrieval_backend = retrieval_backend
         self._subscribed = False
         self._queue: "queue.Queue[Any]" = queue.Queue(maxsize=max(1, max_queue))
         self._thread: Optional[threading.Thread] = None
@@ -158,10 +163,31 @@ class MemoryService:
     def _process(self, job: Any) -> None:
         user_text, assistant_text = job
         facts = self._extractor.extract(user_text, assistant_text)
-        if facts:
-            stored = self._store.add_many(facts, source="auto")
-            if stored:
-                logger.debug("Memory service stored %d new fact(s)", stored)
+        if not facts:
+            return
+        stored = 0
+        for text in facts:
+            # add() dedupes by text, so True means "genuinely new" — index only
+            # those into the retrieval backend to avoid duplicate documents.
+            if self._store.add(text, source="auto"):
+                stored += 1
+                self._index_fact(text)
+        if stored:
+            logger.debug("Memory service stored %d new fact(s)", stored)
+
+    def _index_fact(self, text: str) -> None:
+        """Mirror a newly stored fact into the retrieval backend (best-effort).
+
+        Failures are swallowed: a flaky retrieval backend must never prevent a
+        fact from being persisted nor take down the extraction worker.
+        """
+        backend = self._retrieval_backend
+        if backend is None:
+            return
+        try:
+            backend.store(text, source="memory")
+        except Exception:  # noqa: BLE001 — indexing is best-effort
+            logger.debug("Failed to index fact into retrieval backend", exc_info=True)
 
     # -- store passthroughs -------------------------------------------------
 
@@ -210,7 +236,35 @@ def build_memory_service(
         max_facts=getattr(mem, "max_facts", 1000),
     )
     extractor = FactExtractor(engine, model)
-    return MemoryService(store, extractor, event_bus=event_bus)
+    retrieval_backend = _build_retrieval_backend(mem)
+    return MemoryService(
+        store,
+        extractor,
+        event_bus=event_bus,
+        retrieval_backend=retrieval_backend,
+    )
+
+
+def _build_retrieval_backend(mem: Any) -> Optional[Any]:
+    """Instantiate the document/retrieval backend for fact indexing.
+
+    Mirrors ``cli.ask._get_memory_backend``: returns ``None`` (logged at DEBUG)
+    when the backend is unavailable, so auto-memory degrades to write-only
+    rather than failing to start.
+    """
+    try:
+        import openjarvis.tools.storage  # noqa: F401 — registers backends
+        from openjarvis.core.registry import MemoryRegistry
+
+        key = getattr(mem, "default_backend", "sqlite")
+        if not MemoryRegistry.contains(key):
+            return None
+        if key == "sqlite":
+            return MemoryRegistry.create(key, db_path=getattr(mem, "db_path", ""))
+        return MemoryRegistry.create(key)
+    except Exception as exc:  # noqa: BLE001 — retrieval bridge is optional
+        logger.debug("Retrieval backend unavailable for memory service: %s", exc)
+        return None
 
 
 def publish_completed_exchange(

--- a/tests/memory/test_memory_service.py
+++ b/tests/memory/test_memory_service.py
@@ -16,6 +16,20 @@ from openjarvis.memory.service import (
 from openjarvis.memory.store import LocalFactStore
 
 
+def _make_retrieval_backend(tmp_path):
+    """Real SQLiteMemory retrieval backend on a temp DB.
+
+    conftest wipes registries between tests, so register manually (mirrors
+    tests/memory/test_sqlite.py).
+    """
+    from openjarvis.core.registry import MemoryRegistry
+    from openjarvis.tools.storage.sqlite import SQLiteMemory
+
+    if not MemoryRegistry.contains("sqlite"):
+        MemoryRegistry.register_value("sqlite", SQLiteMemory)
+    return SQLiteMemory(db_path=tmp_path / "retrieval.db")
+
+
 def _wait_until(predicate, timeout=2.0, interval=0.01):
     deadline = time.time() + timeout
     while time.time() < deadline:
@@ -166,6 +180,89 @@ def test_submit_returns_false_when_queue_full(tmp_path):
     finally:
         gate.set()
         svc.stop()
+
+
+def test_process_indexes_new_facts_into_retrieval_backend(tmp_path):
+    """Extracted facts must land in the retrieval store so inference can recall
+    them — otherwise auto-memory is write-only (facts visible in `memory list`
+    but never surfaced by `ask`)."""
+    backend = _make_retrieval_backend(tmp_path)
+    extractor = FakeExtractor(["The user's dog is named Biscuit"])
+    store = LocalFactStore(tmp_path / "facts.jsonl")
+    svc = MemoryService(store, extractor, retrieval_backend=backend)
+
+    svc._process(("My dog is Biscuit", "Nice!"))
+
+    results = backend.retrieve("dog", top_k=5)
+    assert results, "new fact should be retrievable from the backend"
+    assert any("Biscuit" in r.content for r in results)
+
+
+def test_process_does_not_reindex_duplicate_facts(tmp_path):
+    """A fact already in the store must not be indexed again — re-indexing would
+    accumulate duplicate documents in the retrieval store on every restart."""
+    backend = _make_retrieval_backend(tmp_path)
+    extractor = FakeExtractor(["The user's dog is named Biscuit"])
+    store = LocalFactStore(tmp_path / "facts.jsonl")
+    svc = MemoryService(store, extractor, retrieval_backend=backend)
+
+    svc._process(("My dog is Biscuit", "Nice!"))
+    svc._process(("My dog is Biscuit", "Nice!"))
+
+    assert backend.count() == 1
+
+
+def test_process_without_retrieval_backend_still_stores(tmp_path):
+    """No retrieval backend wired → facts are still persisted, no crash."""
+    extractor = FakeExtractor(["User likes hiking"])
+    store = LocalFactStore(tmp_path / "facts.jsonl")
+    svc = MemoryService(store, extractor)  # retrieval_backend omitted
+
+    svc._process(("I love hiking", "Nice!"))
+
+    assert [f.text for f in store.list()] == ["User likes hiking"]
+
+
+def test_process_survives_retrieval_backend_failure(tmp_path):
+    """Indexing is best-effort: a backend that raises must not prevent the fact
+    from being stored, nor propagate out of the worker."""
+
+    class ExplodingBackend:
+        def store(self, *a, **k):
+            raise RuntimeError("backend down")
+
+    extractor = FakeExtractor(["User likes hiking"])
+    store = LocalFactStore(tmp_path / "facts.jsonl")
+    svc = MemoryService(store, extractor, retrieval_backend=ExplodingBackend())
+
+    svc._process(("I love hiking", "Nice!"))  # must not raise
+
+    assert [f.text for f in store.list()] == ["User likes hiking"]
+
+
+def test_build_memory_service_wires_retrieval_backend(tmp_path):
+    """When memory is enabled, the built service gets a retrieval backend so
+    the fact→retrieval bridge is active by default."""
+    # conftest wipes registries; re-register sqlite (as the module does at
+    # import time in real runtime) so the backend can be constructed.
+    from openjarvis.core.registry import MemoryRegistry
+    from openjarvis.tools.storage.sqlite import SQLiteMemory
+
+    if not MemoryRegistry.contains("sqlite"):
+        MemoryRegistry.register_value("sqlite", SQLiteMemory)
+    cfg = SimpleNamespace(
+        memory=StorageConfig(
+            enabled=True,
+            extraction_model="qwen3:14b",
+            facts_path=str(tmp_path / "facts.jsonl"),
+            db_path=str(tmp_path / "memory.db"),
+            default_backend="sqlite",
+            max_facts=10,
+        )
+    )
+    svc = build_memory_service(cfg, object(), "fallback-model")
+    assert isinstance(svc, MemoryService)
+    assert svc._retrieval_backend is not None
 
 
 def test_build_memory_service_disabled_returns_none(tmp_path):


### PR DESCRIPTION
## Problem

Automatic memory is effectively **write-only**: facts extracted during `jarvis chat`/`serve` land in the JSONL fact store (visible via `jarvis memory list`) but are never surfaced by `jarvis ask`/`chat`. Two independent gaps cause this.

### 1. No fact→retrieval bridge

Fact extraction writes to the `FactStore` (JSONL), but inference-time context injection (`inject_context` / the executor) reads a **separate** FTS document store (`sqlite`/`bm25`/…). Nothing ever indexed extracted facts into that store, so recall always queried an empty index.

`MemoryService` now takes an optional `retrieval_backend` and mirrors each **newly stored** fact into it:
- dedup-aware — only facts that are genuinely new (`FactStore.add()` returns `True`) get indexed, so restarts don't accumulate duplicate documents;
- best-effort — indexing failures are swallowed so a flaky retrieval backend can neither drop a fact nor kill the extraction worker.

`build_memory_service` constructs the backend from config (mirroring `cli.ask._get_memory_backend`) and wires it in, so the bridge is active by default when memory is enabled.

### 2. FTS5 query silently died on punctuation

The Rust `sqlite` backend only trimmed *leading/trailing* punctuation from each term, so an **interior** apostrophe (`"dog's"`) reached the FTS5 `MATCH` as a syntax error — which row iteration then swallowed via `.filter_map(|r| r.ok())`, yielding **zero results with no error**. So "What is my dog's name?" retrieved nothing.

Each term is now wrapped as a quoted FTS5 phrase (embedded double-quotes doubled per the FTS5 escaping rule); the tokenizer ignores the punctuation inside the phrase. Queries that reduce to only punctuation now return an empty result set instead of erroring.

## Testing

- **Rust** (`storage::sqlite::tests`): new `test_sqlite_apostrophe_in_query` and `test_sqlite_punctuation_only_query_is_empty_not_error`. Full crate: 47 passed.
- **Python** (`tests/memory/test_memory_service.py`): index-new-facts, no-duplicate-reindex, best-effort-on-backend-failure, backward-compat-without-a-backend, and build-wires-backend. Memory + related CLI suites: 167 passed.
- `cargo clippy --all-targets -- -D warnings` clean; `ruff check`/`format` clean.

## Manual verification (local MLX + Qwen2.5-7B-Instruct)

1. Fresh `jarvis chat`: "My dog is named Biscuit and my favorite color is orange." → `memory list` shows 2 facts **and** `memory stats` shows 2 retrieval documents — indexed automatically, no manual `memory index` step.
2. Fresh `jarvis ask "What is my dog's name?"` (note the apostrophe) → **"Your dog's name is Biscuit."** Both previously failed.
