### PR TITLE
style(skills): wrap importer manifest parse call

### DIFF
--- a/src/openjarvis/skills/importer.py
+++ b/src/openjarvis/skills/importer.py
@@ -104,7 +104,9 @@ class SkillImporter:
 
         try:
             frontmatter, body = self._read_skill_md(source_md)
-            manifest = self._parser.parse_frontmatter(frontmatter, markdown_content=body)
+            manifest = self._parser.parse_frontmatter(
+                frontmatter, markdown_content=body
+            )
         except Exception as exc:
             result.success = False
             result.warnings.append(f"Parse error: {exc}")


### PR DESCRIPTION
Fixes the Ruff E501 failure on main introduced while fixing up #639. The call was 89 characters against the repository's 88-character limit. No behavior change.\n\nVerification:\n- `uvx ruff@0.14.14 check src/ tests/` — passed\n- `pytest tests/skills/test_importer.py tests/skills/test_skills.py -q` — 31 passed