### PR TITLE
Fix(frontend): remove jitter when scrolling up during chat autoscroll

### DIFF
--- a/frontend/src/components/Chat/ChatArea.tsx
+++ b/frontend/src/components/Chat/ChatArea.tsx
@@ -22,6 +22,8 @@ export function ChatArea() {
   const navigate = useNavigate();
   const listRef = useRef<HTMLDivElement>(null);
   const shouldAutoScroll = useRef(true);
+  const wasStreaming = useRef(false);
+  const lastScrollTop = useRef(0);
 
   // Check if any data sources are connected
   const [hasConnectedSources, setHasConnectedSources] = useState<boolean | null>(null);
@@ -34,15 +36,34 @@ export function ChatArea() {
   }, []);
 
   useEffect(() => {
+    // Sending a message always pins the view to the bottom, even if the
+    // user had scrolled up to read earlier messages.
+    if (streamState.isStreaming && !wasStreaming.current) {
+      shouldAutoScroll.current = true;
+    }
+    wasStreaming.current = streamState.isStreaming;
     if (shouldAutoScroll.current && listRef.current) {
       listRef.current.scrollTop = listRef.current.scrollHeight;
     }
-  }, [messages, streamState.content]);
+  }, [messages, streamState.content, streamState.isStreaming]);
 
   const handleScroll = () => {
     if (!listRef.current) return;
     const { scrollTop, scrollHeight, clientHeight } = listRef.current;
-    shouldAutoScroll.current = scrollHeight - scrollTop - clientHeight < 1;
+    const distance = scrollHeight - scrollTop - clientHeight;
+    const scrolledUp = scrollTop < lastScrollTop.current;
+    lastScrollTop.current = scrollTop;
+    if (scrolledUp && distance >= 1) {
+      // Any upward scroll away from the bottom stops autoscroll immediately,
+      // so streaming content never fights the user (no jitter). Sub-1px
+      // upward movement (elastic bounce settling at the bottom) is ignored.
+      shouldAutoScroll.current = false;
+    } else if (!scrolledUp) {
+      // Re-engage when scrolled back to the bottom. < 2 rather than < 1:
+      // at fractional zoom levels the at-bottom residual can reach 1px,
+      // which would otherwise leave autoscroll permanently disengaged.
+      shouldAutoScroll.current = distance < 2;
+    }
   };
 
   const isEmpty = messages.length === 0 && !streamState.isStreaming;

--- a/frontend/src/components/Chat/ChatArea.tsx
+++ b/frontend/src/components/Chat/ChatArea.tsx
@@ -42,7 +42,7 @@ export function ChatArea() {
   const handleScroll = () => {
     if (!listRef.current) return;
     const { scrollTop, scrollHeight, clientHeight } = listRef.current;
-    shouldAutoScroll.current = scrollHeight - scrollTop - clientHeight < 100;
+    shouldAutoScroll.current = scrollHeight - scrollTop - clientHeight < 1;
   };
 
   const isEmpty = messages.length === 0 && !streamState.isStreaming;


### PR DESCRIPTION
## What does this PR do?

Originally while text was streaming in the chat area in the desktop app it was hard to scroll up creating a jitter when you tried to scroll up, because interface activated autoscroll when within 100px of the bottom. This PR changes the threshold to 1 px to create a smooth transition in and out of autoscroll when a response is streaming.

Before:
https://github.com/user-attachments/assets/312eb168-0250-4b8a-80ea-0f81e439849b

After:
https://github.com/user-attachments/assets/a0e41022-c330-4b35-b36a-7fb852cec016

## How was this tested?

This was tested by changing the threshold value and prompting a long response to test the autoscroll while streaming, and scrolling up at different speeds. Low values above 1 px still resulted in noticeable jitter when scrolling slowly albeit much less than 100px, while setting it to 0 px made it nearly impossible to trigger autoscroll.

## Checklist

- [x] Tests pass (`uv run pytest tests/ -v`)
- [x] Linter passes (`uv run ruff check src/ tests/`)
- [x] Formatter passes (`uv run ruff format --check src/ tests/`)
- [x] Frontend tests pass (npm test)
- [x] TypeScript passes (npx tsc --noEmit)
- [x] Frontend build passes (npm run build)
