### PR TITLE
fix(desktop): preserve active chat when switching models

### DIFF
--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -149,8 +149,7 @@ export function CommandPalette() {
     setCommandPaletteOpen(false);
 
     if (modelId !== previousModel) {
-      const { createConversation, setModelLoading, addLogEntry } = useAppStore.getState();
-      createConversation(modelId);
+      const { setModelLoading, addLogEntry } = useAppStore.getState();
       setModelLoading(true);
       addLogEntry({ timestamp: Date.now(), level: 'info', category: 'model', message: `Switching to ${modelId}...` });
       try {


### PR DESCRIPTION
## Problem

Switching models from the desktop command palette calls `createConversation()` whenever the selected model changes which creates an empty conversation and a "New chat" entry each time. This can clutter your sidebar when switching models without sending messages as it gets full of "New chat" entries, and since it is possible to switch models within a chat, creating a new conversation each time just creates friction.

## Fix

Remove the conversation-creation side effect from model selection. Switching models now preserves the active chat while retaining the existing model preloading, loading state, logging, and in-flight stream cancellation behavior.

The next request uses the newly selected model with the current conversation context.

## Verification

- `npm run build` — passed
- `npm test` — 6 tests passed
- `npx tsc --noEmit` — passed
- `git diff --check` — passed

No public API or documentation changes are required.