### PR TITLE
fix(telemetry): record cloud inference cost

### DIFF
--- a/src/openjarvis/telemetry/instrumented_engine.py
+++ b/src/openjarvis/telemetry/instrumented_engine.py
@@ -212,6 +212,7 @@ class InstrumentedEngine(InferenceEngine):
             completion_tokens=completion_tokens,
             total_tokens=prompt_tok + completion_tokens,
             latency_seconds=latency,
+            cost_usd=result.get("cost_usd", 0.0),
             ttft=ttft,
             throughput_tok_per_sec=throughput,
             energy_per_output_token_joules=energy_per_output_token,

--- a/tests/telemetry/test_instrumented_engine.py
+++ b/tests/telemetry/test_instrumented_engine.py
@@ -71,6 +71,17 @@ class TestInstrumentedEngine:
         assert record.prompt_tokens == 10
         assert record.completion_tokens == 5
 
+    def test_generate_records_cost(self, mock_engine, bus):
+        mock_engine.generate.return_value["cost_usd"] = 0.0015
+        ie = InstrumentedEngine(mock_engine, bus)
+        messages = [Message(role=Role.USER, content="Hi")]
+        ie.generate(messages, model="test")
+
+        event = next(
+            e for e in bus.history if e.event_type == EventType.TELEMETRY_RECORD
+        )
+        assert event.data["record"].cost_usd == pytest.approx(0.0015)
+
     def test_list_models_delegates(self, mock_engine, bus):
         ie = InstrumentedEngine(mock_engine, bus)
         assert ie.list_models() == ["test-model"]


### PR DESCRIPTION
## Summary

- propagate cost_usd from cloud engine results into InstrumentedEngine telemetry records
- preserve the existing zero-cost default for engines that do not report cost
- add regression coverage for cost propagation

Fixes #699

## Confirmation

A deterministic mocked-provider run through CloudEngine, InstrumentedEngine, TelemetryStore, TelemetryAggregator, and jarvis telemetry stats reproduced the bug before the fix: the engine calculated $0.000450 while storage and CLI reported $0.000000.

After the fix, the same path reports $0.000450 at every stage.

## Testing

- Ruff check and formatting checks passed for the changed files
- Telemetry-focused suite: 297 passed