### PR TITLE
fix(tools): eager-import scan_chunks and knowledge_sql at package load

### DIFF
--- a/src/openjarvis/tools/__init__.py
+++ b/src/openjarvis/tools/__init__.py
@@ -142,4 +142,14 @@ try:
 except ImportError:
     pass
 
+try:
+    import openjarvis.tools.scan_chunks  # noqa: F401
+except ImportError:
+    pass
+
+try:
+    import openjarvis.tools.knowledge_sql  # noqa: F401
+except ImportError:
+    pass
+
 __all__ = ["BaseTool", "ToolExecutor", "ToolSpec"]

--- a/tests/tools/test_tool_registration.py
+++ b/tests/tools/test_tool_registration.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+import subprocess
 import sys
 
 from openjarvis.core.registry import ToolRegistry
@@ -68,6 +69,10 @@ EXPECTED_TOOLS = {
     "kg_add_relation",
     "kg_query",
     "kg_neighbors",
+    # knowledge_sql.py
+    "knowledge_sql",
+    # scan_chunks.py
+    "scan_chunks",
 }
 
 
@@ -100,3 +105,25 @@ def test_all_builtin_tools_registered():
     assert not missing, (
         f"Tools not registered (missing import in __init__.py?): {sorted(missing)}"
     )
+
+
+def test_package_import_registers_deep_research_tools():
+    """Registration must not depend on another module being imported first."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import openjarvis.tools; "
+                "from openjarvis.core.registry import ToolRegistry; "
+                "expected = {'knowledge_sql', 'scan_chunks'}; "
+                "missing = expected - set(ToolRegistry.keys()); "
+                "assert not missing, f'Missing tools: {sorted(missing)}'"
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary

Every other built-in tool is imported in `tools/__init__.py` specifically to fire its `@ToolRegistry.register()` decorator at package-load time. `scan_chunks` and `knowledge_sql` were missing from that list, so their respective `test_registered` tests only passed when some unrelated test (via `agent_manager_routes.py`, `channels_cmd.py`, or `deep_research_setup_cmd.py`) happened to import the module first in the same process. Under `pytest-xdist`, that's worker-distribution dependent — adding an unrelated test file elsewhere in the suite could flip either test from pass to fail with no change to the test itself.

## Fix

Add the same `try/import ... except ImportError: pass` pattern already used for every other built-in tool.

## Test plan

- [x] `uv run pytest tests/tools/test_knowledge_sql.py::test_registered tests/tools/test_scan_chunks.py::test_registered -v` — both pass in isolation (no reliance on import order from another test file)
- [x] `ruff check` / `ruff format --check` on the changed file — clean