### PR TITLE
Add headless site audit tool (Playwright + axe-core)

### DIFF
--- a/scripts/site_audit/.gitignore
+++ b/scripts/site_audit/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+report/

--- a/scripts/site_audit/audit.mjs
+++ b/scripts/site_audit/audit.mjs
@@ -1,0 +1,305 @@
+#!/usr/bin/env node
+// Headless crawl of the OpenJarvis frontend. Boots the backend + vite dev
+// server (unless already running), clicks through every sidebar nav item
+// like a user would, and reports console errors, failed network requests,
+// blank/broken routes, broken images, accessibility violations, and slow
+// loads — plus a desktop + mobile screenshot per page.
+import { chromium } from 'playwright';
+import AxeBuilder from '@axe-core/playwright';
+import { spawn } from 'node:child_process';
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const REPORT_DIR = path.join(__dirname, 'report');
+const SHOT_DIR = path.join(REPORT_DIR, 'screenshots');
+
+const BACKEND_URL = process.env.AUDIT_BACKEND_URL || 'http://127.0.0.1:8000';
+const FRONTEND_URL = process.env.AUDIT_FRONTEND_URL || 'http://127.0.0.1:5173';
+const SKIP_START = process.argv.includes('--no-start');
+const VERBOSE = process.argv.includes('--verbose');
+
+const DESKTOP_VIEWPORT = { width: 1440, height: 900 };
+const MOBILE_VIEWPORT = { width: 390, height: 844 };
+const SLOW_LOAD_MS = 2000;
+
+function log(...args) {
+  console.log('[site-audit]', ...args);
+}
+
+async function isUp(url) {
+  try {
+    const res = await fetch(url, { signal: AbortSignal.timeout(2000) });
+    return res.status < 500;
+  } catch {
+    return false;
+  }
+}
+
+async function waitFor(url, timeoutMs, label) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (await isUp(url)) return;
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  throw new Error(`Timed out waiting for ${label} at ${url}`);
+}
+
+function spawnService(label, cmd, args, cwd) {
+  log(`starting ${label}: ${cmd} ${args.join(' ')} (cwd=${cwd})`);
+  const child = spawn(cmd, args, {
+    cwd,
+    // own process group so teardown can kill vite/uvicorn's own children too
+    detached: true,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  child.stdout.on('data', (d) => VERBOSE && process.stdout.write(`[${label}] ${d}`));
+  child.stderr.on('data', (d) => VERBOSE && process.stderr.write(`[${label}] ${d}`));
+  child.on('error', (err) => log(`${label} failed to start: ${err.message}`));
+  return child;
+}
+
+function killService(label, child) {
+  if (!child || child.killed) return;
+  try {
+    log(`stopping ${label}`);
+    process.kill(-child.pid, 'SIGTERM');
+  } catch (err) {
+    log(`could not stop ${label}: ${err.message}`);
+  }
+}
+
+// Dismisses first-visit/full-screen modals (e.g. the opt-in dialog) that
+// use the app's `.fixed.inset-0.z-50` overlay pattern and would otherwise
+// intercept every click for the rest of the crawl. No-op if none is open.
+async function dismissBlockingOverlay(page) {
+  const overlayButton = page.locator('.fixed.inset-0.z-50 button').first();
+  const present = await overlayButton.isVisible({ timeout: 1500 }).catch(() => false);
+  if (!present) return;
+  log('dismissing a blocking modal/overlay');
+  await overlayButton.click().catch(() => {});
+  await page.waitForTimeout(200);
+}
+
+async function runAudit() {
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ viewport: DESKTOP_VIEWPORT });
+  const page = await context.newPage();
+
+  const consoleIssues = [];
+  const networkIssues = [];
+  page.on('console', (msg) => {
+    if (msg.type() === 'error' || msg.type() === 'warning') {
+      consoleIssues.push({ type: msg.type(), text: msg.text() });
+    }
+  });
+  page.on('pageerror', (err) => {
+    consoleIssues.push({ type: 'pageerror', text: err.message });
+  });
+  page.on('requestfailed', (req) => {
+    networkIssues.push({ url: req.url(), reason: req.failure()?.errorText || 'request failed' });
+  });
+  page.on('response', (res) => {
+    if (res.status() >= 400) {
+      networkIssues.push({ url: res.url(), status: res.status() });
+    }
+  });
+
+  log('loading app shell...');
+  // NOT 'networkidle': Vite's dev-server HMR socket (and the app's own
+  // polling) stays open indefinitely, so networkidle never fires and every
+  // wait stalls for its full timeout. Wait for the sidebar to actually
+  // render instead, which is what a real user would wait for.
+  await page.goto(FRONTEND_URL, { waitUntil: 'domcontentloaded' });
+  await page.locator('nav button').first().waitFor({ state: 'visible', timeout: 15_000 });
+  await dismissBlockingOverlay(page);
+
+  const navLabels = await page.locator('nav button').allInnerTexts();
+  log(`discovered ${navLabels.length} nav items: ${navLabels.join(', ')}`);
+
+  const pages = [];
+  for (const label of navLabels) {
+    const consoleBefore = consoleIssues.length;
+    const networkBefore = networkIssues.length;
+    const issues = [];
+
+    try {
+      // Client-side route change, not a real navigation — no load event to
+      // wait for. Give React + its data fetch a moment to settle instead.
+      await page.locator('nav button', { hasText: label }).first().click();
+      await page.waitForTimeout(800);
+      await dismissBlockingOverlay(page);
+    } catch (err) {
+      log(`  ${label}: could not click nav item — ${err.message.split('\n')[0]}`);
+      issues.push({ category: 'navigation', severity: 'critical', detail: `Clicking sidebar item "${label}" failed: ${err.message.split('\n')[0]}` });
+      pages.push({ label, url: page.url(), slug: label.toLowerCase().replace(/[^a-z0-9]+/g, '-'), blank: true, timing: null, issues });
+      await page.keyboard.press('Escape').catch(() => {});
+      continue;
+    }
+
+    const url = page.url();
+    const slug = label.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-+|-+$)/g, '') || 'page';
+    let blank = false;
+    let timing = null;
+
+    try {
+      const mainState = await page.evaluate(() => {
+        const main = document.querySelector('main');
+        if (!main) return { present: false, textLength: 0, childCount: 0 };
+        return {
+          present: true,
+          textLength: main.innerText.trim().length,
+          childCount: main.children.length,
+        };
+      });
+      blank = !mainState.present || (mainState.textLength === 0 && mainState.childCount === 0);
+
+      const brokenImages = await page.evaluate(() =>
+        Array.from(document.images)
+          .filter((img) => img.complete && img.naturalWidth === 0)
+          .map((img) => img.currentSrc || img.src),
+      );
+
+      timing = await page.evaluate(() => {
+        const entry = performance.getEntriesByType('navigation')[0];
+        return entry ? { domContentLoaded: entry.domContentLoadedEventEnd, load: entry.loadEventEnd } : null;
+      });
+
+      let axeViolations = [];
+      try {
+        const axeResults = await new AxeBuilder({ page }).analyze();
+        axeViolations = axeResults.violations.map((v) => ({
+          id: v.id,
+          impact: v.impact || 'moderate',
+          help: v.help,
+          nodes: v.nodes.length,
+        }));
+      } catch (err) {
+        axeViolations = [{ id: 'axe-error', impact: 'unknown', help: err.message, nodes: 0 }];
+      }
+
+      await page.screenshot({ path: path.join(SHOT_DIR, `${slug}-desktop.png`), fullPage: true });
+      await page.setViewportSize(MOBILE_VIEWPORT);
+      await page.waitForTimeout(150);
+      await page.screenshot({ path: path.join(SHOT_DIR, `${slug}-mobile.png`), fullPage: true });
+      await page.setViewportSize(DESKTOP_VIEWPORT);
+
+      if (blank) {
+        issues.push({
+          category: 'navigation',
+          severity: 'critical',
+          detail: `Sidebar item "${label}" navigated to ${url} but rendered a blank page (no matching route or empty component).`,
+        });
+      }
+      for (const c of consoleIssues.slice(consoleBefore)) {
+        issues.push({ category: 'console', severity: c.type === 'pageerror' ? 'critical' : 'warning', detail: c.text });
+      }
+      for (const n of networkIssues.slice(networkBefore)) {
+        issues.push({ category: 'network', severity: 'error', detail: n.status ? `HTTP ${n.status} — ${n.url}` : `${n.reason} — ${n.url}` });
+      }
+      for (const img of brokenImages) {
+        issues.push({ category: 'images', severity: 'warning', detail: `Broken image: ${img}` });
+      }
+      for (const v of axeViolations) {
+        issues.push({ category: 'accessibility', severity: v.impact, detail: `${v.id}: ${v.help} (${v.nodes} node(s))` });
+      }
+      if (timing && timing.load > SLOW_LOAD_MS) {
+        issues.push({ category: 'performance', severity: 'warning', detail: `Page load took ${Math.round(timing.load)}ms (>${SLOW_LOAD_MS}ms)` });
+      }
+    } catch (err) {
+      log(`  ${label}: error while inspecting page — ${err.message.split('\n')[0]}`);
+      issues.push({ category: 'crawl-error', severity: 'critical', detail: `Inspection failed on "${label}": ${err.message.split('\n')[0]}` });
+    }
+
+    pages.push({ label, url, slug, blank, timing, issues });
+    log(`  ${label} -> ${url}: ${issues.length} issue(s)${blank ? ' [BLANK PAGE]' : ''}`);
+  }
+
+  await browser.close();
+  return { generatedAt: new Date().toISOString(), pages };
+}
+
+async function writeReport(report) {
+  await writeFile(path.join(REPORT_DIR, 'report.json'), JSON.stringify(report, null, 2));
+
+  const lines = [];
+  const totalIssues = report.pages.reduce((s, p) => s + p.issues.length, 0);
+  lines.push(`# Site audit — ${report.generatedAt}`, '');
+  lines.push(`${report.pages.length} pages crawled, ${totalIssues} issue(s) found.`, '');
+
+  for (const p of report.pages) {
+    const marker = p.blank ? '❌' : p.issues.length ? '⚠️' : '✅';
+    lines.push(`## ${marker} ${p.label} (${p.url})`, '');
+    lines.push(`Screenshots: \`screenshots/${p.slug}-desktop.png\`, \`screenshots/${p.slug}-mobile.png\``, '');
+    if (p.issues.length === 0) {
+      lines.push('No issues found.', '');
+      continue;
+    }
+    for (const issue of p.issues) {
+      lines.push(`- **[${issue.severity}] ${issue.category}** — ${issue.detail}`);
+    }
+    lines.push('');
+  }
+
+  await writeFile(path.join(REPORT_DIR, 'report.md'), lines.join('\n'));
+}
+
+function printSummary(report) {
+  console.log('\n=== Site audit summary ===');
+  for (const p of report.pages) {
+    const marker = p.blank ? '❌' : p.issues.length ? '⚠️ ' : '✅';
+    const count = p.issues.length ? `${p.issues.length} issue(s)` : 'clean';
+    console.log(`  ${marker} ${p.label.padEnd(14)} ${count}`);
+  }
+  console.log(`\nFull report: scripts/site_audit/report/report.md`);
+  console.log(`Screenshots: scripts/site_audit/report/screenshots/`);
+}
+
+async function main() {
+  await mkdir(SHOT_DIR, { recursive: true });
+
+  let backendChild;
+  let frontendChild;
+  const backendAlreadyUp = await isUp(`${BACKEND_URL}/health`);
+  const frontendAlreadyUp = await isUp(FRONTEND_URL);
+
+  try {
+    if (!SKIP_START) {
+      if (!backendAlreadyUp) {
+        backendChild = spawnService('backend', 'uv', ['run', 'jarvis', 'serve'], REPO_ROOT);
+        await waitFor(`${BACKEND_URL}/health`, 60_000, 'backend');
+      } else {
+        log('backend already running at ' + BACKEND_URL + ', reusing it');
+      }
+      if (!frontendAlreadyUp) {
+        frontendChild = spawnService(
+          'frontend',
+          'npm',
+          ['run', 'dev', '--', '--host', '127.0.0.1', '--port', '5173', '--strictPort'],
+          path.join(REPO_ROOT, 'frontend'),
+        );
+        await waitFor(FRONTEND_URL, 60_000, 'frontend');
+      } else {
+        log('frontend already running at ' + FRONTEND_URL + ', reusing it');
+      }
+    } else {
+      await waitFor(`${BACKEND_URL}/health`, 5000, 'backend');
+      await waitFor(FRONTEND_URL, 5000, 'frontend');
+    }
+
+    const report = await runAudit();
+    await writeReport(report);
+    printSummary(report);
+    process.exitCode = report.pages.some((p) => p.issues.length > 0) ? 1 : 0;
+  } finally {
+    killService('frontend', frontendChild);
+    killService('backend', backendChild);
+  }
+}
+
+main().catch((err) => {
+  console.error('[site-audit] fatal:', err);
+  process.exitCode = 1;
+});

