### PR TITLE
fix(desktop): allow remote API connections

### DIFF
--- a/frontend/src-tauri/Info.plist
+++ b/frontend/src-tauri/Info.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>NSAppTransportSecurity</key>
+  <dict>
+    <!-- The desktop API URL is user-configurable, so it cannot be represented
+         by Tauri's single, build-time exceptionDomain setting. Keep this
+         exception scoped to WKWebView; native URLSession traffic retains ATS. -->
+    <key>NSAllowsArbitraryLoadsInWebContent</key>
+    <true/>
+  </dict>
+</dict>
+</plist>

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -24,7 +24,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:*; img-src 'self' data: blob:"
+      "csp": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' http: https: ws: wss:; img-src 'self' data: blob:"
     }
   },
   "bundle": {

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -45,7 +45,6 @@
     "macOS": {
       "entitlements": "Entitlements.plist",
       "minimumSystemVersion": "10.15",
-      "exceptionDomain": "",
       "frameworks": [],
       "providerShortName": null,
       "signingIdentity": "-"

--- a/frontend/src/lib/useAgentEvents.test.ts
+++ b/frontend/src/lib/useAgentEvents.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { buildWsUrl } from './useAgentEvents';
+
+const SETTINGS_KEY = 'openjarvis-settings';
+
+class MemoryStorage {
+  private store = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.store.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.store.set(key, String(value));
+  }
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { localStorage: MemoryStorage }).localStorage =
+    new MemoryStorage();
+});
+
+afterEach(() => {
+  (globalThis as unknown as { localStorage?: MemoryStorage }).localStorage =
+    undefined;
+});
+
+describe('buildWsUrl', () => {
+  it('authenticates agent events with the configured API key', () => {
+    localStorage.setItem(
+      SETTINGS_KEY,
+      JSON.stringify({
+        apiUrl: 'https://jarvis.example.com:8443',
+        apiKey: 'secret+/=',
+      }),
+    );
+
+    const url = new URL(buildWsUrl('agent/one'));
+
+    expect(url.origin).toBe('wss://jarvis.example.com:8443');
+    expect(url.pathname).toBe('/v1/agents/events');
+    expect(url.searchParams.get('agent_id')).toBe('agent/one');
+    expect(url.searchParams.get('token')).toBe('secret+/=');
+  });
+
+  it('normalizes a versioned API base without duplicating /v1', () => {
+    localStorage.setItem(
+      SETTINGS_KEY,
+      JSON.stringify({ apiUrl: 'http://192.0.2.10:8000/v1/' }),
+    );
+
+    expect(buildWsUrl()).toBe('ws://192.0.2.10:8000/v1/agents/events');
+  });
+
+  it('omits the token for a keyless server', () => {
+    localStorage.setItem(
+      SETTINGS_KEY,
+      JSON.stringify({ apiUrl: 'http://localhost:8000' }),
+    );
+
+    const url = new URL(buildWsUrl('agent-one'));
+
+    expect(url.searchParams.has('token')).toBe(false);
+  });
+});

