### PR TITLE
Add arXiv badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
   <p><i>Personal AI, On Personal Devices.</i></p>
 
   <p>
+    <a href="https://arxiv.org/abs/2605.17172"><img src="https://img.shields.io/badge/arXiv-2605.17172-b31b1b.svg" alt="arXiv"></a>
     <a href="https://openjarvis.stanford.edu/"><img src="https://img.shields.io/badge/project-OpenJarvis-blue" alt="Project"></a>
     <a href="https://open-jarvis.github.io/OpenJarvis/"><img src="https://img.shields.io/badge/docs-mkdocs-blue" alt="Docs"></a>
     <img src="https://img.shields.io/badge/python-%3E%3D3.10-blue" alt="Python">


### PR DESCRIPTION
Adds a red arXiv badge linking to the OpenJarvis paper ([2605.17172](https://arxiv.org/abs/2605.17172)) as the first item in the README header badge row, matching the style used on the [Intelligence-Per-Watt repo](https://github.com/HazyResearch/intelligence-per-watt).

```html
<a href="https://arxiv.org/abs/2605.17172"><img src="https://img.shields.io/badge/arXiv-2605.17172-b31b1b.svg" alt="arXiv"></a>
```

Same badge format and `b31b1b` arXiv-red color as IPW. Badge image URL verified (HTTP 200, `image/svg+xml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)