### PR TITLE
fix(security): block sensitive file aliases

### DIFF
--- a/rust/crates/openjarvis-security/src/file_policy.rs
+++ b/rust/crates/openjarvis-security/src/file_policy.rs
@@ -1,39 +1,31 @@
 //! File sensitivity policy — block access to secrets, credentials, and keys.
 
-use once_cell::sync::Lazy;
-use std::collections::HashSet;
-use std::path::Path;
+use std::ffi::OsString;
+use std::io;
+use std::path::{Path, PathBuf};
 
-static SENSITIVE_PATTERNS: Lazy<HashSet<&'static str>> = Lazy::new(|| {
-    HashSet::from([
-        ".env",
-        ".secret",
-        "id_rsa",
-        "id_ed25519",
-        ".htpasswd",
-        ".pgpass",
-        ".netrc",
-    ])
-});
+static SENSITIVE_PATTERNS: &[&str] = &[
+    ".env",
+    ".secret",
+    "id_rsa",
+    "id_ed25519",
+    ".htpasswd",
+    ".pgpass",
+    ".netrc",
+];
 
-static SENSITIVE_EXTENSIONS: Lazy<Vec<&'static str>> = Lazy::new(|| {
-    vec![
-        ".pem", ".key", ".p12", ".pfx", ".jks", ".secrets",
-    ]
-});
+static SENSITIVE_EXTENSIONS: &[&str] =
+    &[".env", ".pem", ".key", ".p12", ".pfx", ".jks", ".secrets"];
 
-static SENSITIVE_PREFIXES: Lazy<Vec<&'static str>> = Lazy::new(|| {
-    vec![".env.", "credentials."]
-});
+static SENSITIVE_PREFIXES: &[&str] = &[".env.", "credentials."];
 
-/// Return `true` if path matches a sensitive file pattern.
-pub fn is_sensitive_file(path: &Path) -> bool {
+fn matches_sensitive_name(path: &Path) -> bool {
     let name = match path.file_name().and_then(|n| n.to_str()) {
-        Some(n) => n,
+        Some(name) => name.to_lowercase(),
         None => return false,
     };
 
-    if SENSITIVE_PATTERNS.contains(name) {
+    if SENSITIVE_PATTERNS.contains(&name.as_str()) {
         return true;
     }
 
@@ -50,6 +42,59 @@ pub fn is_sensitive_file(path: &Path) -> bool {
     }
 
     false
+}
+
+fn resolve_allow_missing(path: &Path) -> io::Result<PathBuf> {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()?.join(path)
+    };
+    let mut current = absolute.as_path();
+    let mut missing_parts: Vec<OsString> = Vec::new();
+
+    loop {
+        match std::fs::symlink_metadata(current) {
+            Ok(_) => {
+                let mut resolved = std::fs::canonicalize(current)?;
+                for part in missing_parts.iter().rev() {
+                    resolved.push(part);
+                }
+                return Ok(resolved);
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                let part = current.file_name().ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::NotFound,
+                        "path has no existing ancestor to resolve",
+                    )
+                })?;
+                missing_parts.push(part.to_os_string());
+                current = current.parent().ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::NotFound,
+                        "path has no existing ancestor to resolve",
+                    )
+                })?;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+/// Return `true` if a path or its resolved target is sensitive.
+///
+/// Missing leaf components are permitted for prospective writes. Other
+/// resolution failures fail closed because the target cannot be established.
+pub fn is_sensitive_file(path: &Path) -> bool {
+    if matches_sensitive_name(path) {
+        return true;
+    }
+
+    match resolve_allow_missing(path) {
+        Ok(resolved) => matches_sensitive_name(&resolved),
+        Err(_) => true,
+    }
 }
 
 /// Return only non-sensitive paths.
