### PR TITLE
fix: stop SessionStore treating ":memory:" as a file path

### DIFF
--- a/src/openjarvis/server/session_store.py
+++ b/src/openjarvis/server/session_store.py
@@ -25,9 +25,11 @@ class SessionStore:
     def __init__(self, db_path: str = "") -> None:
         if not db_path:
             db_path = str(get_config_dir() / "sessions.db")
-        from openjarvis.security.file_utils import secure_create
+        # Ensure the parent directory exists (skip for :memory:)
+        if db_path != ":memory:":
+            from openjarvis.security.file_utils import secure_create
 
-        secure_create(Path(db_path))
+            secure_create(Path(db_path))
         self._db = sqlite3.connect(db_path, check_same_thread=False)
         self._db.row_factory = sqlite3.Row
         self._create_tables()

--- a/tests/server/test_session_store.py
+++ b/tests/server/test_session_store.py
@@ -115,3 +115,29 @@ class TestLastActiveChannel:
 
     def test_returns_none_for_unknown_user(self, store):
         assert store.get_last_active_channel("nobody") is None
+
+
+class TestInMemoryDatabase:
+    """``:memory:`` is a SQLite sentinel, not a path — it must not be created.
+
+    ``secure_create`` treats it as a filename, which fails outright on Windows
+    (``:`` is illegal there) and litters the working directory elsewhere.
+    """
+
+    def test_in_memory_store_is_usable(self):
+        s = SessionStore(db_path=":memory:")
+        try:
+            session = s.get_or_create("user1", "twilio")
+            assert session["sender_id"] == "user1"
+        finally:
+            s.close()
+
+    def test_in_memory_store_creates_no_file(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        before = set(tmp_path.iterdir())
+        s = SessionStore(db_path=":memory:")
+        try:
+            assert set(tmp_path.iterdir()) == before
+            assert not (tmp_path / ":memory:").exists()
+        finally:
+            s.close()


### PR DESCRIPTION
`SessionStore.__init__` passes its `db_path` straight to `secure_create()`, which touches the path and chmods it. `:memory:` is a SQLite sentinel, not a filename, so this tries to create a file literally named `:memory:`.

- **On Windows** `:` is illegal in a filename, so construction raises `OSError: [Errno 22] Invalid argument: ':memory:'`. Both tests in `tests/server/test_channel_bridge_deep_research.py` fail there today.
- **Elsewhere** it succeeds and is merely wrong: it leaves a stray `:memory:` file in the working directory, and because `Path(":memory:").parent` is `.`, `secure_mkdir` chmods the working directory itself to `0o700`.

`sqlite3.connect(":memory:")` handles the sentinel correctly on its own, so the touched file is pure litter either way.

## Approach

`KnowledgeStore`, `TelemetryStore` and `TraceStore` already guard this exact case — `connectors/store.py` even carries the comment "Ensure the parent directory exists (skip for :memory:)". `SessionStore` was the one store missing the check. This applies the same guard, with the same comment, rather than inventing a new pattern.

## Tests

Two regression tests: one that an in-memory store is usable, one that constructing it creates no file. The second fails on every platform without the fix, so this cannot silently return on Linux or macOS where the symptom is invisible.

`tests/server/test_session_store.py` — 13 passed. With this change the full `tests/server` suite goes from 4 failures to 2 on Windows; the other 2 are unrelated and fixed separately.

## Not included

`security/audit.py:41` has the same unguarded `secure_create` call. `AuditLogger` is never constructed with `:memory:` today so it is latent, and it seemed better left out of a fix aimed at one bug. Happy to fold it in, or push the guard down into `secure_create()` itself, if you would prefer either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
