### PR TITLE
fix(analytics): make external analytics opt-in

### DIFF
--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -455,6 +455,26 @@ db_path = "~/.openjarvis/telemetry.db"
 
 ---
 
+### `[analytics]` — External Anonymous Analytics
+
+Controls anonymous usage events sent to the OpenJarvis team's PostHog instance.
+This is independent of the local `[telemetry]` database and the Savings
+Leaderboard.
+
+```toml
+[analytics]
+enabled = false
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `false` | Whether to send allowlisted anonymous usage events. No analytics ID or connection is created while disabled. |
+
+See [Anonymous Analytics](../telemetry.md) for the exact event list, privacy
+guardrails, and opt-in instructions.
+
+---
+
 ### `[traces]` — Trace Recording
 
 Controls the trace system that records full interaction sequences for the learning system.

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -18,6 +18,17 @@ The bash and PowerShell installers do the same thing on their respective hosts. 
 curl -fsSL https://open-jarvis.github.io/OpenJarvis/install.sh | bash
 ```
 
+External anonymous analytics are off by default. To explicitly share anonymous
+install progress and enable future runtime analytics, add `--analytics`:
+
+```bash
+curl -fsSL https://open-jarvis.github.io/OpenJarvis/install.sh | bash -s -- --analytics
+```
+
+See [Anonymous Analytics](../telemetry.md) for the exact event list and how to
+change this choice later. Local performance and energy telemetry stays on your
+computer and is unaffected.
+
 The installer downloads everything for you — including [uv](https://docs.astral.sh/uv/)
 (the Python package manager), the Python venv, Ollama, and a small starter
 model. **You don't need to install uv or any other prerequisite first.**
@@ -78,6 +89,7 @@ Local-first remains the default when no key is in env. Precedence is OpenRouter 
 | `--minimal` | Skip the foreground model pull. First chat will need to wait for the bg pull to finish. |
 | `--no-bg-orchestrator` | Don't detach the background work pipeline. (Mostly for testing.) |
 | `--force` | Re-run all steps even if `install-state.json` says they're done. |
+| `--analytics` | Opt in to anonymous install and runtime analytics. Off when omitted. |
 
 ## Environment overrides
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,18 +1,49 @@
-# Telemetry
+# Anonymous Analytics
 
-OpenJarvis ships **anonymous usage telemetry** by default so the team can
-see where the product breaks, what features people actually use, and
-how to make it better. This page documents exactly what is and isn't
-collected, where the data goes, and how to opt out.
+OpenJarvis can send anonymous usage events to help the team see where the
+product breaks and which features are useful. External analytics are **off by
+default**. Until you explicitly opt in, OpenJarvis does not create an analytics
+identifier, connect to PostHog, or send these events.
+
+This is separate from [local telemetry](user-guide/telemetry.md), which records
+performance and energy metrics only on your computer, and from the voluntary
+[Savings Leaderboard](leaderboard.md).
 
 ## TL;DR
 
-- **On by default**, anonymous, no chat content.
+- **Off by default**. Nothing is sent unless you explicitly opt in.
 - **Anonymous** — one random UUID per install, no email, no name, no IP.
 - **No chat content, ever.** Only counts, timings, and feature names.
-- **Self-hosted backend** on the OpenJarvis team's PostHog instance —
-  data is not sold or shared with third parties.
+- **OpenJarvis PostHog project** — see [Where the data goes](#where-the-data-goes)
+  for the current hosting details. Data is not sold or shared with advertisers.
 - **365-day retention**, after which events are deleted automatically.
+
+## Choose whether to share
+
+### During installation
+
+The normal installer keeps external analytics off. To opt in to both install
+events and future runtime events, pass `--analytics` explicitly:
+
+```bash
+curl -fsSL https://open-jarvis.github.io/OpenJarvis/install.sh | bash -s -- --analytics
+```
+
+### After installation
+
+You can change the setting at any time:
+
+```bash
+# Opt in
+jarvis config set analytics.enabled true
+
+# Opt out again
+jarvis config set analytics.enabled false
+```
+
+Upgrades and ordinary installer re-runs do not overwrite an existing explicit
+choice. Turning analytics off stops future events; it does not delete local
+telemetry, leaderboard participation, or previously collected analytics data.
 
 ## What we collect
 
@@ -92,10 +123,11 @@ dropped. Tests covering the patterns: [`tests/analytics/test_redaction.py`](../t
 
 ## How identity works
 
-A single UUID v4 is generated on first install and stored at
-`~/.openjarvis/anon_id`. The install script, backend, and frontend all
-read the same file so events across the full lifecycle tie to one
-person — without us ever knowing who that person is.
+A UUID v4 is generated only after analytics are enabled and stored at
+`~/.openjarvis/anon_id`. The installer, backend, and frontend all read the same
+file so opted-in events across the full lifecycle tie to one anonymous install.
+When analytics are disabled, the file is not created just by starting
+OpenJarvis.
 
 Delete the file (`rm ~/.openjarvis/anon_id`) and a fresh UUID will be
 generated next time the app runs. The previous UUID and its events
@@ -121,4 +153,5 @@ are then orphaned.
 - The leaderboard / contest opt-in (`OptInModal.tsx`) is a separate,
   voluntary feature that publicly shares your energy and savings on
   the OpenJarvis leaderboard. It is **not** the same as analytics and
-  requires explicit opt-in with a display name and email.
+  requires explicit opt-in with a display name and email. Choosing
+  **Leave Leaderboard** changes only leaderboard participation.

--- a/frontend/src/components/Desktop/SavingsDashboard.tsx
+++ b/frontend/src/components/Desktop/SavingsDashboard.tsx
@@ -365,7 +365,7 @@ export function SavingsDashboard({ apiUrl }: { apiUrl: string }) {
     setShowOptIn(false);
   };
 
-  const handleOptOut = () => {
+  const handleLeaveLeaderboard = () => {
     localStorage.removeItem(OPTIN_KEY);
     localStorage.removeItem(OPTIN_NAME_KEY);
     localStorage.removeItem(OPTIN_EMAIL_KEY);
@@ -422,8 +422,20 @@ export function SavingsDashboard({ apiUrl }: { apiUrl: string }) {
           <div style={{ fontSize: 16, fontWeight: 600, marginBottom: 8, color: colors.text }}>
             Share Your Savings
           </div>
-          <div style={{ fontSize: 13, color: colors.textMuted, marginBottom: 14, lineHeight: 1.5 }}>
+          <div style={{ fontSize: 13, color: colors.textMuted, marginBottom: 6, lineHeight: 1.5 }}>
             Opt in to privately share your savings for the chance to win a Mac Mini!
+          </div>
+          <div style={{ fontSize: 12, color: colors.textMuted, marginBottom: 14, lineHeight: 1.5 }}>
+            This controls only the Savings Leaderboard.{' '}
+            <a
+              href="https://open-jarvis.github.io/OpenJarvis/telemetry/"
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{ color: colors.accent, textDecoration: 'none' }}
+            >
+              Anonymous analytics
+            </a>{' '}
+            are managed separately.
           </div>
           <div style={{ marginBottom: 8 }}>
             <input
@@ -505,7 +517,7 @@ export function SavingsDashboard({ apiUrl }: { apiUrl: string }) {
             </button>
             {optInEnabled && (
               <button
-                onClick={handleOptOut}
+                onClick={handleLeaveLeaderboard}
                 style={{
                   padding: '8px 14px',
                   borderRadius: 8,
@@ -517,7 +529,7 @@ export function SavingsDashboard({ apiUrl }: { apiUrl: string }) {
                   marginLeft: 'auto',
                 }}
               >
-                Opt Out
+                Leave Leaderboard
               </button>
             )}
           </div>

--- a/frontend/src/components/OptInModal.tsx
+++ b/frontend/src/components/OptInModal.tsx
@@ -43,7 +43,7 @@ export function OptInModal({ onClose }: OptInModalProps) {
     setJoined(true);
   };
 
-  const handleOptOut = () => {
+  const handleLeaveLeaderboard = () => {
     setOptIn(false, '', '');
     setJoined(false);
     onClose();
@@ -130,6 +130,22 @@ export function OptInModal({ onClose }: OptInModalProps) {
             ))}
           </div>
 
+          <p
+            className="text-xs text-center mb-5 leading-relaxed"
+            style={{ color: 'var(--color-text-tertiary)' }}
+          >
+            This setting controls only the Savings Leaderboard.{' '}
+            <a
+              href="https://open-jarvis.github.io/OpenJarvis/telemetry/"
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{ color: 'var(--color-accent)' }}
+            >
+              Anonymous analytics
+            </a>{' '}
+            are managed separately.
+          </p>
+
           {/* Success state */}
           {joined ? (
             <div className="text-center">
@@ -157,11 +173,11 @@ export function OptInModal({ onClose }: OptInModalProps) {
                   Done
                 </button>
                 <button
-                  onClick={handleOptOut}
+                  onClick={handleLeaveLeaderboard}
                   className="px-5 py-2.5 rounded-xl text-sm transition-colors cursor-pointer"
                   style={{ color: 'var(--color-text-tertiary)' }}
                 >
-                  Opt Out
+                  Leave Leaderboard
                 </button>
               </div>
             </div>

--- a/frontend/src/lib/analytics.test.ts
+++ b/frontend/src/lib/analytics.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  posthog: {
+    init: vi.fn(),
+    identify: vi.fn(),
+    register: vi.fn(),
+    capture: vi.fn(),
+  },
+  getBase: vi.fn(() => 'http://localhost:8000'),
+}));
+
+vi.mock('posthog-js', () => ({ default: mocks.posthog }));
+vi.mock('./api', () => ({ getBase: mocks.getBase }));
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function identityResponse(enabled: boolean) {
+  return {
+    ok: true,
+    json: async () => ({
+      enabled,
+      anon_id: enabled ? 'anonymous-install-id' : '',
+      host: 'https://analytics.example.test',
+      key: enabled ? 'public-project-key' : '',
+    }),
+  };
+}
+
+describe('analytics opt-in', () => {
+  it('does not initialize or capture when the backend disables analytics', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(identityResponse(false)));
+    const analytics = await import('./analytics');
+
+    await analytics.initAnalytics();
+    analytics.track('app_opened');
+
+    expect(mocks.posthog.init).not.toHaveBeenCalled();
+    expect(mocks.posthog.identify).not.toHaveBeenCalled();
+    expect(mocks.posthog.register).not.toHaveBeenCalled();
+    expect(mocks.posthog.capture).not.toHaveBeenCalled();
+    expect(analytics.isAnalyticsEnabled()).toBe(false);
+  });
+
+  it('initializes and captures only after an explicit enabled response', async () => {
+    mocks.posthog.init.mockImplementation(
+      (_key: string, options: { loaded?: () => void }) => options.loaded?.(),
+    );
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(identityResponse(true)));
+    const analytics = await import('./analytics');
+
+    await analytics.initAnalytics();
+    analytics.track('app_opened');
+
+    expect(mocks.posthog.init).toHaveBeenCalledOnce();
+    expect(mocks.posthog.identify).toHaveBeenCalledWith('anonymous-install-id');
+    expect(mocks.posthog.capture).toHaveBeenCalledWith('app_opened', {});
+    expect(analytics.isAnalyticsEnabled()).toBe(true);
+  });
+});

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -193,7 +193,8 @@ nav:
       - Memory: user-guide/memory.md
       - External MCP Servers: user-guide/mcp-external-servers.md
       - Scheduler: user-guide/scheduler.md
-      - Telemetry: user-guide/telemetry.md
+      - Local Telemetry: user-guide/telemetry.md
+      - Anonymous Analytics: telemetry.md
       - Evaluations: user-guide/evaluations.md
       - Benchmarks: user-guide/benchmarks.md
       - Security: user-guide/security.md

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -8,6 +8,7 @@
 #   --no-bg-orchestrator   Skip the detached background orchestrator
 #   --minimal              Skip foreground model pull (no `qwen3.5:2b`)
 #   --force                Re-run all steps even if state file says done
+#   --analytics            Opt in to anonymous external analytics
 #
 # Environment overrides:
 #   OPENJARVIS_HOME        Install dir (default: $HOME/.openjarvis)
@@ -20,11 +21,13 @@ set -euo pipefail
 SKIP_BG=0
 MINIMAL=0
 FORCE=0
+ANALYTICS=0
 for arg in "$@"; do
     case "$arg" in
         --no-bg-orchestrator) SKIP_BG=1 ;;
         --minimal) MINIMAL=1 ;;
         --force) FORCE=1 ;;
