### PR TITLE
Update cost-comparison models: GPT-5.6 Sol & Claude Fable 5

### DIFF
--- a/docs/leaderboard.md
+++ b/docs/leaderboard.md
@@ -55,5 +55,5 @@ See how the OpenJarvis community saves money, energy, and compute by running AI 
 <div id="leaderboard-pagination" class="lb-pagination"></div>
 
 <p style="font-size:12px;opacity:0.6;margin-top:12px">
-*Dollar savings estimated vs. Claude Opus 4.6 API pricing ($5/1M input, $25/1M output tokens). Assumes local open-source models produce roughly the same number of tokens per request as cloud models.
+*Dollar savings estimated vs. Claude Fable 5 API pricing ($10/1M input, $50/1M output tokens). Assumes local open-source models produce roughly the same number of tokens per request as cloud models.
 </p>

--- a/frontend/src/components/Chat/SystemPanel.tsx
+++ b/frontend/src/components/Chat/SystemPanel.tsx
@@ -29,8 +29,8 @@ interface TelemetryStats {
 }
 
 const CLOUD_PRICING = [
-  { name: 'GPT-5.3', input: 2.00, output: 10.00, primary: true },
-  { name: 'Claude Opus 4.6', input: 5.00, output: 25.00, primary: false },
+  { name: 'GPT-5.6 Sol', input: 5.00, output: 30.00, primary: true },
+  { name: 'Claude Fable 5', input: 10.00, output: 50.00, primary: false },
   { name: 'Gemini 3.1 Pro', input: 2.00, output: 12.00, primary: false },
 ];
 

--- a/frontend/src/components/Dashboard/CostComparison.tsx
+++ b/frontend/src/components/Dashboard/CostComparison.tsx
@@ -2,8 +2,8 @@ import { DollarSign, TrendingDown, Cloud, HardDrive } from 'lucide-react';
 import { useAppStore } from '../../lib/store';
 
 const CLOUD_PRICING = [
-  { name: 'GPT-5.3', input: 2.00, output: 10.00 },
-  { name: 'Claude Opus 4.6', input: 5.00, output: 25.00 },
+  { name: 'GPT-5.6 Sol', input: 5.00, output: 30.00 },
+  { name: 'Claude Fable 5', input: 10.00, output: 50.00 },
   { name: 'Gemini 3.1 Pro', input: 2.00, output: 12.00 },
 ];
 

--- a/frontend/src/components/Desktop/SavingsDashboard.tsx
+++ b/frontend/src/components/Desktop/SavingsDashboard.tsx
@@ -222,8 +222,8 @@ const styles: Record<string, React.CSSProperties> = {
 };
 
 const PROVIDER_COLORS: Record<string, string> = {
-  'gpt-5.3': colors.green,
-  'claude-opus-4.6': colors.yellow,
+  'gpt-5.6-sol': colors.green,
+  'claude-fable-5': colors.yellow,
   'gemini-3.1-pro': colors.accent,
 };
 

