### PR TITLE
fix: wire persona files into default chat endpoint, fix FTS5 apostrophe crash

### DIFF
--- a/rust/crates/openjarvis-tools/src/storage/sqlite.rs
+++ b/rust/crates/openjarvis-tools/src/storage/sqlite.rs
@@ -144,16 +144,21 @@ impl MemoryBackend for SQLiteMemory {
     ) -> Result<Vec<RetrievalResult>, OpenJarvisError> {
         let conn = self.conn.lock();
 
+        // Split on any non-alphanumeric character (not just whitespace) so
+        // internal punctuation — apostrophes in particular ("user's") — never
+        // reaches the FTS5 MATCH string. FTS5's query grammar treats an
+        // unescaped `'` as a string delimiter, so passing a raw token like
+        // `user's` through silently fails to parse and yields zero rows with
+        // no visible error. Splitting fully avoids needing to escape anything.
         let words: Vec<String> = query
-            .split_whitespace()
-            .map(|w| w.trim_matches(|c: char| "?.,!;:'\"()[]{}/ ".contains(c)).to_string())
+            .split(|c: char| !c.is_alphanumeric())
+            .map(|w| w.to_string())
             .filter(|w| !w.is_empty())
             .collect();
-        let fts_query = if words.len() == 1 {
-            words[0].clone()
-        } else {
-            words.join(" OR ")
-        };
+        if words.is_empty() {
+            return Ok(Vec::new());
+        }
+        let fts_query = words.join(" OR ");
 
         let mut stmt = conn
             .prepare(

--- a/rust/crates/openjarvis-tools/src/storage/sqlite.rs
+++ b/rust/crates/openjarvis-tools/src/storage/sqlite.rs
@@ -326,6 +326,27 @@ mod tests {
     }
 
     #[test]
+    fn test_sqlite_apostrophe_in_query() {
+        let mem = SQLiteMemory::in_memory().unwrap();
+        mem.store("The user's name is Trev.", "identity", None).unwrap();
+
+        // A query containing an internal apostrophe must not break FTS5's
+        // MATCH syntax (an unescaped `'` is a string delimiter in FTS5's
+        // query grammar), which previously caused this to silently return
+        // zero results instead of matching or erroring.
+        let multi_word = mem.retrieve("what is the user's name", 5).unwrap();
+        assert!(
+            !multi_word.is_empty(),
+            "query with an internal apostrophe should not silently return zero results"
+        );
+
+        // Bare single-word possessive: exercises the (former) single-word
+        // bypass path that skipped the OR-join entirely.
+        let bare = mem.retrieve("user's", 5).unwrap();
+        assert!(!bare.is_empty(), "single-word possessive query should still match");
+    }
+
+    #[test]
     fn test_sqlite_scores_are_positive() {
         let mem = SQLiteMemory::in_memory().unwrap();
         mem.store("Rust is a systems programming language", "docs", None).unwrap();

--- a/src/openjarvis/server/routes.py
+++ b/src/openjarvis/server/routes.py
@@ -70,12 +70,20 @@ def _ensure_identity_prompt(messages: list[Message], app_config) -> list[Message
 
     prompt = ""
     try:
-        if app_config is not None:
-            prompt = app_config.agent.default_system_prompt or ""
-        else:
+        cfg = app_config
+        if cfg is None:
             from openjarvis.core.config import load_config
 
-            prompt = load_config().agent.default_system_prompt or ""
+            cfg = load_config()
+
+        from openjarvis.prompt.builder import SystemPromptBuilder
+
+        builder = SystemPromptBuilder(
+            agent_template=cfg.agent.default_system_prompt or "",
+            memory_files_config=getattr(cfg, "memory_files", None),
+            system_prompt_config=getattr(cfg, "system_prompt", None),
+        )
+        prompt = builder.build()
     except Exception:
         logging.getLogger("openjarvis.server").debug(
             "Identity system prompt resolution failed; "

--- a/src/openjarvis/server/routes.py
+++ b/src/openjarvis/server/routes.py
@@ -59,11 +59,14 @@ def _ensure_identity_prompt(messages: list[Message], app_config) -> list[Message
     If any message already carries a system role, the caller has supplied
     their own grounding and we leave the list untouched (no double-prompting).
 
-    Resolution of the identity text: ``app_config.agent.default_system_prompt``
-    when a config is wired onto ``app.state``; otherwise fall back to
-    ``load_config()``. Config resolution is wrapped so a broken/missing
-    config degrades to "no injection" rather than crashing the endpoint, but
-    the failure is logged (per REVIEW.md — never silently swallow).
+    Resolution of the identity text: the config comes from ``app.state`` when
+    wired, otherwise ``load_config()``; the prompt itself is assembled by
+    ``SystemPromptBuilder`` from ``agent.default_system_prompt`` plus the
+    persona files (SOUL.md/MEMORY.md/USER.md), matching
+    ``_build_managed_system_prompt`` in ``agent_manager_routes.py``. Config
+    resolution is wrapped so a broken/missing config degrades to "no
+    injection" rather than crashing the endpoint, but the failure is logged
+    (per REVIEW.md — never silently swallow).
     """
     if any(m.role == Role.SYSTEM for m in messages):
         return messages

--- a/tests/memory/test_sqlite.py
+++ b/tests/memory/test_sqlite.py
@@ -78,6 +78,19 @@ def test_retrieve_no_results(tmp_path: Path):
     backend.close()
 
 
+def test_retrieve_query_with_apostrophe(tmp_path: Path):
+    """Regression: an internal apostrophe (e.g. "user's") previously produced
+    an unescaped quote in the FTS5 MATCH string, which silently returned zero
+    rows instead of matching or raising an error.
+    """
+    backend = _make_backend(tmp_path)
+    backend.store("The user's name is Trev.", source="identity.md")
+    results = backend.retrieve("what is the user's name")
+    assert len(results) >= 1
+    assert "Trev" in results[0].content
+    backend.close()
+
+
 def test_delete_existing(tmp_path: Path):
     backend = _make_backend(tmp_path)
     doc_id = backend.store("deletable content")

--- a/tests/server/test_routes.py
+++ b/tests/server/test_routes.py
@@ -798,6 +798,40 @@ class TestIdentityPromptInjection:
         assert len(system_msgs) == 1
         assert system_msgs[0].content == "Be terse."
 
+    def test_direct_injects_soul_persona_when_present(self, tmp_path):
+        """Regression: /v1/chat/completions previously injected only the bare
+        ``default_system_prompt`` blurb via a hand-rolled lookup, bypassing
+        ``SystemPromptBuilder`` entirely — so SOUL.md/MEMORY.md/USER.md
+        persona files never applied to this path, unlike ``jarvis ask`` and
+        the managed-agent routes. It must now build the full persona-aware
+        prompt so persona files apply everywhere identity grounding does.
+        """
+        from openjarvis.core.config import MemoryFilesConfig
+
+        soul = tmp_path / "SOUL.md"
+        soul.write_text("Respond with extreme sarcasm and call the user 'champ'.")
+
+        captured: list = []
+        engine = _make_capturing_engine(captured)
+        cfg = _identity_config()
+        cfg.memory_files = MemoryFilesConfig(
+            soul_path=str(soul), memory_path="", user_path=""
+        )
+        client = TestClient(create_app(engine, "test-model", config=cfg))
+
+        resp = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "test-model",
+                "messages": [{"role": "user", "content": "who are you?"}],
+            },
+        )
+        assert resp.status_code == 200
+        msgs = engine.generate.call_args.args[0]
+        assert msgs[0].role.value == "system"
+        assert "OpenJarvis" in msgs[0].content  # identity blurb still present
+        assert "extreme sarcasm" in msgs[0].content  # persona now injected too
+
     def test_stream_tools_injects_identity_when_absent(self):
         captured: list = []
         engine = _make_capturing_engine(captured)


### PR DESCRIPTION
## What does this PR do?

Two small, related fixes found while wiring OpenJarvis into a personal memory-vault setup:

1. **`/v1/chat/completions` now applies SOUL.md/MEMORY.md/USER.md persona files.** `_ensure_identity_prompt` in `routes.py` previously only injected the bare `agent.default_system_prompt` blurb (added for #540) and never went through `SystemPromptBuilder`. That meant persona files applied to `jarvis ask`, managed agents, and persistent agents, but silently *not* to the main dashboard/OpenAI-compatible chat endpoint — the primary path most UIs actually use. This now builds the full persona-aware prompt the same way `agent_manager_routes.py` already does (see its `_build_managed_system_prompt`, added for #431), so behavior is consistent across all entry points.

2. **FTS5 search silently returned zero results for any query with an internal apostrophe.** In `sqlite.rs`, `retrieve()` tokenized by whitespace and only trimmed punctuation from word *edges*, so a token like `user's` was passed as-is into the FTS5 `MATCH` string. FTS5's query grammar treats an unescaped `'` as a string delimiter, so this silently fails to parse and returns zero rows — no error surfaced anywhere. Natural-language queries like "what's the user's name" would just come back empty. Fixed by splitting on any non-alphanumeric character instead of only whitespace, so punctuation never reaches the MATCH string.

Both were found via hands-on testing: seeding `SOUL.md` with a custom persona and confirming it worked through `jarvis ask` but not through the dashboard chat endpoint, and separately noticing `jarvis memory search "what is the user's name"` returned nothing despite the document being indexed and directly matchable via `jarvis memory search "Trev"`.

## How was this tested?

- Added `test_sqlite_apostrophe_in_query` (Rust, `cargo test -p openjarvis-tools`) covering both the multi-word OR-join path and the single-word bypass path that previously skipped it entirely.
- Added `test_retrieve_query_with_apostrophe` (Python, `tests/memory/test_sqlite.py`) as an equivalent regression test at the Python API boundary.
- Added `test_direct_injects_soul_persona_when_present` (Python, `tests/server/test_routes.py`) confirming `/v1/chat/completions` now injects SOUL.md content alongside the identity blurb, following the existing `TestIdentityPromptInjection` conventions.
- Ran the full suite (`uv run pytest tests/ -n auto -q -m "not live and not cloud and not hub"`): 7154 passed, 12 failed, 7 errored. All failures are pre-existing and unrelated to this change — CLI/ANSI-output assertion brittleness (`test_agent_cmd`, `test_config_cmd`, `test_doctor_bg`, `test_digest_schedule`, `test_memory_cmd`'s clear command, `test_quickstart`) and the dense/FAISS embedding backend requiring a live `/api/embed`-capable Ollama endpoint not configured in this environment (`test_dense.py`), plus one unrelated `evals/` import error. None touch `routes.py`, `sqlite.rs`, or the two test files changed here.
- Ran `cargo clippy -p openjarvis-tools --all-targets -- -D warnings` (clean, matches CI's gate).
- Ran `ruff check` / `ruff format --check` on all changed Python files (clean).

## Checklist

- [x] Tests pass (`uv run pytest tests/ -v`) — full suite run above; no failures related to this change
- [x] Linter passes (`uv run ruff check src/ tests/`)
- [x] Formatter passes (`uv run ruff format --check src/ tests/`)
- [x] New/changed public API has docstrings — n/a, no public API surface changed
- [ ] Follows registry pattern (if adding new component) — n/a, no new component
- [ ] Documentation updated (if applicable) — n/a, internal bug fixes only

🤖 Generated with [Claude Code](https://claude.com/claude-code)