### PR TITLE
feat: Implement anonymous ID generation with fallbacks

### DIFF
--- a/frontend/vite.config.tsy
+++ b/frontend/vite.config.tsy
@@ -51,10 +51,9 @@ export default defineConfig({
       },
     },
   },
-          server: {
-            port: 5173,
-            allowedHosts: ['0.0.0.0', 'shodan.ehrendingen'],
-            proxy: {
+  server: {
+    port: 5173,
+    proxy: {
       '/v1': process.env.VITE_API_URL || 'http://localhost:8000',
       '/health': process.env.VITE_API_URL || 'http://localhost:8000',
       '/api': process.env.VITE_API_URL || 'http://localhost:8000',


### PR DESCRIPTION

If I serve the UI in my local network using http, crypto is not available in the browser. As this is a user id, the fallback is my proposed solution.

---

Introduces a `generateAnonId` function to ensure reliable UUID creation across various environments (modern browser APIs like `crypto.randomUUID`, secure crypto methods, and legacy fallback). This replaces the reliance solely on `crypto.randomUUID()` in components and state logic for generating default anonymous IDs when none are stored locally.

