### PR TITLE
fix(cloud): preserve Gemini tool calls while streaming

### DIFF
--- a/src/openjarvis/engine/cloud.py
+++ b/src/openjarvis/engine/cloud.py
@@ -1350,14 +1350,16 @@ class CloudEngine(InferenceEngine):
                             args = json.loads(args)
                         except (json.JSONDecodeError, TypeError):
                             args = {"input": args}
-                    function_call: Dict[str, Any] = {
-                        "name": tool_call.name,
-                        "args": args if isinstance(args, dict) else {},
+                    function_call_part: Dict[str, Any] = {
+                        "function_call": {
+                            "name": tool_call.name,
+                            "args": args if isinstance(args, dict) else {},
+                        }
                     }
                     signature = self._thought_sigs.get(tool_call.id)
                     if signature is not None:
-                        function_call["thought_signature"] = signature
-                    parts.append({"function_call": function_call})
+                        function_call_part["thought_signature"] = signature
+                    parts.append(function_call_part)
                 contents.append({"role": "model", "parts": parts})
             elif message.role.value == "assistant":
                 contents.append({"role": "model", "parts": [{"text": message.content}]})
@@ -1377,7 +1379,7 @@ class CloudEngine(InferenceEngine):
         if tools:
             config.tools = [{"function_declarations": _convert_tools_to_google(tools)}]
 
-        tool_ids: Dict[str, int] = {}
+        tool_call_count = 0
         for chunk in self._google_client.models.generate_content_stream(
             model=model,
             contents=contents,
@@ -1402,8 +1404,12 @@ class CloudEngine(InferenceEngine):
                         name = getattr(function_call, "name", "")
                         raw_args = getattr(function_call, "args", {})
                         args = dict(raw_args) if hasattr(raw_args, "items") else {}
-                        tool_id = f"google_{name}"
-                        tool_index = tool_ids.setdefault(tool_id, len(tool_ids))
+                        # Gemini emits complete function-call parts, so each part is
+                        # a distinct invocation. The same function may legitimately
+                        # be called more than once in a parallel response.
+                        tool_index = tool_call_count
+                        tool_id = f"google_{name}_{tool_index}"
+                        tool_call_count += 1
                         tool_call = {
                             "index": tool_index,
                             "id": tool_id,
@@ -1430,7 +1436,7 @@ class CloudEngine(InferenceEngine):
             if text:
                 yield StreamChunk(content=text)
 
-        yield StreamChunk(finish_reason="tool_calls" if tool_ids else "stop")
+        yield StreamChunk(finish_reason="tool_calls" if tool_call_count else "stop")
 
     async def _stream_openrouter(
         self,

--- a/src/openjarvis/engine/cloud.py
+++ b/src/openjarvis/engine/cloud.py
@@ -9,6 +9,7 @@ import json
 import logging
 import os
 import time
+import uuid
 from collections.abc import AsyncIterator, Sequence
 from typing import Any, Dict, List, Tuple
 
@@ -1380,11 +1381,25 @@ class CloudEngine(InferenceEngine):
             config.tools = [{"function_declarations": _convert_tools_to_google(tools)}]
 
         tool_call_count = 0
+        stream_id = uuid.uuid4().hex
+        final_usage: Dict[str, Any] | None = None
         for chunk in self._google_client.models.generate_content_stream(
             model=model,
             contents=contents,
             config=config,
         ):
+            usage_metadata = getattr(chunk, "usage_metadata", None)
+            if usage_metadata is not None:
+                prompt_tokens = getattr(usage_metadata, "prompt_token_count", 0) or 0
+                completion_tokens = (
+                    getattr(usage_metadata, "candidates_token_count", 0) or 0
+                )
+                final_usage = {
+                    "prompt_tokens": prompt_tokens,
+                    "completion_tokens": completion_tokens,
+                    "total_tokens": prompt_tokens + completion_tokens,
+                }
+
             candidates = getattr(chunk, "candidates", None)
             parts = []
             if candidates:
@@ -1408,7 +1423,11 @@ class CloudEngine(InferenceEngine):
                         # a distinct invocation. The same function may legitimately
                         # be called more than once in a parallel response.
                         tool_index = tool_call_count
-                        tool_id = f"google_{name}_{tool_index}"
+                        # The engine is shared across server requests, and saved
+                        # thought signatures are keyed by tool-call ID. Include a
+                        # per-stream nonce so concurrent conversations cannot
+                        # overwrite each other's signatures.
+                        tool_id = f"google_{stream_id}_{tool_index}"
                         tool_call_count += 1
                         tool_call = {
                             "index": tool_index,
@@ -1436,7 +1455,10 @@ class CloudEngine(InferenceEngine):
             if text:
                 yield StreamChunk(content=text)
 
-        yield StreamChunk(finish_reason="tool_calls" if tool_call_count else "stop")
+        yield StreamChunk(
+            finish_reason="tool_calls" if tool_call_count else "stop",
+            usage=final_usage,
+        )
 
     async def _stream_openrouter(
         self,

--- a/src/openjarvis/engine/cloud.py
+++ b/src/openjarvis/engine/cloud.py
@@ -1305,6 +1305,133 @@ class CloudEngine(InferenceEngine):
             if chunk.text:
                 yield chunk.text
 
+    async def _stream_full_google(
+        self,
+        messages: Sequence[Message],
+        *,
+        model: str,
+        temperature: float,
+        max_tokens: int,
+        **kwargs: Any,
+    ) -> AsyncIterator[StreamChunk]:
+        """Stream Google text and function-call parts as full chunks."""
+        if self._google_client is None:
+            raise EngineConnectionError("Google client not available")
+
+        system_text = ""
+        contents: List[Dict[str, Any]] = []
+        for message in messages:
+            if message.role.value == "system":
+                system_text = message.content
+            elif message.role.value == "tool":
+                function_response = {
+                    "function_response": {
+                        "name": message.name or "unknown",
+                        "response": {"result": message.content},
+                    }
+                }
+                if (
+                    contents
+                    and contents[-1]["role"] == "user"
+                    and contents[-1]["parts"]
+                    and "function_response" in contents[-1]["parts"][-1]
+                ):
+                    contents[-1]["parts"].append(function_response)
+                else:
+                    contents.append({"role": "user", "parts": [function_response]})
+            elif message.role.value == "assistant" and message.tool_calls:
+                parts: List[Dict[str, Any]] = []
+                if message.content:
+                    parts.append({"text": message.content})
+                for tool_call in message.tool_calls:
+                    args = tool_call.arguments
+                    if isinstance(args, str):
+                        try:
+                            args = json.loads(args)
+                        except (json.JSONDecodeError, TypeError):
+                            args = {"input": args}
+                    function_call: Dict[str, Any] = {
+                        "name": tool_call.name,
+                        "args": args if isinstance(args, dict) else {},
+                    }
+                    signature = self._thought_sigs.get(tool_call.id)
+                    if signature is not None:
+                        function_call["thought_signature"] = signature
+                    parts.append({"function_call": function_call})
+                contents.append({"role": "model", "parts": parts})
+            elif message.role.value == "assistant":
+                contents.append({"role": "model", "parts": [{"text": message.content}]})
+            else:
+                contents.append({"role": "user", "parts": [{"text": message.content}]})
+
+        from google.genai import types as genai_types
+
+        config = genai_types.GenerateContentConfig(
+            temperature=temperature,
+            max_output_tokens=max_tokens,
+        )
+        if system_text:
+            config.system_instruction = system_text
+
+        tools = kwargs.pop("tools", None)
+        if tools:
+            config.tools = [{"function_declarations": _convert_tools_to_google(tools)}]
+
+        tool_ids: Dict[str, int] = {}
+        for chunk in self._google_client.models.generate_content_stream(
+            model=model,
+            contents=contents,
+            config=config,
+        ):
+            candidates = getattr(chunk, "candidates", None)
+            parts = []
+            if candidates:
+                parts = getattr(candidates[0].content, "parts", []) or []
+
+            if parts:
+                text_found = False
+                calls: List[Dict[str, Any]] = []
+                for part in parts:
+                    text = getattr(part, "text", None)
+                    if text:
+                        text_found = True
+                        yield StreamChunk(content=text)
+
+                    function_call = getattr(part, "function_call", None)
+                    if function_call:
+                        name = getattr(function_call, "name", "")
+                        raw_args = getattr(function_call, "args", {})
+                        args = dict(raw_args) if hasattr(raw_args, "items") else {}
+                        tool_id = f"google_{name}"
+                        tool_index = tool_ids.setdefault(tool_id, len(tool_ids))
+                        tool_call = {
+                            "index": tool_index,
+                            "id": tool_id,
+                            "type": "function",
+                            "function": {
+                                "name": name,
+                                "arguments": json.dumps(args),
+                            },
+                        }
+                        calls.append(tool_call)
+                        signature = getattr(part, "thought_signature", None)
+                        if signature is not None:
+                            tool_call["thought_signature"] = signature
+                            self._thought_sigs[tool_id] = signature
+                if calls:
+                    yield StreamChunk(tool_calls=calls)
+                if text_found:
+                    continue
+
+            try:
+                text = chunk.text
+            except (AttributeError, ValueError):
+                text = None
+            if text:
+                yield StreamChunk(content=text)
+
+        yield StreamChunk(finish_reason="tool_calls" if tool_ids else "stop")
+
     async def _stream_openrouter(
         self,
         messages: Sequence[Message],
@@ -1600,7 +1727,7 @@ class CloudEngine(InferenceEngine):
             async for chunk in self._stream_full_anthropic(messages, **kw):
                 yield chunk
         elif _is_google_model(model):
-            async for chunk in super().stream_full(messages, **kw):
+            async for chunk in self._stream_full_google(messages, **kw):
                 yield chunk
         else:
             async for chunk in self._stream_full_openai(messages, **kw):

--- a/tests/engine/test_cloud_stream_full.py
+++ b/tests/engine/test_cloud_stream_full.py
@@ -3,6 +3,8 @@ and _prepare_anthropic_messages."""
 
 from __future__ import annotations
 
+import sys
+from types import ModuleType, SimpleNamespace
 from typing import Any, List
 from unittest.mock import MagicMock
 
@@ -61,6 +63,28 @@ def _openai_tool_call_delta(
     tc.function.name = name
     tc.function.arguments = arguments
     return tc
+
+
+class _GoogleConfig:
+    def __init__(self, **kwargs: Any) -> None:
+        self.__dict__.update(kwargs)
+
+
+def _google_stream_chunk(*parts: Any, text: str | None = None) -> Any:
+    candidates = []
+    if parts:
+        candidates = [SimpleNamespace(content=SimpleNamespace(parts=list(parts)))]
+    return SimpleNamespace(text=text, candidates=candidates, usage_metadata=None)
+
+
+def _google_types_modules() -> dict[str, ModuleType]:
+    types = ModuleType("google.genai.types")
+    types.GenerateContentConfig = _GoogleConfig
+    genai = ModuleType("google.genai")
+    genai.types = types
+    google = ModuleType("google")
+    google.genai = genai
+    return {"google": google, "google.genai": genai, "google.genai.types": types}
 
 
 # ---------------------------------------------------------------------------
@@ -411,6 +435,166 @@ def test_prepare_anthropic_messages_tool_calls():
     assert blocks[1]["id"] == "call_1"
     assert blocks[1]["name"] == "get_weather"
     assert blocks[1]["input"] == {"city": "Berlin"}
+
+
+# ---------------------------------------------------------------------------
+# _stream_full_google tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stream_full_google_text_only(monkeypatch: pytest.MonkeyPatch):
+    """Google text chunks retain their content and finish normally."""
+    client = MagicMock()
+    client.models.generate_content_stream.return_value = iter(
+        [_google_stream_chunk(text="Hello"), _google_stream_chunk(text=" world")]
+    )
+    engine = _make_cloud_engine(google_client=client)
+    engine._thought_sigs = {}
+    messages = [Message(role=Role.USER, content="hi")]
+    modules = _google_types_modules()
+
+    with monkeypatch.context() as patch:
+        for name, module in modules.items():
+            patch.setitem(sys.modules, name, module)
+        result = [
+            chunk
+            async for chunk in engine.stream_full(messages, model="gemini-2.5-flash")
+        ]
+
+    assert [chunk.content for chunk in result[:-1]] == ["Hello", " world"]
+    assert result[-1].finish_reason == "stop"
+
+
+@pytest.mark.asyncio
+async def test_stream_full_google_preserves_tool_calls(monkeypatch: pytest.MonkeyPatch):
+    """Google function_call parts become OpenAI-compatible tool call chunks."""
+    function_call = SimpleNamespace(name="get_weather", args={"city": "Berlin"})
+    part = SimpleNamespace(
+        function_call=function_call, text=None, thought_signature=b"sig"
+    )
+    client = MagicMock()
+    client.models.generate_content_stream.return_value = iter(
+        [_google_stream_chunk(part)]
+    )
+    engine = _make_cloud_engine(google_client=client)
+    engine._thought_sigs = {}
+    messages = [Message(role=Role.USER, content="weather")]
+    modules = _google_types_modules()
+
+    with monkeypatch.context() as patch:
+        for name, module in modules.items():
+            patch.setitem(sys.modules, name, module)
+        result = [
+            chunk
+            async for chunk in engine.stream_full(
+                messages,
+                model="gemini-2.5-flash",
+                tools=[
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "description": "Get weather",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                    }
+                ],
+            )
+        ]
+
+    tool_call = result[0].tool_calls[0]
+    assert tool_call == {
+        "index": 0,
+        "id": "google_get_weather",
+        "type": "function",
+        "function": {"name": "get_weather", "arguments": '{"city": "Berlin"}'},
+        "thought_signature": b"sig",
+    }
+    assert engine._thought_sigs["google_get_weather"] == b"sig"
+    assert result[-1].finish_reason == "tool_calls"
+    config = client.models.generate_content_stream.call_args.kwargs["config"]
+    assert config.tools == [
+        {
+            "function_declarations": [
+                {
+                    "name": "get_weather",
+                    "description": "Get weather",
+                    "parameters": {"type": "object", "properties": {}},
+                }
+            ]
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_stream_full_google_preserves_mixed_and_multiple_calls(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Google streams retain mixed text and multiple deterministic tool calls."""
+    weather = SimpleNamespace(name="get_weather", args={"city": "Berlin"})
+    calendar = SimpleNamespace(name="get_calendar", args={"day": "Monday"})
+    text_part = SimpleNamespace(text="I'll check.", function_call=None)
+    weather_part = SimpleNamespace(
+        function_call=weather, text=None, thought_signature=None
+    )
+    calendar_part = SimpleNamespace(
+        function_call=calendar, text=None, thought_signature=None
+    )
+    client = MagicMock()
+    client.models.generate_content_stream.return_value = iter(
+        [
+            _google_stream_chunk(text_part, weather_part),
+            _google_stream_chunk(weather_part, calendar_part),
+        ]
+    )
+    engine = _make_cloud_engine(google_client=client)
+    engine._thought_sigs = {}
+    modules = _google_types_modules()
+
+    with monkeypatch.context() as patch:
+        for name, module in modules.items():
+            patch.setitem(sys.modules, name, module)
+        result = [
+            chunk
+            async for chunk in engine.stream_full(
+                [Message(role=Role.USER, content="plan")], model="gemini-2.5-flash"
+            )
+        ]
+
+    assert result[0].content == "I'll check."
+    assert result[1].tool_calls == [
+        {
+            "index": 0,
+            "id": "google_get_weather",
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "arguments": '{"city": "Berlin"}',
+            },
+        }
+    ]
+    assert result[2].tool_calls == [
+        {
+            "index": 0,
+            "id": "google_get_weather",
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "arguments": '{"city": "Berlin"}',
+            },
+        },
+        {
+            "index": 1,
+            "id": "google_get_calendar",
+            "type": "function",
+            "function": {
+                "name": "get_calendar",
+                "arguments": '{"day": "Monday"}',
+            },
+        },
+    ]
+    assert result[-1].finish_reason == "tool_calls"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/engine/test_cloud_stream_full.py
+++ b/tests/engine/test_cloud_stream_full.py
@@ -506,12 +506,12 @@ async def test_stream_full_google_preserves_tool_calls(monkeypatch: pytest.Monke
     tool_call = result[0].tool_calls[0]
     assert tool_call == {
         "index": 0,
-        "id": "google_get_weather",
+        "id": "google_get_weather_0",
         "type": "function",
         "function": {"name": "get_weather", "arguments": '{"city": "Berlin"}'},
         "thought_signature": b"sig",
     }
-    assert engine._thought_sigs["google_get_weather"] == b"sig"
+    assert engine._thought_sigs["google_get_weather_0"] == b"sig"
     assert result[-1].finish_reason == "tool_calls"
     config = client.models.generate_content_stream.call_args.kwargs["config"]
     assert config.tools == [
@@ -545,7 +545,7 @@ async def test_stream_full_google_preserves_mixed_and_multiple_calls(
     client.models.generate_content_stream.return_value = iter(
         [
             _google_stream_chunk(text_part, weather_part),
-            _google_stream_chunk(weather_part, calendar_part),
+            _google_stream_chunk(calendar_part),
         ]
     )
     engine = _make_cloud_engine(google_client=client)
@@ -566,7 +566,7 @@ async def test_stream_full_google_preserves_mixed_and_multiple_calls(
     assert result[1].tool_calls == [
         {
             "index": 0,
-            "id": "google_get_weather",
+            "id": "google_get_weather_0",
             "type": "function",
             "function": {
                 "name": "get_weather",
@@ -576,17 +576,8 @@ async def test_stream_full_google_preserves_mixed_and_multiple_calls(
     ]
     assert result[2].tool_calls == [
         {
-            "index": 0,
-            "id": "google_get_weather",
-            "type": "function",
-            "function": {
-                "name": "get_weather",
-                "arguments": '{"city": "Berlin"}',
-            },
-        },
-        {
             "index": 1,
-            "id": "google_get_calendar",
+            "id": "google_get_calendar_1",
             "type": "function",
             "function": {
                 "name": "get_calendar",
@@ -595,6 +586,94 @@ async def test_stream_full_google_preserves_mixed_and_multiple_calls(
         },
     ]
     assert result[-1].finish_reason == "tool_calls"
+
+
+@pytest.mark.asyncio
+async def test_stream_full_google_keeps_parallel_same_name_calls_distinct(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Parallel invocations of one function receive unique indexes and IDs."""
+    paris = SimpleNamespace(name="get_weather", args={"city": "Paris"})
+    london = SimpleNamespace(name="get_weather", args={"city": "London"})
+    parts = [
+        SimpleNamespace(function_call=paris, text=None, thought_signature=b"sig"),
+        SimpleNamespace(function_call=london, text=None, thought_signature=None),
+    ]
+    client = MagicMock()
+    client.models.generate_content_stream.return_value = iter(
+        [_google_stream_chunk(*parts)]
+    )
+    engine = _make_cloud_engine(google_client=client)
+    engine._thought_sigs = {}
+
+    with monkeypatch.context() as patch:
+        for name, module in _google_types_modules().items():
+            patch.setitem(sys.modules, name, module)
+        result = [
+            chunk
+            async for chunk in engine.stream_full(
+                [Message(role=Role.USER, content="Weather in Paris and London")],
+                model="gemini-3-flash-preview",
+            )
+        ]
+
+    calls = result[0].tool_calls
+    assert [(call["index"], call["id"]) for call in calls] == [
+        (0, "google_get_weather_0"),
+        (1, "google_get_weather_1"),
+    ]
+    assert [call["function"]["arguments"] for call in calls] == [
+        '{"city": "Paris"}',
+        '{"city": "London"}',
+    ]
+
+
+@pytest.mark.asyncio
+async def test_stream_full_google_replays_signature_on_part(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A saved Gemini signature is replayed beside, not inside, function_call."""
+    client = MagicMock()
+    client.models.generate_content_stream.return_value = iter([])
+    engine = _make_cloud_engine(google_client=client)
+    engine._thought_sigs = {"google_get_weather_0": b"sig"}
+    messages = [
+        Message(role=Role.USER, content="weather"),
+        Message(
+            role=Role.ASSISTANT,
+            content=None,
+            tool_calls=[
+                ToolCall(
+                    id="google_get_weather_0",
+                    name="get_weather",
+                    arguments='{"city": "Berlin"}',
+                )
+            ],
+        ),
+        Message(role=Role.TOOL, name="get_weather", content='{"temp": 20}'),
+    ]
+
+    with monkeypatch.context() as patch:
+        for name, module in _google_types_modules().items():
+            patch.setitem(sys.modules, name, module)
+        result = [
+            chunk
+            async for chunk in engine.stream_full(
+                messages, model="gemini-3-flash-preview"
+            )
+        ]
+
+    contents = client.models.generate_content_stream.call_args.kwargs["contents"]
+    assert contents[1]["parts"] == [
+        {
+            "function_call": {
+                "name": "get_weather",
+                "args": {"city": "Berlin"},
+            },
+            "thought_signature": b"sig",
+        }
+    ]
+    assert result[-1].finish_reason == "stop"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/engine/test_cloud_stream_full.py
+++ b/tests/engine/test_cloud_stream_full.py
@@ -70,11 +70,19 @@ class _GoogleConfig:
         self.__dict__.update(kwargs)
 
 
-def _google_stream_chunk(*parts: Any, text: str | None = None) -> Any:
+def _google_stream_chunk(
+    *parts: Any,
+    text: str | None = None,
+    usage_metadata: Any = None,
+) -> Any:
     candidates = []
     if parts:
         candidates = [SimpleNamespace(content=SimpleNamespace(parts=list(parts)))]
-    return SimpleNamespace(text=text, candidates=candidates, usage_metadata=None)
+    return SimpleNamespace(
+        text=text,
+        candidates=candidates,
+        usage_metadata=usage_metadata,
+    )
 
 
 def _google_types_modules() -> dict[str, ModuleType]:
@@ -504,14 +512,15 @@ async def test_stream_full_google_preserves_tool_calls(monkeypatch: pytest.Monke
         ]
 
     tool_call = result[0].tool_calls[0]
-    assert tool_call == {
-        "index": 0,
-        "id": "google_get_weather_0",
-        "type": "function",
-        "function": {"name": "get_weather", "arguments": '{"city": "Berlin"}'},
-        "thought_signature": b"sig",
+    assert tool_call["index"] == 0
+    assert tool_call["id"].startswith("google_")
+    assert tool_call["type"] == "function"
+    assert tool_call["function"] == {
+        "name": "get_weather",
+        "arguments": '{"city": "Berlin"}',
     }
-    assert engine._thought_sigs["google_get_weather_0"] == b"sig"
+    assert tool_call["thought_signature"] == b"sig"
+    assert engine._thought_sigs[tool_call["id"]] == b"sig"
     assert result[-1].finish_reason == "tool_calls"
     config = client.models.generate_content_stream.call_args.kwargs["config"]
     assert config.tools == [
@@ -531,7 +540,7 @@ async def test_stream_full_google_preserves_tool_calls(monkeypatch: pytest.Monke
 async def test_stream_full_google_preserves_mixed_and_multiple_calls(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    """Google streams retain mixed text and multiple deterministic tool calls."""
+    """Google streams retain mixed text and multiple tool calls."""
     weather = SimpleNamespace(name="get_weather", args={"city": "Berlin"})
     calendar = SimpleNamespace(name="get_calendar", args={"day": "Monday"})
     text_part = SimpleNamespace(text="I'll check.", function_call=None)
@@ -563,28 +572,19 @@ async def test_stream_full_google_preserves_mixed_and_multiple_calls(
         ]
 
     assert result[0].content == "I'll check."
-    assert result[1].tool_calls == [
-        {
-            "index": 0,
-            "id": "google_get_weather_0",
-            "type": "function",
-            "function": {
-                "name": "get_weather",
-                "arguments": '{"city": "Berlin"}',
-            },
-        }
-    ]
-    assert result[2].tool_calls == [
-        {
-            "index": 1,
-            "id": "google_get_calendar_1",
-            "type": "function",
-            "function": {
-                "name": "get_calendar",
-                "arguments": '{"day": "Monday"}',
-            },
-        },
-    ]
+    weather_call = result[1].tool_calls[0]
+    calendar_call = result[2].tool_calls[0]
+    assert weather_call["index"] == 0
+    assert weather_call["function"] == {
+        "name": "get_weather",
+        "arguments": '{"city": "Berlin"}',
+    }
+    assert calendar_call["index"] == 1
+    assert calendar_call["function"] == {
+        "name": "get_calendar",
+        "arguments": '{"day": "Monday"}',
+    }
+    assert weather_call["id"] != calendar_call["id"]
     assert result[-1].finish_reason == "tool_calls"
 
 
@@ -618,14 +618,93 @@ async def test_stream_full_google_keeps_parallel_same_name_calls_distinct(
         ]
 
     calls = result[0].tool_calls
-    assert [(call["index"], call["id"]) for call in calls] == [
-        (0, "google_get_weather_0"),
-        (1, "google_get_weather_1"),
-    ]
+    assert [call["index"] for call in calls] == [0, 1]
+    assert calls[0]["id"] != calls[1]["id"]
     assert [call["function"]["arguments"] for call in calls] == [
         '{"city": "Paris"}',
         '{"city": "London"}',
     ]
+
+
+@pytest.mark.asyncio
+async def test_stream_full_google_ids_are_unique_across_requests(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Shared engines keep signatures isolated between conversations."""
+    first_part = SimpleNamespace(
+        function_call=SimpleNamespace(name="get_weather", args={"city": "Paris"}),
+        text=None,
+        thought_signature=b"paris-sig",
+    )
+    second_part = SimpleNamespace(
+        function_call=SimpleNamespace(name="get_weather", args={"city": "London"}),
+        text=None,
+        thought_signature=b"london-sig",
+    )
+    client = MagicMock()
+    client.models.generate_content_stream.side_effect = [
+        iter([_google_stream_chunk(first_part)]),
+        iter([_google_stream_chunk(second_part)]),
+    ]
+    engine = _make_cloud_engine(google_client=client)
+    engine._thought_sigs = {}
+
+    with monkeypatch.context() as patch:
+        for name, module in _google_types_modules().items():
+            patch.setitem(sys.modules, name, module)
+        first = [
+            chunk
+            async for chunk in engine.stream_full(
+                [Message(role=Role.USER, content="Weather in Paris")],
+                model="gemini-3-flash-preview",
+            )
+        ]
+        second = [
+            chunk
+            async for chunk in engine.stream_full(
+                [Message(role=Role.USER, content="Weather in London")],
+                model="gemini-3-flash-preview",
+            )
+        ]
+
+    first_id = first[0].tool_calls[0]["id"]
+    second_id = second[0].tool_calls[0]["id"]
+    assert first_id != second_id
+    assert engine._thought_sigs[first_id] == b"paris-sig"
+    assert engine._thought_sigs[second_id] == b"london-sig"
+
+
+@pytest.mark.asyncio
+async def test_stream_full_google_emits_final_usage(monkeypatch: pytest.MonkeyPatch):
+    """Google's final usage metadata is normalized onto the terminal chunk."""
+    usage = SimpleNamespace(prompt_token_count=12, candidates_token_count=5)
+    client = MagicMock()
+    client.models.generate_content_stream.return_value = iter(
+        [
+            _google_stream_chunk(text="Hello"),
+            _google_stream_chunk(usage_metadata=usage),
+        ]
+    )
+    engine = _make_cloud_engine(google_client=client)
+    engine._thought_sigs = {}
+
+    with monkeypatch.context() as patch:
+        for name, module in _google_types_modules().items():
+            patch.setitem(sys.modules, name, module)
+        result = [
+            chunk
+            async for chunk in engine.stream_full(
+                [Message(role=Role.USER, content="hi")],
+                model="gemini-2.5-flash",
+            )
+        ]
+
+    assert result[-1].finish_reason == "stop"
+    assert result[-1].usage == {
+        "prompt_tokens": 12,
+        "completion_tokens": 5,
+        "total_tokens": 17,
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes #707

Gemini models previously used the base `stream_full()` fallback, which only
wrapped text from `_stream_google()` and therefore silently discarded streamed
`function_call` parts.

This adds a Google-specific rich streaming path that:

- emits text and OpenAI-compatible `StreamChunk.tool_calls` values;
- forwards caller-provided tools through `GenerateContentConfig`;
- preserves and stores Gemini `thought_signature` metadata; and
- emits `finish_reason="tool_calls"` when function calls were streamed.

Repeated fragments for a function use the same deterministic `google_<name>`
identifier and index, while distinct function names receive stable indexes.

## Validation

No external credentials or network calls were required; all new coverage uses a
fake Google client.

- `PYTHONPATH=src uv run --extra dev pytest tests/engine/test_cloud_stream_full.py -v` — 14 passed
- `PYTHONPATH=src uv run --extra dev pytest tests/engine/test_engine_wrappers.py -v` — 3 passed
- `PYTHONPATH=src uv run --extra dev ruff check src/openjarvis/engine/cloud.py tests/engine/test_cloud_stream_full.py` — passed
- `PYTHONPATH=src uv run --extra dev ruff format --check src/openjarvis/engine/cloud.py tests/engine/test_cloud_stream_full.py` — passed

The existing OpenAI-compatible and Anthropic `stream_full()` tests remain
unchanged and pass in the focused suite.

The broader `tests/` run was attempted with the server and framework-comparison
extras. It reached 1,466 passed and 8 skipped before stopping after three
pre-existing/environmental failures: the loop-guard assertion and two tests
requiring the unavailable native `openjarvis_rust` extension. These are outside
this change.

Provider-wide streaming usage and cost telemetry remain out of scope.