--- a/scripts/site_audit/audit.mjs
+++ b/scripts/site_audit/audit.mjs
@@ -12,7 +12,13 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const REPO_ROOT = path.resolve(__dirname, '..', '..');
+// Override lets this script (living in one checkout/worktree) spawn the
+// backend + frontend from a different checkout — e.g. running it against
+// your primary working copy's uncommitted changes without copying the tool
+// there first.
+const REPO_ROOT = process.env.AUDIT_REPO_ROOT
+  ? path.resolve(process.env.AUDIT_REPO_ROOT)
+  : path.resolve(__dirname, '..', '..');
 const REPORT_DIR = path.join(__dirname, 'report');
 const SHOT_DIR = path.join(REPORT_DIR, 'screenshots');
 
@@ -126,6 +132,17 @@ async function runAudit() {
     const issues = [];
 
     try {
+      // A previous route may have unmounted the whole app shell (e.g. an
+      // unregistered route rendering nothing) — reset to a known-good page
+      // so one broken link doesn't take down every item after it.
+      const sidebarReady = await page.locator('nav button').first().isVisible({ timeout: 2000 }).catch(() => false);
+      if (!sidebarReady) {
+        log(`  sidebar missing before "${label}" (previous page likely broke it) — resetting to app shell`);
+        await page.goto(FRONTEND_URL, { waitUntil: 'domcontentloaded' });
+        await page.locator('nav button').first().waitFor({ state: 'visible', timeout: 15_000 });
+        await dismissBlockingOverlay(page);
+      }
+
       // Client-side route change, not a real navigation — no load event to
       // wait for. Give React + its data fetch a moment to settle instead.
       await page.locator('nav button', { hasText: label }).first().click();

--- a/scripts/site_audit/package-lock.json
+++ b/scripts/site_audit/package-lock.json
@@ -1,0 +1,87 @@
+{
+  "name": "site-audit",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "site-audit",
+      "version": "1.0.0",
+      "hasInstallScript": true,
+      "devDependencies": {
+        "@axe-core/playwright": "^4.10.1",
+        "playwright": "^1.49.0"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.12.1.tgz",
+      "integrity": "sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.12.1"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/scripts/site_audit/package.json
+++ b/scripts/site_audit/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "site-audit",
+  "private": true,
+  "version": "1.0.0",
+  "type": "module",
+  "description": "Headless crawl of the OpenJarvis frontend that reports console errors, network failures, broken nav, accessibility violations, and screenshots per page.",
+  "scripts": {
+    "audit": "node audit.mjs",
+    "postinstall": "playwright install chromium"
+  },
+  "devDependencies": {
+    "@axe-core/playwright": "^4.10.1",
+    "playwright": "^1.49.0"
+  }
+}


### PR DESCRIPTION
## Summary
- New `scripts/site_audit/` tool: a headless Playwright crawl of the frontend that boots (or reuses) the vite dev server + `jarvis serve` backend, clicks through every sidebar nav item like a real user, and reports console errors, failed network requests, blank/broken routes, broken images, axe-core accessibility violations, and slow loads.
- Saves a desktop + mobile screenshot per page and a Markdown/JSON report to `scripts/site_audit/report/` (gitignored).
- Dismisses the first-visit opt-in modal automatically so it doesn't block the crawl.

## How to run
```
cd scripts/site_audit
npm install        # once, also downloads a Chromium build via playwright
npm run audit
```
Reads `scripts/site_audit/report/report.md` for the findings and `report/screenshots/` for visuals.

## Test plan
- [x] Ran the script end-to-end against the real `jarvis serve` backend and vite dev server in a git worktree; verified clean startup/teardown of both processes.
- [x] Confirmed it correctly dismisses the first-visit opt-in modal that otherwise blocks every click.
- [x] Verified output: `report/report.md` + `report/report.json` + 14 screenshots (7 pages x desktop/mobile) generated correctly, with 20 real accessibility findings (missing button labels, contrast, unlabeled form controls) surfaced across pages.
- [ ] Not yet run against the working tree's in-progress Sidebar/MemoryPage changes (this worktree only has the last committed frontend state) — worth a rerun once those land, since the new `/memory` and `/digest` sidebar links aren't wired to routes yet and the crawler is expected to flag them as blank pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)