### PR TITLE
fix: proxy WebSocket upgrades to the API in dev

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -54,7 +54,15 @@ export default defineConfig({
   server: {
     port: 5173,
     proxy: {
-      '/v1': process.env.VITE_API_URL || 'http://localhost:8000',
+      // ws: true is required for the /v1/agents/events WebSocket. Without it
+      // Vite proxies the HTTP request but not the upgrade, so the socket never
+      // opens — no error, no close event, just silence — and every live agent
+      // view sits empty in dev while working in a production build.
+      '/v1': {
+        target: process.env.VITE_API_URL || 'http://localhost:8000',
+        changeOrigin: true,
+        ws: true,
+      },
       '/health': process.env.VITE_API_URL || 'http://localhost:8000',
       '/api': process.env.VITE_API_URL || 'http://localhost:8000',
     },


### PR DESCRIPTION
The Vite dev proxy forwards `/v1` as plain HTTP with no `ws: true`, so the WebSocket upgrade for `/v1/agents/events` is never proxied.

The socket does not open, does not error, and does not close — it just sits silent. So every live agent view is empty under `npm run dev`, while working correctly in a production build, where the frontend is served from the same origin as the API.

That includes the per-agent live trace on the Agents page, which subscribes through `useAgentEvents` (`frontend/src/lib/useAgentEvents.ts`).

## Why it costs more than it looks

With no error surfaced, the symptom reads as *"the server isn't emitting events"* rather than *"the transport never connected"* — so the investigation starts on the wrong side. I lost a while to exactly that before checking the proxy.

## Reproduce

With `jarvis start` running and the frontend on `npm run dev`, from the dev page console:

```js
const ws = new WebSocket(`ws://${location.host}/v1/agents/events`);
ws.onopen = () => console.log('open');
ws.onerror = () => console.log('error');
ws.onclose = (e) => console.log('close', e.code);
```

**Before:** nothing logs — no open, no error, no close.
**After:** `open` logs, and a real agent tick delivers events (`agent_tick_start`, `inference_start`/`end`, `tool_call_start`/`end`, `agent_tick_end`).

Verified on Windows 11 / Node 24.

## Note on `changeOrigin`

Set alongside `ws: true` so the upgrade request carries the target's host — some setups require it when `VITE_API_URL` points somewhere other than localhost. Happy to drop it if you'd rather keep the change to the single line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