--- a/frontend/src/pages/AgentsPage.tsx
+++ b/frontend/src/pages/AgentsPage.tsx
@@ -3740,8 +3740,8 @@ export function AgentsPage() {
               const paramsB = paramMatch ? parseFloat(paramMatch[1]) : 9;
               const flops = 2 * paramsB * 1e9 * (inTok + outTok);
               const providers = [
-                { label: 'GPT-5.3', inPer1M: 2.0, outPer1M: 10.0 },
-                { label: 'Claude Opus 4.6', inPer1M: 5.0, outPer1M: 25.0 },
+                { label: 'GPT-5.6 Sol', inPer1M: 5.0, outPer1M: 30.0 },
+                { label: 'Claude Fable 5', inPer1M: 10.0, outPer1M: 50.0 },
                 { label: 'Gemini 3.1 Pro', inPer1M: 2.0, outPer1M: 12.0 },
               ];
               const energyWh = (inTok + outTok) / 1000 * 0.4;

--- a/src/openjarvis/server/comparison.py
+++ b/src/openjarvis/server/comparison.py
@@ -215,8 +215,8 @@ COMPARISON_HTML = """\
         <tr>
           <th></th>
           <th>OpenJarvis (Local)</th>
-          <th>GPT-5.3</th>
-          <th>Claude Opus 4.6</th>
+          <th>GPT-5.6 Sol</th>
+          <th>Claude Fable 5</th>
           <th>Gemini 3.1 Pro</th>
         </tr>
       </thead>
@@ -261,11 +261,11 @@ COMPARISON_HTML = """\
         <div class="cc-value">$0.00/mo</div>
       </div>
       <div class="calc-card cloud">
-        <div class="cc-label">GPT-5.3</div>
+        <div class="cc-label">GPT-5.6 Sol</div>
         <div class="cc-value" id="calc-gpt">--</div>
       </div>
       <div class="calc-card cloud">
-        <div class="cc-label">Claude Opus 4.6</div>
+        <div class="cc-label">Claude Fable 5</div>
         <div class="cc-value" id="calc-claude">--</div>
       </div>
       <div class="calc-card cloud">
@@ -292,13 +292,13 @@ COMPARISON_HTML = """\
 <script>
 // Embedded data -- avoids API calls, keeps the page static and fast.
 const CLOUD_PRICING = {
-  "gpt-5.3": {
-    input_per_1m: 2.00, output_per_1m: 10.00,
-    label: "GPT-5.3"
+  "gpt-5.6-sol": {
+    input_per_1m: 5.00, output_per_1m: 30.00,
+    label: "GPT-5.6 Sol"
   },
-  "claude-opus-4.6": {
-    input_per_1m: 5.00, output_per_1m: 25.00,
-    label: "Claude Opus 4.6"
+  "claude-fable-5": {
+    input_per_1m: 10.00, output_per_1m: 50.00,
+    label: "Claude Fable 5"
   },
   "gemini-3.1-pro": {
     input_per_1m: 2.00, output_per_1m: 12.00,
@@ -376,8 +376,8 @@ function updateTable() {
   const sc = SCENARIOS[activeScenario];
   const i = sc.avg_input_tokens, o = sc.avg_output_tokens;
   const c = sc.calls_per_month;
-  const gpt = calcMonthlyCost(c, i, o, 'gpt-5.3');
-  const claude = calcMonthlyCost(c, i, o, 'claude-opus-4.6');
+  const gpt = calcMonthlyCost(c, i, o, 'gpt-5.6-sol');
+  const claude = calcMonthlyCost(c, i, o, 'claude-fable-5');
   const gemini = calcMonthlyCost(c, i, o, 'gemini-3.1-pro');
 
   document.getElementById('t-gpt-m').textContent = fmtDollar(gpt);
@@ -410,8 +410,8 @@ function updateCalc() {
   const avgOut = tpc - avgIn;
   const callsPerMonth = cpd * 30;
 
-  const gpt = calcMonthlyCost(callsPerMonth, avgIn, avgOut, 'gpt-5.3');
-  const claude = calcMonthlyCost(callsPerMonth, avgIn, avgOut, 'claude-opus-4.6');
+  const gpt = calcMonthlyCost(callsPerMonth, avgIn, avgOut, 'gpt-5.6-sol');
+  const claude = calcMonthlyCost(callsPerMonth, avgIn, avgOut, 'claude-fable-5');
   const gemini = calcMonthlyCost(callsPerMonth, avgIn, avgOut, 'gemini-3.1-pro');
 
   document.getElementById('calc-gpt').textContent = fmtDollar(gpt) + '/mo';

--- a/src/openjarvis/server/dashboard.py
+++ b/src/openjarvis/server/dashboard.py
@@ -184,7 +184,7 @@ DASHBOARD_HTML = """\
   <div class="providers">
     <div class="provider-card openai">
       <div class="pname">OpenAI</div>
-      <div class="pmodel">GPT-5.3 &mdash; $2.00 / $10.00 per 1M tokens</div>
+      <div class="pmodel">GPT-5.6 Sol &mdash; $5.00 / $30.00 per 1M tokens</div>
       <div class="savings-amount" id="save-openai">$0.00</div>
       <div class="breakdown">
         <div class="item">
@@ -199,7 +199,7 @@ DASHBOARD_HTML = """\
     </div>
     <div class="provider-card anthropic">
       <div class="pname">Anthropic</div>
-      <div class="pmodel">Claude Opus 4.6 &mdash; $5.00 / $25.00 per 1M tokens</div>
+      <div class="pmodel">Claude Fable 5 &mdash; $10.00 / $50.00 per 1M tokens</div>
       <div class="savings-amount" id="save-anthropic">$0.00</div>
       <div class="breakdown">
         <div class="item">
@@ -281,12 +281,12 @@ DASHBOARD_HTML = """\
   <div class="providers-heading">Energy &amp; Compute Avoided</div>
   <div class="metrics-row">
     <div class="metric-card">
-      <div class="mheading">Energy Saved (vs GPT-5.3)</div>
+      <div class="mheading">Energy Saved (vs GPT-5.6 Sol)</div>
       <div class="mvalue green" id="energy-joules">0 <span class="munit">J</span></div>
       <div class="msub" id="energy-kwh">0 kWh of cloud datacenter energy avoided</div>
     </div>
     <div class="metric-card">
-      <div class="mheading">FLOPs Avoided (vs GPT-5.3)</div>
+      <div class="mheading">FLOPs Avoided (vs GPT-5.6 Sol)</div>
       <div class="mvalue purple" id="flops-val">0 <span class="munit">FLOP</span></div>
       <div class="msub" id="flops-sub">cloud compute operations not needed</div>
     </div>
@@ -354,8 +354,8 @@ async function refresh() {
       providerMap[p.provider] = p;
     });
 
