### PR TITLE
Fix leaderboard savings lookup after provider-key rename (#634 follow-up)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -89,7 +89,7 @@ export default function App() {
           setSavings(data);
           if (optInEnabled && optInDisplayName && data) {
             const claudeEntry = data.per_provider.find(
-              (p) => p.provider === 'claude-opus-4.6',
+              (p) => p.provider === 'claude-fable-5',
             );
             const dollarSavings = claudeEntry ? claudeEntry.total_cost : 0;
             const energySaved = data.per_provider.reduce(


### PR DESCRIPTION
## What

Follow-up fix for a regression introduced by #634.

That PR renamed the Anthropic cost-comparison provider key `claude-opus-4.6` → `claude-fable-5` across the backend and most frontend consumers, but missed one: `App.tsx` computes the leaderboard `dollar_savings` figure by finding the Anthropic entry by key:

```js
const claudeEntry = data.per_provider.find((p) => p.provider === 'claude-opus-4.6');
const dollarSavings = claudeEntry ? claudeEntry.total_cost : 0;
```

After the rename that `.find()` returns `undefined`, so this path silently submitted **`dollar_savings = 0`** to the leaderboard. This one-line fix points the lookup at the new key.

## How it was found

Post-merge exhaustive grep for consumers of the renamed keys (`grep '.provider ===' / 'providerMap[' / per_provider.find`). This was the **only** remaining stale consumer — all other lookups (dashboard `providerMap`, `PROVIDER_COLORS`) already use the new keys.

## Verification

- `tsc --noEmit` — clean
- Confirmed no other `claude-opus-4.6` / `gpt-5.3` string-literal key references remain repo-wide (the `claude-opus-4-6` dashed id in `CommandPalette.tsx` is the real model-selector entry, intentionally unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)