### PR TITLE
feat: allow subscribing to every agent's events

### DIFF
--- a/frontend/src/lib/useAgentEvents.test.ts
+++ b/frontend/src/lib/useAgentEvents.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { ALL_AGENTS, buildWsUrl, shouldSubscribe } from './useAgentEvents';
+
+// `/v1/agents/events` has always broadcast every agent's events — `agent_id`
+// is an optional server-side filter. Only this hook prevented a global feed,
+// by refusing to connect without an id. These cover the pure helpers behind
+// that decision, in the style of api.auth.test.ts (no jsdom in this suite).
+
+// The helper reads `window.location`; there is no window under node.
+const g = globalThis as unknown as { window?: unknown };
+const originalWindow = g.window;
+
+function setPage(protocol: string, host: string): void {
+  g.window = { location: { protocol, host } };
+}
+
+beforeEach(() => {
+  setPage('http:', 'localhost:5173');
+});
+
+afterEach(() => {
+  g.window = originalWindow;
+});
+
+describe('shouldSubscribe', () => {
+  it('does not subscribe without an id', () => {
+    // Callers pass a possibly-undefined selected-agent id and rely on this
+    // meaning "do not subscribe". Changing it would turn every such caller
+    // into a firehose subscription.
+    expect(shouldSubscribe(undefined)).toBe(false);
+    expect(shouldSubscribe('')).toBe(false);
+  });
+
+  it('subscribes for a single agent', () => {
+    expect(shouldSubscribe('1183a1b037e7')).toBe(true);
+  });
+
+  it('subscribes for ALL_AGENTS', () => {
+    expect(shouldSubscribe(ALL_AGENTS)).toBe(true);
+  });
+});
+
+describe('buildWsUrl', () => {
+  it('filters to one agent', () => {
+    expect(buildWsUrl('1183a1b037e7')).toBe(
+      'ws://localhost:5173/v1/agents/events?agent_id=1183a1b037e7',
+    );
+  });
+
+  it('sends no filter for ALL_AGENTS', () => {
+    // Sending agent_id=* would filter for an agent literally named "*",
+    // which matches nothing — the absence of the parameter is the filter.
+    expect(buildWsUrl(ALL_AGENTS)).toBe('ws://localhost:5173/v1/agents/events');
+    expect(buildWsUrl(ALL_AGENTS)).not.toContain('agent_id');
+  });
+
+  it('sends no filter when no id is given', () => {
+    expect(buildWsUrl()).toBe('ws://localhost:5173/v1/agents/events');
+  });
+
+  it('escapes an id so it cannot alter the query', () => {
+    expect(buildWsUrl('a&b=c')).toBe(
+      'ws://localhost:5173/v1/agents/events?agent_id=a%26b%3Dc',
+    );
+  });
+
+  it('upgrades wss for an https page', () => {
+    setPage('https:', 'jarvis.local');
+    expect(buildWsUrl(ALL_AGENTS)).toBe('wss://jarvis.local/v1/agents/events');
+  });
+});

--- a/frontend/src/lib/useAgentEvents.ts
+++ b/frontend/src/lib/useAgentEvents.ts
@@ -7,7 +7,27 @@ export interface AgentEvent {
   data: Record<string, unknown>;
 }
 
-function buildWsUrl(agentId?: string): string {
+/**
+ * Subscribe to every agent's events rather than one agent's.
+ *
+ * The server has always supported this — ``/v1/agents/events`` treats
+ * ``agent_id`` as an optional filter and broadcasts everything without it
+ * (`server/ws_bridge.py`). Only this hook prevented it, by refusing to connect
+ * without an id, which left `buildWsUrl`'s no-filter branch unreachable.
+ *
+ * An explicit sentinel rather than reusing `undefined`: callers pass a
+ * possibly-undefined selected-agent id and rely on that meaning "do not
+ * subscribe", so redefining it would silently turn those into firehose
+ * subscriptions.
+ */
+export const ALL_AGENTS = '*';
+
+/** Whether the hook should open a socket at all. */
+export function shouldSubscribe(agentId?: string): boolean {
+  return Boolean(agentId);
+}
+
+export function buildWsUrl(agentId?: string): string {
   const base = getBase();
   let origin: string;
   if (base) {
@@ -17,13 +37,17 @@ function buildWsUrl(agentId?: string): string {
     origin = `${loc.protocol === 'https:' ? 'wss:' : 'ws:'}//${loc.host}`;
   }
   const path = '/v1/agents/events';
-  return agentId
+  // ALL_AGENTS means "no filter", which is the absence of the parameter —
+  // sending agent_id=* would filter for an agent literally named "*".
+  return agentId && agentId !== ALL_AGENTS
     ? `${origin}${path}?agent_id=${encodeURIComponent(agentId)}`
     : `${origin}${path}`;
 }
 
 /**
  * Subscribe to agent events over WebSocket.
+ *
+ * Pass a single agent id, or {@link ALL_AGENTS} for every agent.
  * Auto-reconnects with backoff when the socket drops.
  */
 export function useAgentEvents(
@@ -37,7 +61,7 @@ export function useAgentEvents(
   typesRef.current = eventTypes;
 
   useEffect(() => {
-    if (!agentId) return;
+    if (!shouldSubscribe(agentId)) return;
     let ws: WebSocket | null = null;
     let closed = false;
     let retry = 0;


### PR DESCRIPTION
`buildWsUrl` already handles the case with no agent id, omitting the `agent_id` parameter — which is exactly how the server expresses *no filter*: `/v1/agents/events` treats `agent_id` as optional and broadcasts everything without it (`server/ws_bridge.py`).

But `useAgentEvents` returns early when there is no id:

```ts
useEffect(() => {
  if (!agentId) return;   // ← makes buildWsUrl's no-filter branch unreachable
```

So the capability exists on both the server and in the URL builder, and is unreachable from the client.

## The design decision worth reviewing

An explicit `ALL_AGENTS` sentinel rather than redefining `undefined`.

Both current callers (`pages/AgentsPage.tsx`, two call sites) pass a possibly-undefined selected-agent id and rely on `undefined` meaning *do not subscribe*. Making it mean *everything* would silently turn them into firehose subscriptions on every render where no agent is selected — including one whose callback refetches agent data.

Sending `agent_id=*` would filter for an agent literally named `*`, so the sentinel maps to the **absence** of the parameter, not a wildcard value.

## Tests

`shouldSubscribe` is extracted so the connect/skip decision is testable without a DOM — this suite runs under node with no jsdom, matching how `api.auth.test.ts` covers the pure helpers.

8 tests: the subscribe decision for undefined/empty/id/ALL_AGENTS, the URL for a single agent, ALL_AGENTS and no id, parameter escaping, and the `wss` upgrade on an https page. All passing.

## Honest note on scope

This enables a global activity feed. **No caller upstream uses it yet**, so it is groundwork rather than a feature you can see. If you would rather not carry unused surface until there is a consumer, say so and I will close it — no argument from me.

It pairs with #692, without which none of this is observable in dev at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