-    // OpenAI / GPT-5.3
-    const oa = providerMap['gpt-5.3'] || {};
+    // OpenAI / GPT-5.6 Sol
+    const oa = providerMap['gpt-5.6-sol'] || {};
     document.getElementById('save-openai')
       .textContent = fmtDollar(oa.total_cost || 0);
     document.getElementById('save-openai-in')
@@ -363,8 +363,8 @@ async function refresh() {
     document.getElementById('save-openai-out')
       .textContent = fmtDollar(oa.output_cost || 0);
 
-    // Anthropic / Claude Opus 4.6
-    const an = providerMap['claude-opus-4.6'] || {};
+    // Anthropic / Claude Fable 5
+    const an = providerMap['claude-fable-5'] || {};
     document.getElementById('save-anthropic')
       .textContent = fmtDollar(an.total_cost || 0);
     document.getElementById('save-anthropic-in')
@@ -384,13 +384,13 @@ async function refresh() {
     // Monthly projections
     const proj = d.monthly_projection || {};
     document.getElementById('proj-openai')
-      .textContent = fmtDollar(proj['gpt-5.3'] || 0);
+      .textContent = fmtDollar(proj['gpt-5.6-sol'] || 0);
     document.getElementById('proj-anthropic')
-      .textContent = fmtDollar(proj['claude-opus-4.6'] || 0);
+      .textContent = fmtDollar(proj['claude-fable-5'] || 0);
     document.getElementById('proj-google')
       .textContent = fmtDollar(proj['gemini-3.1-pro'] || 0);
 
-    // Energy / FLOPs (use GPT-5.3 as reference)
+    // Energy / FLOPs (use GPT-5.6 Sol as reference)
     const ej = oa.energy_joules || 0;
     const eWh = oa.energy_wh || 0;
     const fl = oa.flops || 0;

--- a/src/openjarvis/server/savings.py
+++ b/src/openjarvis/server/savings.py
@@ -23,19 +23,19 @@ from openjarvis.core.types import TOKEN_COUNTING_VERSION  # noqa: E402,F401
 # ---------------------------------------------------------------------------
 
 CLOUD_PRICING: Dict[str, Dict[str, float]] = {
-    "gpt-5.3": {
-        "input_per_1m": 2.00,
-        "output_per_1m": 10.00,
-        "label": "GPT-5.3",
+    "gpt-5.6-sol": {
+        "input_per_1m": 5.00,
+        "output_per_1m": 30.00,
+        "label": "GPT-5.6 Sol",
         "provider": "OpenAI",
         "params_b": 200.0,
         "energy_wh_per_1k_tokens": 0.4,
         "flops_per_token": 3.0e12,
     },
-    "claude-opus-4.6": {
-        "input_per_1m": 5.00,
-        "output_per_1m": 25.00,
-        "label": "Claude Opus 4.6",
+    "claude-fable-5": {
+        "input_per_1m": 10.00,
+        "output_per_1m": 50.00,
+        "label": "Claude Fable 5",
         "provider": "Anthropic",
         "params_b": 137.0,
         "energy_wh_per_1k_tokens": 0.5,

--- a/tests/evals/test_use_case_benchmarks.py
+++ b/tests/evals/test_use_case_benchmarks.py
@@ -347,7 +347,7 @@ class TestCostCalculator:
             calls_per_month=1000,
             avg_input_tokens=500,
             avg_output_tokens=200,
-            provider_key="gpt-5.3",
+            provider_key="gpt-5.6-sol",
         )
         assert est.monthly_cost > 0
         assert est.annual_cost == est.monthly_cost * 12


### PR DESCRIPTION
## What

Refreshes the **cost-comparison / savings** surfaces to current frontier cloud pricing (per 1M tokens, verified against published API pricing):

| Provider | Before | After |
|---|---|---|
| OpenAI | GPT-5.3 — $2 in / $10 out | **GPT-5.6 Sol — $5 in / $30 out** |
| Anthropic | Claude Opus 4.6 — $5 in / $25 out | **Claude Fable 5 — $10 in / $50 out** |
| Google | Gemini 3.1 Pro — $2 in / $12 out | *unchanged* |

GPT-5.6 Sol went GA 2026-07-09 at $5/$30 (flagship "Sol" tier). Claude Fable 5 is $10/$50 (2× Opus 4.8).

## Where

The comparison data was duplicated across several surfaces; all updated together so backend, server-rendered pages, and the desktop UI stay consistent:

- `server/savings.py` — canonical `CLOUD_PRICING` (feeds `cost_calculator.py`)
- `server/dashboard.py`, `server/comparison.py` — server-rendered `/dashboard` & `/comparison` HTML+JS
- `Dashboard/CostComparison.tsx`, `Chat/SystemPanel.tsx`, `pages/AgentsPage.tsx` — React cost tables
- `Desktop/SavingsDashboard.tsx` — `PROVIDER_COLORS` keys
- `docs/leaderboard.md` — savings methodology note

Internal provider keys are renamed in lockstep (`gpt-5.3`→`gpt-5.6-sol`, `claude-opus-4.6`→`claude-fable-5`) so dict keys, dashboard JS lookups, and frontend color maps all match. The leaderboard payload is aggregate-only, so no stored-data migration is needed.

## Scope notes

- Energy/FLOPs metadata (`params_b`, `energy_wh_per_1k_tokens`, `flops_per_token`) carried over unchanged — only models + costs were in scope.
- `intelligence/model_catalog.py` and `evals/` configs left untouched (real model / benchmark entries, not the cost comparison).

## Verification

- `ruff check` on changed Python — passed
- `pytest tests/evals/test_use_case_benchmarks.py` cost/scenario tests — 5 passed
- `tsc --noEmit` on frontend — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)