### PR TITLE
fix: strip openrouter/ prefix before forwarding to OpenRouter API

### DIFF
--- a/src/openjarvis/server/cloud_router.py
+++ b/src/openjarvis/server/cloud_router.py
@@ -371,7 +371,7 @@ async def stream_cloud(
                 "OPENROUTER_API_KEY not set — add it in the Cloud Models tab"
             )
         async for token in _stream_openai(
-            model,
+            model.removeprefix("openrouter/"),
             messages,
             temperature,
             max_tokens,

--- a/src/openjarvis/server/cloud_router.py
+++ b/src/openjarvis/server/cloud_router.py
@@ -84,6 +84,17 @@ def is_cloud_model(model: str) -> bool:
     return get_provider(model) is not None
 
 
+def _openrouter_model_id(model: str) -> str:
+    """Return the provider-facing ID for an OpenRouter model."""
+    prefix = "openrouter/"
+    candidate = model.removeprefix(prefix)
+    # OpenRouter owns IDs such as "openrouter/auto" itself. Only remove the
+    # LiteLLM routing prefix when the remainder is still a provider/model ID.
+    if model.startswith(prefix) and "/" in candidate:
+        return candidate
+    return model
+
+
 # ---------------------------------------------------------------------------
 # Message conversion
 # ---------------------------------------------------------------------------
@@ -371,7 +382,7 @@ async def stream_cloud(
                 "OPENROUTER_API_KEY not set — add it in the Cloud Models tab"
             )
         async for token in _stream_openai(
-            model.removeprefix("openrouter/"),
+            _openrouter_model_id(model),
             messages,
             temperature,
             max_tokens,

--- a/tests/server/test_cloud_router.py
+++ b/tests/server/test_cloud_router.py
@@ -1,0 +1,48 @@
+"""Regression tests for openrouter/-prefixed model handling."""
+
+from __future__ import annotations
+
+import pytest
+
+from openjarvis.core.types import Message
+from openjarvis.server import cloud_router
+
+
+def test_get_provider_detects_bare_openrouter_id():
+    assert cloud_router.get_provider("anthropic/claude-haiku-4.5") == "openrouter"
+
+
+def test_get_provider_detects_litellm_prefixed_openrouter_id():
+    model = "openrouter/anthropic/claude-haiku-4.5"
+    assert cloud_router.get_provider(model) == "openrouter"
+
+
+@pytest.mark.parametrize(
+    "requested_model,expected_forwarded_model",
+    [
+        ("anthropic/claude-haiku-4.5", "anthropic/claude-haiku-4.5"),
+        ("openrouter/anthropic/claude-haiku-4.5", "anthropic/claude-haiku-4.5"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_stream_cloud_strips_openrouter_prefix_before_forwarding(
+    monkeypatch, requested_model, expected_forwarded_model
+):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    captured: dict[str, str] = {}
+
+    async def fake_stream_openai(model, messages, temperature, max_tokens, **kwargs):
+        captured["model"] = model
+        yield "ok"
+
+    monkeypatch.setattr(cloud_router, "_stream_openai", fake_stream_openai)
+
+    tokens = [
+        token
+        async for token in cloud_router.stream_cloud(
+            requested_model, [Message(role="user", content="hi")]
+        )
+    ]
+
+    assert tokens == ["ok"]
+    assert captured["model"] == expected_forwarded_model

--- a/tests/server/test_cloud_router.py
+++ b/tests/server/test_cloud_router.py
@@ -1,4 +1,4 @@
-"""Regression tests for openrouter/-prefixed model handling."""
+"""Regression tests for OpenRouter model ID normalization."""
 
 from __future__ import annotations
 
@@ -22,10 +22,11 @@ def test_get_provider_detects_litellm_prefixed_openrouter_id():
     [
         ("anthropic/claude-haiku-4.5", "anthropic/claude-haiku-4.5"),
         ("openrouter/anthropic/claude-haiku-4.5", "anthropic/claude-haiku-4.5"),
+        ("openrouter/auto", "openrouter/auto"),
     ],
 )
 @pytest.mark.asyncio
-async def test_stream_cloud_strips_openrouter_prefix_before_forwarding(
+async def test_stream_cloud_normalizes_openrouter_model_before_forwarding(
     monkeypatch, requested_model, expected_forwarded_model
 ):
     monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")


### PR DESCRIPTION
## Summary
- `cloud_router.get_provider()` correctly detects LiteLLM-style `openrouter/anthropic/claude-haiku-4.5` model strings as the `openrouter` provider, but `stream_cloud()` forwards the model string verbatim, so the redundant `openrouter/` prefix reaches OpenRouter's own API and the request fails.
- Fix: strip the `openrouter/` prefix (`model.removeprefix("openrouter/")`) before forwarding.

## Test plan
- [x] `uv run pytest tests/server/test_cloud_router.py -v` — 4 passed (new test file), covering both bare (`anthropic/claude-haiku-4.5`) and LiteLLM-prefixed (`openrouter/anthropic/claude-haiku-4.5`) model strings
- [x] `ruff check` / `ruff format --check` on touched files