### PR TITLE
fix: bind a deep_research agent's configured tools on the server path

### DIFF
--- a/src/openjarvis/server/agent_manager_routes.py
+++ b/src/openjarvis/server/agent_manager_routes.py
@@ -588,6 +588,78 @@ def _instantiate_managed_tool(
     return tool_cls()
 
 
+def _tool_instance_name(tool: Any) -> str:
+    """Best-effort name for a tool instance (empty string if unavailable)."""
+    try:
+        return tool.spec.name
+    except Exception:
+        return ""
+
+
+def _resolve_tool_instances(
+    tool_config: Any,
+    *,
+    engine: Any,
+    model: str,
+    app_state: Any,
+) -> List[Any]:
+    """Instantiate a managed agent's configured tools.
+
+    Mirrors :func:`_resolve_tool_specs` in how it interprets names (``browser``
+    meta-tool expansion, silently skipping channels, warning on unknown names)
+    but returns live tool *instances* rather than OpenAI-format specs.
+
+    Agent classes that run their own loop — ``DeepResearchAgent`` in particular
+    — take real instances, whereas the raw streaming path hands specs to the
+    engine. Without this, an agent's configured tools cannot reach it at all.
+    """
+    if not tool_config:
+        return []
+
+    from openjarvis.core.registry import ChannelRegistry, ToolRegistry
+
+    _ensure_registries_populated()
+
+    instances: List[Any] = []
+    seen: set = set()
+
+    def _add(name: str) -> None:
+        if name in seen or not ToolRegistry.contains(name):
+            return
+        try:
+            instances.append(
+                _instantiate_managed_tool(
+                    ToolRegistry.get(name),
+                    name,
+                    engine=engine,
+                    model=model,
+                    app_state=app_state,
+                )
+            )
+            seen.add(name)
+        except Exception as exc:
+            logger.warning("Could not instantiate tool '%s' (%s) — dropping", name, exc)
+
+    for entry in tool_config:
+        if not isinstance(entry, str):
+            continue
+        if entry == "browser":
+            for sub in _BROWSER_SUB_TOOLS:
+                _add(sub)
+            continue
+        if ChannelRegistry.contains(entry):
+            continue
+        if not ToolRegistry.contains(entry):
+            logger.warning(
+                "Tool '%s' referenced in agent config but not in ToolRegistry",
+                entry,
+            )
+            continue
+        _add(entry)
+
+    return instances
+
+
 def _build_deep_research_tools(
     engine: Any,
     model: str,
@@ -863,10 +935,41 @@ async def _stream_managed_agent(
     # Resolve agent type and class for DeepResearch tool wiring
     agent_type = agent_record.get("agent_type", "")
     if agent_type == "deep_research":
+        # Local knowledge-base tools (empty when no knowledge.db exists).
         dr_tools = _build_deep_research_tools(
             engine=engine,
             model=model,
         )
+        # …plus the agent's OWN configured tools. Binding only the knowledge
+        # tools above silently discarded config["tools"] on this path — the
+        # agent-creation wizard writes it for every agent type, so a
+        # deep_research agent configured for `web_search` was left holding
+        # none of it, with no warning. Merge rather than replace: the local
+        # knowledge base and the web are complementary.
+        seen_names = {_tool_instance_name(t) for t in dr_tools}
+        for tool in _resolve_tool_instances(
+            config.get("tools"),
+            engine=engine,
+            model=model,
+            app_state=app_state,
+        ):
+            name = _tool_instance_name(tool)
+            if name and name not in seen_names:
+                dr_tools.append(tool)
+                seen_names.add(name)
+
+        # …and MCP tools (e.g. the Playwright browser), which previously
+        # reached only the generic streaming path.
+        if app_state is not None:
+            try:
+                _, mcp_adapters = _get_mcp_tools(app_state)
+                for name, adapter in mcp_adapters.items():
+                    if name not in seen_names:
+                        dr_tools.append(adapter)
+                        seen_names.add(name)
+            except Exception as exc:
+                logger.warning("MCP tool discovery failed for %s: %s", agent_id, exc)
+
         # Store on app_state so streaming loop can access them
         if app_state is not None and dr_tools:
             app_state._dr_tools = dr_tools
@@ -991,6 +1094,19 @@ async def _stream_managed_agent(
                 def _run_agent():
                     agent_metadata = {}
                     try:
+                        # NOTE: prior turns are deliberately NOT replayed here.
+                        # Measured on qwen2.5:7b: replaying this agent's stored
+                        # history made it stop calling tools entirely (0 tool
+                        # calls, an identical canned "check the official source"
+                        # reply every time), whereas the same query with no
+                        # history called web_search and answered from the
+                        # result. Recorded assistant turns that answered
+                        # *without* tools read as demonstrations of not using
+                        # tools — the same imitation failure as a few-shot
+                        # exemplar that shows an answer without showing the
+                        # retrieval. Re-introducing memory here needs history
+                        # that models the desired behaviour, not just fewer
+                        # messages.
                         result = dr_agent.run(user_content)
                         content = result.content or "No results found."
                         agent_metadata = result.metadata or {}

--- a/tests/server/test_deep_research_tools_wiring.py
+++ b/tests/server/test_deep_research_tools_wiring.py
@@ -53,3 +53,108 @@ def test_deep_research_tools_returns_empty_when_no_db() -> None:
     )
 
     assert tools == []
+
+
+@pytest.fixture
+def registered_tools():
+    """Guarantee the tools this module asserts on are in the registry.
+
+    ``_ensure_registries_populated`` only repopulates when the registry is
+    *entirely* empty, so a fixture that clears it partially can leave these
+    missing depending on test order.
+    """
+    import importlib
+
+    from openjarvis.core.registry import ToolRegistry
+
+    for mod_name in ("openjarvis.tools.web_search", "openjarvis.tools.think"):
+        mod = importlib.import_module(mod_name)
+        if not ToolRegistry.contains(mod_name.rsplit(".", 1)[-1]):
+            importlib.reload(mod)
+    return ToolRegistry
+
+
+@pytest.mark.skipif(not HAS_FASTAPI, reason="fastapi not installed")
+class TestResolveToolInstances:
+    """A managed agent's configured tools must reach agents that own their loop.
+
+    ``_build_deep_research_tools`` only supplies the knowledge-base tools. A
+    deep_research agent configured with ``web_search`` used to receive none of
+    it while its system prompt instructed it to search the web, so it answered
+    from model memory and invented citations instead.
+    """
+
+    def test_configured_tools_are_instantiated(self, registered_tools) -> None:
+        from openjarvis.server.agent_manager_routes import _resolve_tool_instances
+
+        tools = _resolve_tool_instances(
+            ["web_search", "think"],
+            engine=MagicMock(),
+            model="test-model",
+            app_state=None,
+        )
+
+        names = {t.spec.name for t in tools}
+        assert "web_search" in names
+        assert "think" in names
+
+    def test_unknown_and_empty_configs_are_safe(self) -> None:
+        from openjarvis.server.agent_manager_routes import _resolve_tool_instances
+
+        kwargs = {"engine": MagicMock(), "model": "m", "app_state": None}
+        assert _resolve_tool_instances(None, **kwargs) == []
+        assert _resolve_tool_instances([], **kwargs) == []
+        # Unknown names are dropped rather than raising.
+        assert _resolve_tool_instances(["no_such_tool_xyz"], **kwargs) == []
+
+    def test_returns_instances_not_specs(self, registered_tools) -> None:
+        """DeepResearchAgent takes live tools, unlike the engine's spec dicts."""
+        from openjarvis.server.agent_manager_routes import _resolve_tool_instances
+
+        tools = _resolve_tool_instances(
+            ["think"],
+            engine=MagicMock(),
+            model="test-model",
+            app_state=None,
+        )
+
+        assert tools and not isinstance(tools[0], dict)
+        assert callable(getattr(tools[0], "execute", None))
+
+    def test_merges_with_knowledge_tools_without_duplicates(
+        self, tmp_path: Path, registered_tools
+    ) -> None:
+        """The two sources combine; ``think`` is in both and must appear once."""
+        from openjarvis.server.agent_manager_routes import (
+            _build_deep_research_tools,
+            _resolve_tool_instances,
+            _tool_instance_name,
+        )
+
+        db_path = tmp_path / "knowledge.db"
+        store = KnowledgeStore(str(db_path))
+        store.store("test content", source="test", doc_type="note")
+        try:
+            merged = _build_deep_research_tools(
+                engine=MagicMock(),
+                model="test-model",
+                knowledge_db_path=str(db_path),
+            )
+            seen = {_tool_instance_name(t) for t in merged}
+            for tool in _resolve_tool_instances(
+                ["web_search", "think"],
+                engine=MagicMock(),
+                model="test-model",
+                app_state=None,
+            ):
+                name = _tool_instance_name(tool)
+                if name and name not in seen:
+                    merged.append(tool)
+                    seen.add(name)
+
+            names = [_tool_instance_name(t) for t in merged]
+            assert "web_search" in names, "web_search must reach the agent"
+            assert "knowledge_search" in names, "local KB tools must be kept too"
+            assert names.count("think") == 1, "overlapping tool must not duplicate"
+        finally:
+            store.close()


### PR DESCRIPTION
Fixes #682.

Through the server path a managed `deep_research` agent received only the four knowledge-base tools from `_build_deep_research_tools()`. Its own `config["tools"]` was never read, because `_resolve_tool_specs()` sits further down the generic path, past the early return in the `deep_research` branch; MCP tools were dropped for the same reason.

The agent-creation wizard writes `config.tools` for every agent type and `CreateAgentRequest.config` is free-form, so this is silently discarded configuration rather than an unsupported option: the agent is created, the UI shows the selected tools, and they do not exist at run time. Nothing is logged, because the config is never inspected on this path. The CLI path is unaffected, which is why it went unnoticed.

## Approach

Adds `_resolve_tool_instances()`, which mirrors `_resolve_tool_specs()` in how it reads names — `browser` meta-tool expansion, skipping channels, warning on unknown names — but returns live instances rather than the OpenAI-format spec dicts handed to the engine. An agent running its own loop needs instances.

Those are merged with the knowledge tools and the MCP adapters rather than replacing them, so local retrieval and web search are both available.

## Verification

Against a live agent, the bound toolset goes from 4 tools to 15, and `agent_learning_log` records a real `web_search` call and result where it previously recorded none.

`tests/server/test_deep_research_tools_wiring.py` — 6 passed. Full `tests/server` — 294 passed, 4 failed; all 4 failures reproduce identically on `main` without this change and are addressed in two separate PRs.

## Note

Conversation history is deliberately still not replayed on this path. The comment at the call site records the measurement behind that — on `qwen2.5:7b`, replaying the stored history made the agent stop calling tools entirely. Re-introducing memory there needs history that models the desired behaviour, and belongs in its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
