### PR TITLE
test: tolerate a 503 memory backend in the route-wiring tests

### DIFF
--- a/tests/server/test_api_routes.py
+++ b/tests/server/test_api_routes.py
@@ -37,16 +37,22 @@ class TestAgentRoutes:
 
 
 class TestMemoryRoutes:
+    # 503 is the documented response when the native ``openjarvis_rust``
+    # extension is absent from the venv (see TestMemoryRustMissing below).
+    # These tests are only asserting "the route is wired up", so a backend
+    # that cannot be built is tolerated the same way a 500 is.
+    _BACKEND_OPTIONAL = (200, 500, 503)
+
     def test_search(self):
         client = TestClient(_make_app())
         resp = client.post("/v1/memory/search", json={"query": "test"})
         # May fail if SQLite not set up, that's ok
-        assert resp.status_code in (200, 500)
+        assert resp.status_code in self._BACKEND_OPTIONAL
 
     def test_stats(self):
         client = TestClient(_make_app())
         resp = client.get("/v1/memory/stats")
-        assert resp.status_code in (200, 500)
+        assert resp.status_code in self._BACKEND_OPTIONAL
 
 
 class TestMemoryRustMissing:


### PR DESCRIPTION
`TestMemoryRoutes.test_search` and `test_stats` assert the status code is in `(200, 500)`. That list dates from the initial commit; #527 later made the memory routes raise **503** when the native `openjarvis_rust` extension is missing.

So both tests now fail on any checkout where the extension has not been built — which is every contributor who has not run `maturin develop`:

```
E       assert 503 in (200, 500)
ERROR    Memory backend unavailable: the native `openjarvis_rust` extension
         is not installed in this environment.
```

The failure is spurious. These two tests only check that the routes are wired up, and their own comment — "May fail if SQLite not set up, that's ok" — says an unavailable backend is tolerated. 503 is exactly that case, and it is already asserted deliberately in `TestMemoryRustMissing` directly below, so the behaviour under test elsewhere is unchanged.

Adds 503 to the tolerated set via a named constant, so the reason is stated once rather than repeated as a bare literal.

`tests/server/test_api_routes.py` — 14 passed. Same spirit as #647.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
