### PR TITLE
fix(desktop): keep background streams out of active chat

### DIFF
--- a/frontend/src/components/Chat/ChatArea.tsx
+++ b/frontend/src/components/Chat/ChatArea.tsx
@@ -15,6 +15,7 @@ function getGreeting(): string {
 }
 
 export function ChatArea() {
+  const activeId = useAppStore((s) => s.activeId);
   const messages = useAppStore((s) => s.messages);
   const streamState = useAppStore((s) => s.streamState);
   const systemPanelOpen = useAppStore((s) => s.systemPanelOpen);
@@ -24,6 +25,8 @@ export function ChatArea() {
   const shouldAutoScroll = useRef(true);
   const wasStreaming = useRef(false);
   const lastScrollTop = useRef(0);
+  const isCurrentChatStreaming = streamState.isStreaming && streamState.conversationId === activeId;
+  const currentStreamContent = isCurrentChatStreaming ? streamState.content : '';
 
   // Check if any data sources are connected
   const [hasConnectedSources, setHasConnectedSources] = useState<boolean | null>(null);
@@ -38,14 +41,14 @@ export function ChatArea() {
   useEffect(() => {
     // Sending a message always pins the view to the bottom, even if the
     // user had scrolled up to read earlier messages.
-    if (streamState.isStreaming && !wasStreaming.current) {
+    if (isCurrentChatStreaming && !wasStreaming.current) {
       shouldAutoScroll.current = true;
     }
-    wasStreaming.current = streamState.isStreaming;
+    wasStreaming.current = isCurrentChatStreaming;
     if (shouldAutoScroll.current && listRef.current) {
       listRef.current.scrollTop = listRef.current.scrollHeight;
     }
-  }, [messages, streamState.content, streamState.isStreaming]);
+  }, [messages, currentStreamContent, isCurrentChatStreaming]);
 
   const handleScroll = () => {
     if (!listRef.current) return;
@@ -66,7 +69,7 @@ export function ChatArea() {
     }
   };
 
-  const isEmpty = messages.length === 0 && !streamState.isStreaming;
+  const isEmpty = messages.length === 0 && !isCurrentChatStreaming;
 
   const PanelIcon = systemPanelOpen ? PanelRightClose : PanelRightOpen;
 
@@ -174,12 +177,12 @@ export function ChatArea() {
                 <MessageBubble
                   key={msg.id}
                   message={msg}
-                  isLive={isLastAssistant && streamState.isStreaming}
+                  isLive={isLastAssistant && isCurrentChatStreaming}
                 />
               );
             })}
             {(() => {
-              if (!streamState.isStreaming || streamState.content !== '') return null;
+              if (!isCurrentChatStreaming || streamState.content !== '') return null;
               // For research messages the ResearchTimeline handles its own
               // pre-content loading state — suppress the generic dots.
               const last = messages[messages.length - 1];

--- a/frontend/src/components/Chat/InputArea.tsx
+++ b/frontend/src/components/Chat/InputArea.tsx
@@ -96,6 +96,7 @@ export function InputArea() {
   const deepResearch = useAppStore((s) => s.deepResearch);
   const setDeepResearch = useAppStore((s) => s.setDeepResearch);
   const corpusSync = useResearchCorpusSync(deepResearch);
+  const isCurrentChatStreaming = streamState.isStreaming && streamState.conversationId === activeId;
 
   const {
     state: speechState,
@@ -226,6 +227,7 @@ export function InputArea() {
     let ttftMs: number | undefined;
 
     setStreamState({
+      conversationId: convId,
       isStreaming: true,
       phase: deepResearch ? 'Researching...' : 'Generating...',
       elapsedMs: 0,
@@ -602,7 +604,7 @@ export function InputArea() {
           style={{ color: 'var(--color-text)', maxHeight: '200px' }}
           disabled={streamState.isStreaming || modelLoading}
         />
-        {streamState.isStreaming ? (
+        {isCurrentChatStreaming ? (
           <button
             onClick={stopStreaming}
             className="p-2 rounded-xl transition-colors shrink-0 cursor-pointer"
@@ -621,7 +623,7 @@ export function InputArea() {
             />
             <button
               onClick={sendMessage}
-              disabled={!input.trim() || modelLoading || !selectedModel}
+              disabled={streamState.isStreaming || !input.trim() || modelLoading || !selectedModel}
               title={selectedModel ? 'Send message' : 'Pick a model first (⌘K)'}
               className="p-2 rounded-xl transition-colors shrink-0 cursor-pointer disabled:opacity-30 disabled:cursor-default"
               style={{

--- a/frontend/src/components/Sidebar/ConversationList.tsx
+++ b/frontend/src/components/Sidebar/ConversationList.tsx
@@ -22,6 +22,9 @@ export function ConversationList({ searchQuery }: Props) {
   const navigate = useNavigate();
   const conversations = useAppStore((s) => s.conversations);
   const activeId = useAppStore((s) => s.activeId);
+  const streamingConversationId = useAppStore((s) =>
+    s.streamState.isStreaming ? s.streamState.conversationId : null,
+  );
   const selectConversation = useAppStore((s) => s.selectConversation);
   const deleteConversation = useAppStore((s) => s.deleteConversation);
 
@@ -43,6 +46,7 @@ export function ConversationList({ searchQuery }: Props) {
     <div className="flex flex-col gap-0.5 py-1">
       {filtered.map((conv) => {
         const isActive = conv.id === activeId;
+        const isStreaming = conv.id === streamingConversationId;
         return (
           <div
             key={conv.id}
@@ -82,11 +86,18 @@ export function ConversationList({ searchQuery }: Props) {
                 e.stopPropagation();
                 deleteConversation(conv.id);
               }}
-              className="p-1.5 mr-1 rounded opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer"
+              disabled={isStreaming}
+              className="p-1.5 mr-1 rounded opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer disabled:cursor-not-allowed disabled:opacity-30"
               style={{ color: 'var(--color-text-tertiary)' }}
-              onMouseEnter={(e) => (e.currentTarget.style.color = 'var(--color-error)')}
+              onMouseEnter={(e) => {
+                if (!isStreaming) e.currentTarget.style.color = 'var(--color-error)';
+              }}
               onMouseLeave={(e) => (e.currentTarget.style.color = 'var(--color-text-tertiary)')}
-              title="Delete conversation"
+              title={
+                isStreaming
+                  ? 'Stop generating before deleting this conversation'
+                  : 'Delete conversation'
+              }
             >
               <Trash2 size={14} />
             </button>

--- a/frontend/src/lib/store.stream-ownership.test.ts
+++ b/frontend/src/lib/store.stream-ownership.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+class MemoryStorage {
+  private store = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.store.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.store.set(key, String(value));
+  }
+
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  (globalThis as unknown as { localStorage: MemoryStorage }).localStorage =
+    new MemoryStorage();
+});
+
+afterEach(() => {
+  (globalThis as unknown as { localStorage?: MemoryStorage }).localStorage =
+    undefined;
+});
+
+async function freshStore() {
+  return (await import('./store')).useAppStore;
+}
+
+describe('conversation stream ownership', () => {
+  it('persists background stream updates without replacing the active messages', async () => {
+    const store = await freshStore();
+    const sourceId = store.getState().createConversation('test-model');
+    store.getState().addMessage(sourceId, {
+      id: 'assistant',
+      role: 'assistant',
+      content: '',
+      timestamp: 1,
+    });
+
+    const activeId = store.getState().createConversation('test-model');
+    store.getState().setStreamState({
+      conversationId: sourceId,
+      isStreaming: true,
+      content: 'streamed response',
+    });
+    store.getState().updateLastAssistant(sourceId, 'streamed response');
+
+    expect(store.getState().activeId).toBe(activeId);
+    expect(store.getState().messages).toEqual([]);
+
+    store.getState().selectConversation(sourceId);
+    expect(store.getState().messages).toHaveLength(1);
+    expect(store.getState().messages[0].content).toBe('streamed response');
+  });
+
+  it('keeps the stream-owning conversation until generation stops', async () => {
+    const store = await freshStore();
+    const sourceId = store.getState().createConversation('test-model');
+    const activeId = store.getState().createConversation('test-model');
+    store.getState().setStreamState({
+      conversationId: sourceId,
+      isStreaming: true,
+    });
+
+    store.getState().deleteConversation(sourceId);
+    expect(
+      store.getState().conversations.map((conversation) => conversation.id),
+    ).toContain(sourceId);
+    expect(store.getState().activeId).toBe(activeId);
+
+    store.getState().resetStream();
+    store.getState().deleteConversation(sourceId);
+    expect(
+      store.getState().conversations.map((conversation) => conversation.id),
+    ).not.toContain(sourceId);
+  });
+});

--- a/frontend/src/lib/store.ts
+++ b/frontend/src/lib/store.ts
@@ -110,6 +110,7 @@ function saveSettings(settings: Settings): void {
 // ── Store ─────────────────────────────────────────────────────────────
 
 const INITIAL_STREAM: StreamState = {
+  conversationId: null,
   isStreaming: false,
   phase: '',
   elapsedMs: 0,
@@ -351,6 +352,9 @@ export const useAppStore = create<AppState>((set, get) => {
     },
 
     deleteConversation: (id: string) => {
+      const streamState = get().streamState;
+      if (streamState.isStreaming && streamState.conversationId === id) return;
+
       const store = loadConversations();
       delete store.conversations[id];
       if (store.activeId === id) {
@@ -393,12 +397,14 @@ export const useAppStore = create<AppState>((set, get) => {
           (message.content.length > 50 ? '...' : '');
       }
       saveConversations(store);
-      set({
-        messages: [...conv.messages],
-        conversations: Object.values(store.conversations).sort(
-          (a, b) => b.updatedAt - a.updatedAt,
-        ),
-      });
+      const conversations = Object.values(store.conversations).sort(
+        (a, b) => b.updatedAt - a.updatedAt,
+      );
+      if (get().activeId === conversationId) {
+        set({ messages: [...conv.messages], conversations });
+      } else {
+        set({ conversations });
+      }
     },
 
     updateLastAssistant: (
@@ -425,7 +431,9 @@ export const useAppStore = create<AppState>((set, get) => {
         if (researchSources) lastMsg.researchSources = researchSources;
         conv.updatedAt = Date.now();
         saveConversations(store);
-        set({ messages: [...conv.messages] });
+        if (get().activeId === conversationId) {
+          set({ messages: [...conv.messages] });
+        }
       }
     },
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -147,6 +147,7 @@ export interface ConversationStore {
 // --- Stream State ---
 
 export interface StreamState {
+  conversationId: string | null;
   isStreaming: boolean;
   phase: string;
   elapsedMs: number;


### PR DESCRIPTION
## Problem

When a response continues streaming after the user switches conversations, each streamed update replaces the messages currently shown with the streaming conversation’s messages.

Before the first token arrives, the global generating indicator also appears in whichever conversation is selected. When streaming finishes, the wrong messages can remain visible even though `activeId` still points to the conversation the user selected.

## Root cause

Streaming correctly retains the ID of its originating conversation, but `updateLastAssistant()` unconditionally replaces the global visible `messages` array after every update.

The global stream state also has no conversation ownership, so chat-specific UI such as generating dots, live-message styling, stop controls, empty-state rendering, and auto-scroll responds to any active stream.

## Fix

- Associate the global stream state with its originating conversation.
- Continue persisting streamed updates to the correct conversation.
- Only update the visible `messages` array when that conversation is selected.
- Only render chat-specific streaming UI when the selected conversation owns the stream.
- Preserve the existing global input lock so only one response can be generated at a time.

System-level activity indicators remain global.

## Verification

- manual testing of switching chats while one chat is streaming
- `npm test`
- `npx tsc --noEmit`
- `npm run build`
- `git diff --check`