+        --analytics) ANALYTICS=1 ;;
         *) echo "install.sh: unknown arg: $arg" >&2; exit 2 ;;
     esac
 done
@@ -250,7 +253,7 @@ INSTALL_START_EPOCH="$(date +%s)"
 CURRENT_STAGE=""
 
 analytics_enabled() {
-    return 0
+    [[ "$ANALYTICS" -eq 1 ]]
 }
 
 detect_os() {
@@ -601,6 +604,12 @@ write_config() {
         --prefer-cloud-when-available
 }
 
+persist_analytics_opt_in() {
+    if [[ "$ANALYTICS" -eq 1 ]]; then
+        "$VENV_DIR/bin/jarvis" config set analytics.enabled true
+    fi
+}
+
 install_symlinks() {
     mkdir -p "$HOME/.local/bin"
     ln -sf "$SCRIPTS_DIR/jarvis-wrapper.sh" "$HOME/.local/bin/jarvis"
@@ -681,6 +690,9 @@ step install_ollama     "Install Ollama"        install_ollama
 step start_ollama       "Start Ollama daemon"   start_ollama
 step pull_default_model "Pull qwen3.5:2b"       pull_default_model
 step write_config       "Write config.toml"     write_config
+# This is intentionally outside step(): an idempotent re-run may skip every
+# installation step, but an explicit --analytics choice must still be saved.
+persist_analytics_opt_in
 step install_symlinks   "Install symlinks"      install_symlinks
 step ensure_path        "Ensure PATH"           ensure_path
 step detach_bg_orchestrator "Detach background work" detach_bg_orchestrator

--- a/src/openjarvis/analytics/__init__.py
+++ b/src/openjarvis/analytics/__init__.py
@@ -8,7 +8,9 @@ identifiers.
 Distinct from :mod:`openjarvis.telemetry`, which stores local FLOPs and
 energy metrics in a SQLite DB and never leaves the machine.
 
-Disable: set ``[analytics] enabled = false`` in ``~/.openjarvis/config.toml``.
+Disabled by default. Enable explicitly with ``jarvis config set
+analytics.enabled true`` or ``[analytics] enabled = true`` in
+``~/.openjarvis/config.toml``.
 """
 
 from openjarvis.analytics.aggregator import SessionAggregator

--- a/src/openjarvis/analytics/client.py
+++ b/src/openjarvis/analytics/client.py
@@ -37,12 +37,15 @@ class AnalyticsClient:
 
     def __init__(self, config: AnalyticsConfig, anon_id: str | None = None) -> None:
         self.config = config
-        self.anon_id = anon_id or get_or_create_anon_id(config.anon_id_path)
         self._lock = threading.Lock()
         self._posthog: Any = None
         self._enabled = is_analytics_enabled(config)
-        if self._enabled:
-            self._init_sdk()
+        self.anon_id = ""
+        if not self._enabled:
+            return
+
+        self.anon_id = anon_id or get_or_create_anon_id(config.anon_id_path)
+        self._init_sdk()
 
     def _init_sdk(self) -> None:
         try:

--- a/src/openjarvis/cli/_bootstrap.py
+++ b/src/openjarvis/cli/_bootstrap.py
@@ -158,6 +158,9 @@ def write_initial_config(
         f"[tools]\n"
         f'enabled = ["code_interpreter", "web_search", '
         f'"file_read", "shell_exec"]\n'
+        f"\n"
+        f"[analytics]\n"
+        f"enabled = false\n"
     )
 
     _cfg.DEFAULT_CONFIG_PATH.write_text(base_toml)

--- a/src/openjarvis/core/config.py
+++ b/src/openjarvis/core/config.py
@@ -1063,7 +1063,7 @@ class AnalyticsConfig:
     or hardware identifiers are ever sent. See ``docs/telemetry.md``.
     """
 
-    enabled: bool = True
+    enabled: bool = False
     host: str = "https://34.231.106.201.sslip.io"
     key: str = "phc_ysKu72QaxzYNmDpHFcesD2ZZAe68zkdWJEKoYYkc5e3n"
     anon_id_path: str = field(default_factory=lambda: str(get_config_dir() / "anon_id"))
@@ -1943,6 +1943,9 @@ default_agent = "simple"
 
 [tools]
 enabled = ["code_interpreter", "web_search", "file_read", "shell_exec"]
+
+[analytics]
+enabled = false
 """
 
 
@@ -2081,6 +2084,9 @@ policy = "heuristic"
 enabled = true
 # gpu_metrics = false
 # gpu_poll_interval_ms = 50
+
+[analytics]
+enabled = false
 
 [traces]
 enabled = false

--- a/src/openjarvis/server/analytics_routes.py
+++ b/src/openjarvis/server/analytics_routes.py
@@ -1,10 +1,11 @@
 """Small router exposing the anonymous analytics identity to the frontend.
 
-The Tauri desktop app and web frontend need the same ``anon_id`` that
-the backend and install.sh use so that all events tie to one person.
-This endpoint returns that ID (generating it on first call) plus the
-public PostHog project key and host so the frontend can initialise
-``posthog-js`` against the same project.
+When analytics are enabled, the Tauri desktop app and web frontend need the
+same ``anon_id`` that the backend and install.sh use so that all events tie to
+one anonymous install. This endpoint returns that ID (generating it on the
+first enabled call) plus the public PostHog project key and host so the
+frontend can initialise ``posthog-js`` against the same project. When
+analytics are disabled, it returns an empty identity without creating one.
 
 Public API — no auth required because the data returned is exactly
 what the frontend would ship to PostHog anyway. The project key is

--- a/tests/analytics/test_client.py
+++ b/tests/analytics/test_client.py
@@ -1,0 +1,51 @@
+"""Tests for analytics opt-in behavior and its local side effects."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from openjarvis.analytics.client import AnalyticsClient
+from openjarvis.core.config import AnalyticsConfig
+
+
+def test_disabled_client_does_not_create_identity(tmp_path: Path, monkeypatch) -> None:
+    anon_id_path = tmp_path / "anon_id"
+    initialized = False
+
+    def _mark_initialized(_client: AnalyticsClient) -> None:
+        nonlocal initialized
+        initialized = True
+
+    monkeypatch.setattr(AnalyticsClient, "_init_sdk", _mark_initialized)
+
+    client = AnalyticsClient(
+        AnalyticsConfig(enabled=False, anon_id_path=str(anon_id_path))
+    )
+
+    assert client.enabled is False
+    assert client.anon_id == ""
+    assert initialized is False
+    assert not anon_id_path.exists()
+
+
+def test_enabled_client_creates_identity_and_initializes_sdk(
+    tmp_path: Path, monkeypatch
+) -> None:
+    anon_id_path = tmp_path / "anon_id"
+    initialized = False
+
+    def _mark_initialized(client: AnalyticsClient) -> None:
+        nonlocal initialized
+        initialized = True
+        client._posthog = object()
+
+    monkeypatch.setattr(AnalyticsClient, "_init_sdk", _mark_initialized)
+
+    client = AnalyticsClient(
+        AnalyticsConfig(enabled=True, anon_id_path=str(anon_id_path))
+    )
+
+    assert client.enabled is True
+    assert client.anon_id
+    assert initialized is True
+    assert anon_id_path.exists()

--- a/tests/analytics/test_routes.py
+++ b/tests/analytics/test_routes.py
@@ -1,0 +1,28 @@
+"""Tests for the frontend-facing analytics identity endpoint."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from openjarvis.core.config import JarvisConfig  # noqa: E402
+from openjarvis.server import analytics_routes  # noqa: E402
+
+
+def test_default_identity_is_disabled_without_local_side_effects(
+    tmp_path: Path, monkeypatch
+) -> None:
+    cfg = JarvisConfig()
+    anon_id_path = tmp_path / "anon_id"
+    cfg.analytics.anon_id_path = str(anon_id_path)
+    monkeypatch.setattr(analytics_routes, "load_config", lambda: cfg)
+
+    identity = analytics_routes.get_identity()
+
+    assert identity.enabled is False
+    assert identity.anon_id == ""
+    assert identity.key == ""
+    assert not anon_id_path.exists()

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -18,6 +18,7 @@ from openjarvis.core.config import (
     SecurityConfig,
     WhatsAppBaileysChannelConfig,
     generate_default_toml,
+    generate_minimal_toml,
     load_config,
     recommend_engine,
 )
@@ -29,6 +30,7 @@ class TestDefaults:
         assert cfg.engine.default == "ollama"
         assert cfg.memory.default_backend == "sqlite"
         assert cfg.telemetry.enabled is True
+        assert cfg.analytics.enabled is False
 
     def test_engine_config_defaults(self) -> None:
         ec = EngineConfig()
@@ -95,6 +97,14 @@ class TestTomlLoading:
         assert cfg.engine.default == "vllm"
         assert cfg.memory.default_backend == "faiss"
 
+    def test_explicit_analytics_opt_in_is_preserved(self, tmp_path: Path) -> None:
+        toml_file = tmp_path / "config.toml"
+        toml_file.write_text("[analytics]\nenabled = true\n")
+
+        cfg = load_config(toml_file)
+
+        assert cfg.analytics.enabled is True
+
     def test_loads_nested_lemonade_host_override(self, tmp_path: Path) -> None:
         toml_file = tmp_path / "config.toml"
         toml_file.write_text(
@@ -139,6 +149,12 @@ class TestGenerateToml:
         assert "[engine]" in toml
         assert 'default = "vllm"' in toml
         assert "H100" in toml
+
+    def test_generated_configs_disable_external_analytics(self) -> None:
+        hw = HardwareInfo(platform="linux")
+
+        for toml in (generate_minimal_toml(hw), generate_default_toml(hw)):
+            assert "[analytics]\nenabled = false" in toml
 
 
 class TestSecurityConfig:

--- a/tests/install/bash/test_install.bats
+++ b/tests/install/bash/test_install.bats
@@ -16,10 +16,12 @@ setup() {
     export OLLAMA_STUB_LOG="$TEST_TMPDIR/ollama.log"
     export UV_STUB_LOG="$TEST_TMPDIR/uv.log"
     export CURL_STUB_LOG="$TEST_TMPDIR/curl.log"
+    export JARVIS_STUB_LOG="$TEST_TMPDIR/jarvis.log"
     : > "$GIT_STUB_LOG"
     : > "$OLLAMA_STUB_LOG"
     : > "$UV_STUB_LOG"
     : > "$CURL_STUB_LOG"
+    : > "$JARVIS_STUB_LOG"
 
     # uv stub needs to fake creating a venv with a jarvis binary.
     # Replace the stubs/uv with one that creates the venv tree on `venv` command.
@@ -46,6 +48,7 @@ case "\$1" in
             cat > "\$venv_path/bin/jarvis" <<'EOJ'
 #!/usr/bin/env bash
 # fake jarvis for tests
+echo "\$@" >> "\$JARVIS_STUB_LOG"
 echo "fake jarvis: \$@"
 exit 0
 EOJ
@@ -123,6 +126,32 @@ IDEOF
     run bash "$SCRIPT" --no-bg-orchestrator
     [ "$status" -eq 0 ]
     ! grep -q "clone" "$GIT_STUB_LOG"
+}
+
+@test "external analytics is off by default" {
+    run bash "$SCRIPT" --no-bg-orchestrator --minimal
+    [ "$status" -eq 0 ]
+    [ ! -e "$OPENJARVIS_HOME/anon_id" ]
+    ! grep -q '/i/v0/e/' "$CURL_STUB_LOG"
+    ! grep -q '^config set analytics.enabled true$' "$JARVIS_STUB_LOG"
+}
+
+@test "--analytics opts into install and runtime analytics" {
+    run bash "$SCRIPT" --no-bg-orchestrator --minimal --analytics
+    [ "$status" -eq 0 ]
+    [ -s "$OPENJARVIS_HOME/anon_id" ]
+    grep -q '/i/v0/e/' "$CURL_STUB_LOG"
+    grep -q '^config set analytics.enabled true$' "$JARVIS_STUB_LOG"
+}
+
+@test "--analytics persists opt-in when install steps are already complete" {
+    run bash "$SCRIPT" --no-bg-orchestrator --minimal
+    [ "$status" -eq 0 ]
+    : > "$JARVIS_STUB_LOG"
+
+    run bash "$SCRIPT" --no-bg-orchestrator --minimal --analytics
+    [ "$status" -eq 0 ]
+    grep -q '^config set analytics.enabled true$' "$JARVIS_STUB_LOG"
 }
 
 @test "detects WSL2 and writes platform note to install-state" {

--- a/tests/install/test_bootstrap_config.py
+++ b/tests/install/test_bootstrap_config.py
@@ -29,6 +29,7 @@ def test_writes_minimal_local_config(tmp_openjarvis_home: Path) -> None:
     assert data["engine"]["default"] == "ollama"
     assert data["intelligence"]["default_model"] == "qwen3.5:2b"
     assert data["agent"]["default_agent"] == "simple"
+    assert data["analytics"]["enabled"] is False
 
 
 def test_writes_cloud_config(tmp_openjarvis_home: Path) -> None:


### PR DESCRIPTION
Fixes #653

## Summary

- External anonymous analytics is disabled by default.
- Users can explicitly opt in with the installer `--analytics` flag or with `[analytics] enabled = true` in configuration.
- Local performance and energy telemetry, Savings Leaderboard participation, and external analytics remain three independent mechanisms.

## Changes by area

| Area | What changed | Verification |
| --- | --- | --- |
| Runtime | Default generated configurations disable external analytics. When disabled, OpenJarvis neither creates an anonymous ID nor initializes PostHog; an explicit `enabled = true` is still honored. | Targeted Python suite: **137 passed**, covering defaults, generated config, explicit opt-in, the analytics client, and the frontend identity route. |
| Installer | Added `--analytics` as the single explicit opt-in for install beacons and future runtime analytics. The choice is persisted even when an idempotent rerun skips completed installation steps. | Installer Bats suite: **32 passed**, including default-off, explicit opt-in, and idempotent rerun cases. |
| Frontend | The analytics client stays inactive when the backend reports analytics disabled. Leaderboard controls now say **Leave Leaderboard** and explain that they do not manage anonymous analytics. | Frontend Vitest suite: **8 passed**; TypeScript check and production build also pass. |
| Docs | Documented the default, installer and configuration opt-in paths, how to opt out again, and the boundary between local telemetry, the leaderboard, and external analytics. | `mkdocs build` passes. |
| Compatibility | Preserved existing explicit opt-ins and leaderboard behavior while leaving the server API shape and dependencies unchanged. | Existing-config regression coverage passes; Rust workspace: **418 passed**; Tauri: **33 passed**. |

## Test plan

- [x] Targeted Python tests: `uv run pytest tests/analytics tests/core/test_config.py tests/install/test_bootstrap_config.py -q` - **137 passed**
- [x] Bash installer tests: `bats tests/install/bash/` - **32 passed**
- [x] Frontend tests: `npm test` - **8 passed**
- [x] Rust workspace tests: `cargo test --workspace` - **418 passed**
- [x] Tauri tests: `cargo test --locked` in `frontend/src-tauri` - **33 passed**
- [x] Python lint and formatting: `ruff check src tests`, `ruff format --check src tests`
- [x] Rust lint: `cargo clippy --workspace --all-targets -- -D warnings`
- [x] TypeScript and frontend build: `npx tsc --noEmit`, `npm run build`
- [x] Documentation build: `mkdocs build`
- [x] Shell syntax and patch hygiene: `bash -n scripts/install/install.sh`, `git diff --check`

## Remaining validation

- [ ] **Upstream GitHub Actions:** all six workflows currently report `action_required` with `jobs: []`. They are waiting for a maintainer to approve workflows from this fork; no CI test job has failed.
- [ ] **Full Python suite on Linux CI:** the complete local run reached **6990 passed, 57 skipped, 6 failed**. Four failures call macOS `sysctl hw.memsize`, which the local sandbox blocks; one Granola test requires real DNS; one KnowledgeSQL registry test hits a pre-existing duplicate-registration order issue. None is in code changed by this PR.

## Compatibility / Not changed

- Existing users with an explicit `[analytics] enabled = true` remain opted in.
- Local performance and energy telemetry is unchanged and remains local.
- Savings Leaderboard storage and submission behavior is unchanged; only its explanatory copy and leave-action label are clearer.
- No server endpoint shape, server API, or third-party dependency changes are introduced.
- #658 remains complementary: its `DO_NOT_TRACK` emergency kill switch can override an explicitly enabled configuration if both changes merge.