--- a/frontend/src/lib/useAgentEvents.ts
+++ b/frontend/src/lib/useAgentEvents.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { getBase } from './api';
+import { getApiKey, getBase } from './api';
 
 export interface AgentEvent {
   type: string;
@@ -7,19 +7,16 @@ export interface AgentEvent {
   data: Record<string, unknown>;
 }
 
-function buildWsUrl(agentId?: string): string {
+export function buildWsUrl(agentId?: string): string {
   const base = getBase();
-  let origin: string;
-  if (base) {
-    origin = base.replace(/^http/, 'ws');
-  } else {
-    const loc = window.location;
-    origin = `${loc.protocol === 'https:' ? 'wss:' : 'ws:'}//${loc.host}`;
-  }
-  const path = '/v1/agents/events';
-  return agentId
-    ? `${origin}${path}?agent_id=${encodeURIComponent(agentId)}`
-    : `${origin}${path}`;
+  const url = new URL('/v1/agents/events', base || window.location.origin);
+  url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+
+  if (agentId) url.searchParams.set('agent_id', agentId);
+  const apiKey = getApiKey();
+  if (apiKey) url.searchParams.set('token', apiKey);
+
+  return url.toString();
 }
 
 /**

--- a/tests/deployment/test_desktop_network_policy.py
+++ b/tests/deployment/test_desktop_network_policy.py
@@ -1,0 +1,25 @@
+"""Regression guards for the desktop app's outbound network policy."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+TAURI_CONFIG = ROOT / "frontend" / "src-tauri" / "tauri.conf.json"
+
+
+def _csp_sources(directive: str) -> set[str]:
+    config = json.loads(TAURI_CONFIG.read_text(encoding="utf-8"))
+    csp = config["app"]["security"]["csp"]
+    directives = {
+        parts[0]: set(parts[1:]) for item in csp.split(";") if (parts := item.split())
+    }
+    return directives[directive]
+
+
+def test_desktop_csp_allows_remote_api_servers() -> None:
+    """The user-configured API URL may point beyond localhost (#649)."""
+    connect_sources = _csp_sources("connect-src")
+
+    assert {"http:", "https:", "ws:", "wss:"} <= connect_sources

--- a/tests/deployment/test_desktop_network_policy.py
+++ b/tests/deployment/test_desktop_network_policy.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import json
+import plistlib
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent.parent
 TAURI_CONFIG = ROOT / "frontend" / "src-tauri" / "tauri.conf.json"
+MACOS_INFO_PLIST = ROOT / "frontend" / "src-tauri" / "Info.plist"
 
 
 def _csp_sources(directive: str) -> set[str]:
@@ -23,3 +25,10 @@ def test_desktop_csp_allows_remote_api_servers() -> None:
     connect_sources = _csp_sources("connect-src")
 
     assert {"http:", "https:", "ws:", "wss:"} <= connect_sources
+
+
+def test_macos_webview_allows_user_configured_http_servers() -> None:
+    """CSP alone cannot override App Transport Security for public hosts."""
+    info = plistlib.loads(MACOS_INFO_PLIST.read_bytes())
+
+    assert info["NSAppTransportSecurity"]["NSAllowsArbitraryLoadsInWebContent"] is True


### PR DESCRIPTION
## What does this PR do?

The desktop settings allow users to configure a remote API server, but the
Tauri Content Security Policy only permitted connections to localhost. As a
result, requests to a configured remote server were blocked by the desktop
webview before they could reach the server.

This PR:

- allows `http:`, `https:`, `ws:`, and `wss:` in the desktop `connect-src`
  policy, covering API requests and agent event streams;
- adds a webview-scoped macOS App Transport Security exception so plaintext
  user-configured hostnames are not still rejected after CSP allows them;
- authenticates the browser WebSocket used for agent events with the configured
  API key, including correct URL encoding and `/v1` normalization;
- adds regression tests for the shipped Tauri configuration, macOS transport
  policy, and authenticated WebSocket URL generation.

The change does not alter server authentication, CORS behavior, or the browser
frontend's network policy.

Fixes #649

## Security note

Tauri's CSP is fixed at build time while the API origin is selected by the user
at runtime. Supporting arbitrary configured origins therefore requires
scheme-wide `connect-src` entries; the CSP no longer provides host-level
egress allowlisting for those four schemes. The macOS ATS exception is limited
to WKWebView traffic, so native networking retains ATS. A future Rust-side
network bridge with a persisted per-origin allowlist could restore host-level
webview isolation without removing arbitrary-server support.

## How was this tested?

Original author validation:

- `uv run pytest tests/ -v` (`7209 passed, 56 skipped`; coverage `61.77%`,
  required minimum `60%`)
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`

Maintainer follow-up validation after the runtime fixes:

- focused Python deployment and WebSocket auth tests (`18 passed`)
- frontend Vitest suite (`9 passed`)
- `npm run build:tauri`
- unsigned macOS Tauri app bundle build, with the generated `Info.plist`
  inspected for the effective webview ATS setting
- desktop Rust tests (`33 passed`)
- Ruff check/format on the changed Python test
- `git diff --check` and plist/JSON validation

The existing macOS Objective-C `unexpected cfg` warnings, frontend chunk-size
warnings, and npm audit findings remain unchanged by this PR.

## Checklist

- [x] Tests pass
- [x] Linter passes
- [x] Formatter passes
- [x] New/changed public API has docstrings (not applicable; no public API change)
- [x] Follows registry pattern (not applicable; no component added)
- [x] Documentation updated (regression tests and security note cover the fix)
