### PR TITLE
fix(frontend): wrap tool descriptions in agent creator

### DIFF
--- a/frontend/src/pages/AgentsPage.tsx
+++ b/frontend/src/pages/AgentsPage.tsx
@@ -575,7 +575,7 @@ function ToolsPicker({
           </div>
           {/* Live description strip */}
           <div
-            className="flex items-center gap-2 px-2.5 py-1.5"
+            className="flex items-start gap-2 px-2.5 py-1.5"
             style={{
               borderTop: '1px solid var(--color-border)',
               background: 'var(--color-bg)',
@@ -609,10 +609,11 @@ function ToolsPicker({
               </span>
             )}
             <span
-              className="truncate"
+              className="min-w-0 whitespace-normal break-words"
               style={{
                 flex: 1,
                 color: 'var(--color-text-tertiary)',
+                lineHeight: 1.4,
               }}
             >
               {hovered ? `— ${hint}` : hint}


### PR DESCRIPTION
## Problem

Tool descriptions would truncate instead of wrapping when hovering over a tool in the agent creation window, preventing you from seeing what many tools do.

## Summary

- allow tool descriptions in the agent creation window to wrap onto multiple lines
- align the description row correctly when text spans multiple lines

## Testing

- `npm test`
- `npx tsc --noEmit`
- `npm run build`
