### PR TITLE
style: apply Ruff formatting to recently merged tests

### DIFF
--- a/tests/skills/test_importer.py
+++ b/tests/skills/test_importer.py
@@ -255,9 +255,7 @@ class TestDangerousCapabilityGate:
         assert result.success
         assert result.requires_confirmation
         assert any("confirmed by caller" in w for w in result.warnings)
-        content = (
-            tmp_path / "skills" / "hermes" / "my-skill" / ".source"
-        ).read_text()
+        content = (tmp_path / "skills" / "hermes" / "my-skill" / ".source").read_text()
         assert 'trust_tier = "unreviewed"' in content
         assert 'dangerous_capabilities = ["shell:execute"]' in content
 
@@ -269,8 +267,6 @@ class TestDangerousCapabilityGate:
         assert result.success
         assert not result.requires_confirmation
         assert result.dangerous_capabilities == []
-        content = (
-            tmp_path / "skills" / "hermes" / "my-skill" / ".source"
-        ).read_text()
+        content = (tmp_path / "skills" / "hermes" / "my-skill" / ".source").read_text()
         assert 'trust_tier = "unreviewed"' in content
         assert "dangerous_capabilities = []" in content

--- a/tests/skills/test_skills.py
+++ b/tests/skills/test_skills.py
@@ -171,9 +171,7 @@ class TestSkillExecutorCapabilities:
         assert result.context.get("result") == "hello"
 
     def test_policy_blocks_missing_capability(self):
-        executor = SkillExecutor(
-            ToolExecutor([EchoTool()]), allowed_capabilities=set()
-        )
+        executor = SkillExecutor(ToolExecutor([EchoTool()]), allowed_capabilities=set())
         result = executor.run(self._manifest())
         assert not result.success
         assert len(result.step_results) == 1

--- a/tests/tools/test_knowledge_sql.py
+++ b/tests/tools/test_knowledge_sql.py
@@ -70,9 +70,7 @@ def test_allows_select_with_keyword_substring(store: KnowledgeStore) -> None:
     from openjarvis.tools.knowledge_sql import KnowledgeSQLTool
 
     tool = KnowledgeSQLTool(store=store)
-    result = tool.execute(
-        query="SELECT author AS created_author FROM knowledge_chunks"
-    )
+    result = tool.execute(query="SELECT author AS created_author FROM knowledge_chunks")
     assert result.success, result.content
     assert "Alice" in result.content
 


### PR DESCRIPTION
Fixes the Ruff formatter check on main. These three test files were added or edited across #639 and #640 but had not been run through the repository's pinned Ruff 0.15.1 formatter. No behavior change.\n\nVerification:\n- `uvx ruff@0.15.1 check src/ tests/` — passed\n- `uvx ruff@0.15.1 format --check src/ tests/` — 1,293 files formatted\n- affected tests — 41 passed