### PR TITLE
fix: detach the daemon from its console on Windows

### DIFF
--- a/src/openjarvis/cli/daemon_cmd.py
+++ b/src/openjarvis/cli/daemon_cmd.py
@@ -81,14 +81,28 @@ def start(
     if agent_name:
         cmd.extend(["--agent", agent_name])
 
-    # Start as background process
+    # Start as background process, fully detached from the launching terminal.
+    #
+    # ``start_new_session`` is POSIX-only: CPython's Windows ``_execute_child``
+    # names the parameter ``unused_start_new_session`` and ignores it. Relying
+    # on it there leaves the server sharing its parent's console, so closing
+    # that console — or logging off — delivers CTRL_CLOSE_EVENT and kills the
+    # daemon. DETACHED_PROCESS gives it no console at all; the new process
+    # group additionally stops a Ctrl-C in the parent reaching it.
     DEFAULT_CONFIG_DIR.mkdir(parents=True, exist_ok=True)
     log_fh = open(_LOG_FILE, "a")  # noqa: SIM115
+    spawn_kwargs: dict = {}
+    if sys.platform == "win32":
+        spawn_kwargs["creationflags"] = (
+            subprocess.DETACHED_PROCESS | subprocess.CREATE_NEW_PROCESS_GROUP
+        )
+    else:
+        spawn_kwargs["start_new_session"] = True
     proc = subprocess.Popen(
         cmd,
         stdout=log_fh,
         stderr=log_fh,
-        start_new_session=True,
+        **spawn_kwargs,
     )
     _write_pid(proc.pid)
 

--- a/tests/cli/test_daemon_cmd.py
+++ b/tests/cli/test_daemon_cmd.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -79,3 +80,58 @@ class TestDaemonCommands:
             result = CliRunner().invoke(cli, ["start"])
         assert result.exit_code != 0
         assert "already running" in result.output
+
+
+class TestDaemonDetachment:
+    """The spawned server must outlive the console that started it.
+
+    ``start_new_session`` is POSIX-only — CPython's Windows ``_execute_child``
+    names the parameter ``unused_start_new_session``. Relying on it there leaves
+    the server sharing its parent's console, so closing that console (or logging
+    off) delivers CTRL_CLOSE_EVENT and kills the daemon.
+    """
+
+    @staticmethod
+    def _spawn_kwargs(platform: str) -> dict:
+        """Return the kwargs ``start`` passes to Popen when spawning the server.
+
+        ``load_config`` is stubbed because it shells out for GPU detection —
+        patching Popen wholesale would otherwise break config loading before
+        the spawn is reached.
+        """
+        with (
+            patch("openjarvis.cli.daemon_cmd._read_pid", return_value=None),
+            patch("openjarvis.cli.daemon_cmd._write_pid"),
+            patch("openjarvis.cli.daemon_cmd.load_config"),
+            patch("openjarvis.cli.daemon_cmd.sys.platform", platform),
+            patch("openjarvis.cli.daemon_cmd.subprocess.Popen") as popen,
+            patch("builtins.open", MagicMock()),
+        ):
+            popen.return_value = MagicMock(pid=4321)
+            result = CliRunner().invoke(cli, ["start"])
+            assert result.exit_code == 0, result.output
+            spawns = [
+                c for c in popen.call_args_list if c.args and "serve" in c.args[0]
+            ]
+            assert spawns, f"start did not spawn the server: {popen.call_args_list}"
+            return spawns[-1].kwargs
+
+    def test_windows_spawn_is_detached_from_the_console(self) -> None:
+        kwargs = self._spawn_kwargs("win32")
+        flags = kwargs.get("creationflags", 0)
+        assert flags & subprocess.DETACHED_PROCESS, (
+            "server must be spawned with DETACHED_PROCESS on Windows, otherwise "
+            "closing the launching console kills it"
+        )
+        assert flags & subprocess.CREATE_NEW_PROCESS_GROUP, (
+            "server must be in its own process group so Ctrl-C in the parent "
+            "console does not propagate to it"
+        )
+        assert not kwargs.get("start_new_session"), (
+            "start_new_session is ignored on Windows; it must not be relied on"
+        )
+
+    def test_posix_spawn_still_uses_start_new_session(self) -> None:
+        kwargs = self._spawn_kwargs("linux")
+        assert kwargs.get("start_new_session") is True
+        assert "creationflags" not in kwargs or kwargs["creationflags"] == 0

--- a/tests/cli/test_daemon_cmd.py
+++ b/tests/cli/test_daemon_cmd.py
@@ -117,13 +117,35 @@ class TestDaemonDetachment:
             return spawns[-1].kwargs
 
     def test_windows_spawn_is_detached_from_the_console(self) -> None:
-        kwargs = self._spawn_kwargs("win32")
+        # These constants are only exported by ``subprocess`` on Windows.
+        # Supply their documented values so the simulated Windows branch is
+        # still exercised by the POSIX test job.
+        detached_process = getattr(subprocess, "DETACHED_PROCESS", 0x00000008)
+        create_new_process_group = getattr(
+            subprocess, "CREATE_NEW_PROCESS_GROUP", 0x00000200
+        )
+        with (
+            patch.object(
+                subprocess,
+                "DETACHED_PROCESS",
+                detached_process,
+                create=True,
+            ),
+            patch.object(
+                subprocess,
+                "CREATE_NEW_PROCESS_GROUP",
+                create_new_process_group,
+                create=True,
+            ),
+        ):
+            kwargs = self._spawn_kwargs("win32")
+
         flags = kwargs.get("creationflags", 0)
-        assert flags & subprocess.DETACHED_PROCESS, (
+        assert flags & detached_process, (
             "server must be spawned with DETACHED_PROCESS on Windows, otherwise "
             "closing the launching console kills it"
         )
-        assert flags & subprocess.CREATE_NEW_PROCESS_GROUP, (
+        assert flags & create_new_process_group, (
             "server must be in its own process group so Ctrl-C in the parent "
             "console does not propagate to it"
         )


### PR DESCRIPTION
`jarvis start` spawns the server with `start_new_session=True`. That argument is **POSIX-only** — CPython's Windows `_execute_child` names the parameter `unused_start_new_session` and ignores it — so on Windows the server inherits the launching console instead of detaching from it.

Closing that console, or logging off, therefore delivers `CTRL_CLOSE_EVENT` to the server. Observed in the wild as the daemon dying overnight, with this as the last line of `server.log`:

```
forrtl: error (200): program aborting due to window-CLOSE event
```

(The Fortran runtime under NumPy installs a console control handler and aborts on the event.)

The failure is quiet. `jarvis start` prints a PID, writes the pid file and exits 0, and the server runs correctly for as long as the console stays open — so it looks like it worked. Registered as a log-on scheduled task, which is the natural way to run this on Windows, it means the machine comes back up with no backend and no error anywhere except that one line.

## Fix

Pass `DETACHED_PROCESS` on Windows so the child gets no console at all, plus `CREATE_NEW_PROCESS_GROUP` so a Ctrl-C in the parent console cannot reach it. POSIX keeps `start_new_session=True` unchanged.

## Verification

The mechanism, checked directly by attaching to each spawned process with `AttachConsole()`:

| spawn mode | console | result |
|---|---|---|
| `start_new_session=True` (today) | attaches successfully | shares a console → dies on window close |
| `DETACHED_PROCESS` (this PR) | fails, `ERROR_INVALID_HANDLE` | no console exists → immune to `CTRL_CLOSE_EVENT` |

A process with no console cannot receive the event, so this closes the failure at its source rather than handling the signal.

End to end on Windows 11 / Python 3.11, through a log-on scheduled task: after the task's `cmd.exe` exits, the server is still alive, has no console, and `/health` returns `{"status":"ok"}`.

Two tests added — one asserting the Windows creation flags, one pinning `start_new_session` on POSIX so this cannot regress the other platform. `tests/cli/test_daemon_cmd.py` passes.

Related to #681, which fixed a different Windows daemon problem (the liveness probe) in the same command group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