@@ -69,6 +114,7 @@ mod tests {
     fn test_sensitive_files() {
         assert!(is_sensitive_file(Path::new(".env")));
         assert!(is_sensitive_file(Path::new(".env.local")));
+        assert!(is_sensitive_file(Path::new("production.env")));
         assert!(is_sensitive_file(Path::new("server.key")));
         assert!(is_sensitive_file(Path::new("cert.pem")));
         assert!(is_sensitive_file(Path::new("id_rsa")));
@@ -80,5 +126,40 @@ mod tests {
         assert!(!is_sensitive_file(Path::new("main.py")));
         assert!(!is_sensitive_file(Path::new("README.md")));
         assert!(!is_sensitive_file(Path::new("config.toml")));
+    }
+
+    #[test]
+    fn test_sensitive_files_are_case_insensitive() {
+        for name in [".ENV", "Credentials.JSON", "PRIVATE.KEY", "ID_RSA"] {
+            assert!(
+                is_sensitive_file(Path::new(name)),
+                "{name} should be sensitive"
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_sensitive_target_is_blocked_through_safe_named_symlink() {
+        use std::os::unix::fs::symlink;
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after Unix epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "openjarvis-file-policy-{}-{unique}",
+            std::process::id()
+        ));
+        std::fs::create_dir(&root).expect("test directory should be created");
+        let target = root.join(".env");
+        let alias = root.join("notes.txt");
+        std::fs::write(&target, "SECRET=value").expect("target should be written");
+        symlink(&target, &alias).expect("symlink should be created");
+
+        assert!(is_sensitive_file(&alias));
+
+        std::fs::remove_dir_all(root).expect("test directory should be removed");
     }
 }

--- a/rust/crates/openjarvis-tools/src/builtin/file_tools.rs
+++ b/rust/crates/openjarvis-tools/src/builtin/file_tools.rs
@@ -1,9 +1,9 @@
 //! File read/write tools.
 
 use crate::traits::BaseTool;
+use once_cell::sync::Lazy;
 use openjarvis_core::{OpenJarvisError, ToolResult, ToolSpec};
 use openjarvis_security::file_policy::is_sensitive_file;
-use once_cell::sync::Lazy;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::path::Path;
@@ -129,9 +129,7 @@ mod tests {
     #[test]
     fn test_file_read_sensitive_blocked() {
         let tool = FileReadTool;
-        let result = tool
-            .execute(&serde_json::json!({"path": ".env"}))
-            .unwrap();
+        let result = tool.execute(&serde_json::json!({"path": ".env"})).unwrap();
         assert!(!result.success);
         assert!(result.content.contains("sensitive"));
     }
@@ -143,5 +141,32 @@ mod tests {
             .execute(&serde_json::json!({"path": "id_rsa", "content": "secret"}))
             .unwrap();
         assert!(!result.success);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_file_tools_block_sensitive_target_through_safe_named_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().expect("temporary directory should be created");
+        let target = temp.path().join(".env");
+        let alias = temp.path().join("notes.txt");
+        std::fs::write(&target, "SECRET=value").expect("target should be written");
+        symlink(&target, &alias).expect("symlink should be created");
+
+        let read_result = FileReadTool
+            .execute(&serde_json::json!({"path": alias}))
+            .expect("file_read should return a result");
+        assert!(!read_result.success);
+        assert!(read_result.content.contains("sensitive"));
+
+        let write_result = FileWriteTool
+            .execute(&serde_json::json!({"path": alias, "content": "replacement"}))
+            .expect("file_write should return a result");
+        assert!(!write_result.success);
+        assert_eq!(
+            std::fs::read_to_string(&target).expect("target should remain readable"),
+            "SECRET=value"
+        );
     }
 }

--- a/src/openjarvis/security/file_policy.py
+++ b/src/openjarvis/security/file_policy.py
@@ -30,17 +30,34 @@ DEFAULT_SENSITIVE_PATTERNS: frozenset[str] = frozenset(
 def is_sensitive_file(path: Union[str, Path]) -> bool:
     """Return ``True`` if *path* matches a sensitive file pattern.
 
-    Checks both the filename and the full name against
-    ``DEFAULT_SENSITIVE_PATTERNS`` using :func:`fnmatch.fnmatch`.
-    Uses the Rust implementation when available, falls back to Python.
+    Checks both the lexical path and its resolved target. Resolution failures
+    are denied because the target cannot be established safely. Uses the Rust
+    implementation when available and falls back to Python.
     """
+    candidates = _path_candidates(Path(path))
+    if candidates is None:
+        return True
+
     try:
         from openjarvis._rust_bridge import get_rust_module
 
         _rust = get_rust_module()
-        return _rust.is_sensitive_file(str(path))
+        matcher = _rust.is_sensitive_file
     except ImportError:
-        return _is_sensitive_file_py(str(path))
+        matcher = _is_sensitive_file_py
+
+    return any(matcher(str(candidate)) for candidate in candidates)
+
+
+def _path_candidates(path: Path) -> tuple[Path, ...] | None:
+    """Return lexical and resolved policy candidates, or ``None`` on failure."""
+    try:
+        resolved = path.resolve(strict=False)
+    except (OSError, RuntimeError):
+        return None
+    if resolved == path:
+        return (path,)
+    return path, resolved
 
 
 def _is_sensitive_file_py(path_str: str) -> bool:
@@ -48,9 +65,13 @@ def _is_sensitive_file_py(path_str: str) -> bool:
     import fnmatch
 
     p = Path(path_str)
-    name = p.name
+    name = p.name.casefold()
+    full_path = str(p).casefold()
     for pattern in DEFAULT_SENSITIVE_PATTERNS:
-        if fnmatch.fnmatch(name, pattern) or fnmatch.fnmatch(str(p), pattern):
+        folded_pattern = pattern.casefold()
+        if fnmatch.fnmatchcase(name, folded_pattern) or fnmatch.fnmatchcase(
+            full_path, folded_pattern
+        ):
             return True
     return False
 

--- a/tests/security/test_file_policy.py
+++ b/tests/security/test_file_policy.py
@@ -4,7 +4,32 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from openjarvis.security.file_policy import filter_sensitive_paths, is_sensitive_file
+import pytest
+
+from openjarvis.security.file_policy import (
+    _is_sensitive_file_py,
+    filter_sensitive_paths,
+    is_sensitive_file,
+)
+
+
+def _symlink_or_mock_resolution(
+    link: Path,
+    target: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    try:
+        link.symlink_to(target)
+    except (NotImplementedError, OSError):
+        link.write_bytes(target.read_bytes())
+        original_resolve = Path.resolve
+
+        def resolve_alias(self: Path, strict: bool = False) -> Path:
+            if self == link:
+                return target
+            return original_resolve(self, strict=strict)
+
+        monkeypatch.setattr(Path, "resolve", resolve_alias)
 
 
 class TestIsSensitiveFile:
@@ -68,6 +93,48 @@ class TestIsSensitiveFile:
     def test_path_object(self) -> None:
         assert is_sensitive_file(Path("server.pem")) is True
         assert is_sensitive_file(Path("main.py")) is False
+
+    def test_sensitive_target_is_blocked_through_safe_named_alias(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        target = tmp_path / ".env"
+        target.write_text("SECRET=value", encoding="utf-8")
+        alias = tmp_path / "notes.txt"
+        _symlink_or_mock_resolution(alias, target, monkeypatch)
+
+        assert is_sensitive_file(alias) is True
+
+    def test_safe_target_remains_allowed_through_alias(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        target = tmp_path / "notes.txt"
+        target.write_text("safe", encoding="utf-8")
+        alias = tmp_path / "alias.txt"
+        _symlink_or_mock_resolution(alias, target, monkeypatch)
+
+        assert is_sensitive_file(alias) is False
+
+    def test_resolution_failure_is_denied(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        def fail_resolution(self: Path, strict: bool = False) -> Path:
+            raise RuntimeError("symlink loop")
+
+        monkeypatch.setattr(Path, "resolve", fail_resolution)
+
+        assert is_sensitive_file(tmp_path / "ordinary.txt") is True
+
+    @pytest.mark.parametrize(
+        "name",
+        [".ENV", "Credentials.JSON", "PRIVATE.KEY", "ID_RSA"],
+    )
+    def test_python_matcher_is_case_insensitive(
+        self,
+        name: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr("fnmatch.os.path.normcase", lambda value: value)
+        assert _is_sensitive_file_py(name) is True
 
 
 class TestFilterSensitivePaths:

--- a/tests/tools/test_apply_patch.py
+++ b/tests/tools/test_apply_patch.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from openjarvis.tools.apply_patch import ApplyPatchTool
 
 
@@ -132,6 +134,37 @@ class TestApplyPatchTool:
         result = tool.execute(patch=patch, path=str(f))
         assert result.success is False
         assert "sensitive" in result.content.lower()
+
+    def test_blocks_sensitive_target_through_safe_named_alias(
+        self, tmp_path, monkeypatch
+    ):
+        target = tmp_path / ".env"
+        target.write_text("SECRET=value\n", encoding="utf-8")
+        alias = tmp_path / "notes.txt"
+        try:
+            alias.symlink_to(target)
+        except (NotImplementedError, OSError):
+            alias.write_text("SECRET=value\n", encoding="utf-8")
+            original_resolve = Path.resolve
+
+            def resolve_alias(self, strict=False):
+                if self == alias:
+                    return target
+                return original_resolve(self, strict=strict)
+
+            monkeypatch.setattr(Path, "resolve", resolve_alias)
+        patch = "@@ -1 +1 @@\n-SECRET=value\n+SECRET=changed\n"
+
+        result = ApplyPatchTool().execute(
+            path=str(alias),
+            patch=patch,
+            backup=False,
+        )
+
+        assert result.success is False
+        assert "sensitive" in result.content.lower()
+        assert target.read_text(encoding="utf-8") == "SECRET=value\n"
+        assert alias.read_text(encoding="utf-8") == "SECRET=value\n"
 
     def test_auto_detect_path_from_patch_header(self, tmp_path):
         f = tmp_path / "auto.txt"

--- a/tests/tools/test_file_read.py
+++ b/tests/tools/test_file_read.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from openjarvis.tools.file_read import FileReadTool
 
 
@@ -84,6 +86,30 @@ class TestFileReadTool:
         f.write_text('{"token": "abc"}', encoding="utf-8")
         tool = FileReadTool()
         result = tool.execute(path=str(f))
+        assert result.success is False
+        assert "sensitive" in result.content.lower()
+
+    def test_blocks_sensitive_target_through_safe_named_alias(
+        self, tmp_path, monkeypatch
+    ):
+        target = tmp_path / ".env"
+        target.write_text("SECRET=value", encoding="utf-8")
+        alias = tmp_path / "notes.txt"
+        try:
+            alias.symlink_to(target)
+        except (NotImplementedError, OSError):
+            alias.write_text("alias content", encoding="utf-8")
+            original_resolve = Path.resolve
+
+            def resolve_alias(self, strict=False):
+                if self == alias:
+                    return target
+                return original_resolve(self, strict=strict)
+
+            monkeypatch.setattr(Path, "resolve", resolve_alias)
+
+        result = FileReadTool().execute(path=str(alias))
+
         assert result.success is False
         assert "sensitive" in result.content.lower()
 

--- a/tests/tools/test_file_write.py
+++ b/tests/tools/test_file_write.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from openjarvis.tools.file_write import FileWriteTool
 
 
@@ -82,6 +84,33 @@ class TestFileWriteTool:
         result = tool.execute(path=str(f), content='{"token": "abc"}')
         assert result.success is False
         assert "sensitive" in result.content.lower()
+
+    def test_blocks_sensitive_target_through_safe_named_alias(
+        self, tmp_path, monkeypatch
+    ):
+        target = tmp_path / ".env"
+        target.write_text("SECRET=value", encoding="utf-8")
+        alias = tmp_path / "notes.txt"
+        try:
+            alias.symlink_to(target)
+        except (NotImplementedError, OSError):
+            alias.write_text("alias content", encoding="utf-8")
+            original_resolve = Path.resolve
+
+            def resolve_alias(self, strict=False):
+                if self == alias:
+                    return target
+                return original_resolve(self, strict=strict)
+
+            monkeypatch.setattr(Path, "resolve", resolve_alias)
+        alias_before = alias.read_text(encoding="utf-8")
+
+        result = FileWriteTool().execute(path=str(alias), content="replacement")
+
+        assert result.success is False
+        assert "sensitive" in result.content.lower()
+        assert target.read_text(encoding="utf-8") == "SECRET=value"
+        assert alias.read_text(encoding="utf-8") == alias_before
 
     def test_allowed_dirs_blocks(self, tmp_path):
         f = tmp_path / "test.txt"


### PR DESCRIPTION
## Summary

- evaluate both lexical paths and resolved targets in the sensitive-file policy
- fail closed when a target cannot be resolved safely while permitting missing write leaves
- make Python and Rust matching case-insensitive and restore `*.env` backend parity
- cover Python read, write, and patch tools plus Rust-native read/write consumers

## Root cause

The policy checked only the submitted filename. A safe-looking symlink such as `notes.txt` could therefore point at `.env`, and case variants behaved differently across platforms. The Rust matcher also omitted the Python catalog's `*.env` rule.

## Impact

Stable symlink aliases and case variants can no longer bypass sensitive-file restrictions through either the Python or Rust-native tool paths. Public APIs and dependency sets remain unchanged.

## Validation

- 121 focused Python tests passed
- standalone changed Rust policy compiled under `-D warnings`; 3 tests passed
- Ruff and rustfmt checks passed
- Unix-only Rust integration tests cover native read/write denial and target preservation
- independent re-review found no Critical, Important, or Minor issues

Full Cargo workspace checking was unavailable on the Windows development host because it lacks a functioning native linker; the Unix-only native integration test is expected to run in CI.
