### PR TITLE
fix: parse skill sources from TOML

### DIFF
--- a/src/openjarvis/core/config.py
+++ b/src/openjarvis/core/config.py
@@ -12,9 +12,18 @@ import os
 import platform
 import shutil
 import subprocess
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, is_dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    List,
+    Optional,
+    get_args,
+    get_origin,
+    get_type_hints,
+)
 
 from openjarvis.core.paths import (
     ConfigurationError,
@@ -1714,6 +1723,11 @@ def _apply_toml_section(target: Any, section: Dict[str, Any]) -> None:
     for dataclass fields annotated as ``str`` and for backward-compat
     property setters that expect string input.
     """
+    try:
+        type_hints = get_type_hints(type(target)) if is_dataclass(target) else {}
+    except (NameError, TypeError):
+        type_hints = {}
+
     for key, value in section.items():
         if hasattr(target, key):
             if isinstance(value, dict):
@@ -1727,6 +1741,21 @@ def _apply_toml_section(target: Any, section: Dict[str, Any]) -> None:
                 # Covers both real dataclass fields and backward-compat
                 # property setters (e.g. reward_weights, default_tools).
                 if isinstance(value, list):
+                    field_type = type_hints.get(key)
+                    if get_origin(field_type) is list:
+                        args = get_args(field_type)
+                        item_type = args[0] if len(args) == 1 else None
+
+                        if isinstance(item_type, type) and is_dataclass(item_type):
+                            value = [
+                                item
+                                if isinstance(item, item_type)
+                                else item_type(**item)
+                                if isinstance(item, dict)
+                                else item
+                                for item in value
+                            ]
+
                     is_str_field = False
                     if hasattr(target, "__dataclass_fields__"):
                         field_obj = target.__dataclass_fields__.get(key)

--- a/tests/core/test_config_skills_sources.py
+++ b/tests/core/test_config_skills_sources.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
-from openjarvis.core.config import SkillsConfig, SkillSourceConfig
+import openjarvis.core.config as config_module
+from openjarvis.core.config import (
+    DigestSectionConfig,
+    SkillsConfig,
+    SkillSourceConfig,
+)
 
 
 class TestSkillSourceConfig:
@@ -41,3 +46,59 @@ class TestSkillsConfigWithSources:
         )
         assert len(cfg.sources) == 2
         assert cfg.sources[0].source == "hermes"
+
+
+class TestSkillsSourcesTomlLoading:
+    def test_loads_sources_as_dataclasses(self, tmp_path):
+        toml_file = tmp_path / "config.toml"
+        toml_file.write_text(
+            """
+[[skills.sources]]
+source = "hermes"
+filter = { category = ["research", "coding"] }
+
+[[skills.sources]]
+source = "github"
+url = "https://github.com/example/skills"
+auto_update = true
+""".lstrip()
+        )
+
+        config_module.load_config.cache_clear()
+        try:
+            cfg = config_module.load_config(toml_file)
+        finally:
+            config_module.load_config.cache_clear()
+
+        assert len(cfg.skills.sources) == 2
+
+        hermes = cfg.skills.sources[0]
+        assert isinstance(hermes, SkillSourceConfig)
+        assert hermes.source == "hermes"
+        assert hermes.filter == {"category": ["research", "coding"]}
+        assert hermes.url == ""
+        assert hermes.auto_update is False
+
+        github = cfg.skills.sources[1]
+        assert isinstance(github, SkillSourceConfig)
+        assert github.source == "github"
+        assert github.url == "https://github.com/example/skills"
+        assert github.filter == {}
+        assert github.auto_update is True
+
+    def test_existing_instance_is_preserved(self):
+        existing = SkillSourceConfig(source="hermes")
+        target = SkillsConfig()
+
+        config_module._apply_toml_section(target, {"sources": [existing]})
+
+        assert target.sources[0] is existing
+
+    def test_list_of_strings_remains_a_list(self):
+        sources = ["gmail", "slack"]
+        target = DigestSectionConfig()
+
+        config_module._apply_toml_section(target, {"sources": sources})
+
+        assert isinstance(target.sources, list)
+        assert target.sources == sources


### PR DESCRIPTION
## What does this PR do?

Fixes #700.

`[[skills.sources]]` entries loaded from TOML were previously stored as raw dictionaries, even though `SkillsConfig.sources` is typed as `List[SkillSourceConfig]`.

Commands that access `.source`, `.url`, or `.filter` therefore failed with:

```text
AttributeError: 'dict' object has no attribute 'source'
```

This change updates `_apply_toml_section()` so that dictionary entries in fields typed as `List[SomeDataclass]` are converted into instances of the expected dataclass.

Existing behavior remains unchanged for:

* regular list fields such as `List[str]`
* already constructed dataclass instances
* existing list-to-string compatibility handling
* unresolved type hints

Regression tests cover:

* loading multiple `[[skills.sources]]` entries from TOML
* Hermes filters and GitHub source options
* preserving existing `SkillSourceConfig` instances
* leaving ordinary `List[str]` fields unchanged

## How was this tested?

The following validation completed successfully:

* Repository CI Python suite: 7,220 passed, 58 skipped
* Test coverage: 61.82% with a required minimum of 60%
* `uv run ruff check src/ tests/`
* `uv run ruff format --check src/ tests/`
* Focused configuration tests
* Rust Clippy with warnings treated as errors
* Rust workspace tests
* Windows validation on Python 3.12 and Python 3.13
* PyO3 extension build and import
* CLI smoke tests on Windows

## Checklist

* [x] Tests pass (`uv run pytest tests/ -v`)
* [x] Linter passes (`uv run ruff check src/ tests/`)
* [x] Formatter passes (`uv run ruff format --check src/ tests/`)
* [x] New/changed public API has docstrings — N/A, no public API change
* [x] Follows registry pattern — N/A, no new component
* [x] Documentation updated — N/A, this restores behavior already described by the existing configuration documentation
