### PR TITLE
fix(cli): preserve environment during self-update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ learning.db
 minion_logs/
 *.oj-debug.json
 oj-debug.*.json
+
+# Local editable-install feature profile (written by official installers)
+/.openjarvis-install-profile.json

--- a/deploy/windows/install.ps1
+++ b/deploy/windows/install.ps1
@@ -289,6 +289,11 @@ try {
     if ($LASTEXITCODE -ne 0) {
         Write-Fail "uv sync failed with exit code $LASTEXITCODE. Check the output above."
     }
+    & $uvExe run --no-sync python -m openjarvis.cli._install_profile record `
+        --extra desktop --group desktop-native
+    if ($LASTEXITCODE -ne 0) {
+        Write-Fail "Failed to record the editable install profile."
+    }
 } finally {
     Pop-Location
 }

--- a/docs/user-guide/cli.md
+++ b/docs/user-guide/cli.md
@@ -9,6 +9,27 @@ jarvis --version   # Print the OpenJarvis version
 jarvis --help      # Show top-level help with all subcommands
 ```
 
+## `jarvis self-update`
+
+Upgrade OpenJarvis using the active installation method:
+
+```bash
+jarvis self-update --check  # Preview the detected command
+jarvis self-update          # Confirm, then update
+jarvis self-update --yes    # Update without prompting
+```
+
+PyPI and `uv tool` installs use their normal upgrade commands. Editable Git
+installs pull the checkout with a fast-forward-only update, then update the
+environment that is currently running OpenJarvis.
+
+Official project-local installers record their uv extras and dependency groups
+in a local, ignored install-profile file. Self-update reuses that exact feature
+set. If an older project-local checkout has no valid profile, self-update uses
+`uv sync --inexact` and prints a warning so optional packages are preserved.
+Editable installs in an external virtual environment are refreshed with
+`uv pip install --python <active-python> -e <checkout>`.
+
 ## `jarvis init`
 
 Detect local hardware (CPU, GPU, RAM) and generate a configuration file at `~/.openjarvis/config.toml`.

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -148,15 +148,11 @@ fi
 
 # ── 7. Install Python dependencies ──────────────────────────────────
 info "Installing Python dependencies..."
-uv sync --extra desktop --extra tools-search --quiet 2>/dev/null \
-  || uv sync --extra desktop --extra tools-search
+uv sync --extra desktop --extra tools-search --group desktop-native --quiet 2>/dev/null \
+  || uv sync --extra desktop --extra tools-search --group desktop-native
+uv run --no-sync python -m openjarvis.cli._install_profile record \
+  --extra desktop --extra tools-search --group desktop-native
 ok "Python dependencies installed"
-
-# ── 7b. Build Rust extension ──────────────────────────────────────
-info "Building Rust extension..."
-uv run maturin develop -m rust/crates/openjarvis-python/Cargo.toml --quiet 2>/dev/null \
-  || uv run maturin develop -m rust/crates/openjarvis-python/Cargo.toml
-ok "Rust extension built"
 
 # ── 8. Install frontend dependencies ────────────────────────────────
 info "Installing frontend dependencies..."

--- a/src/openjarvis/cli/_install_detect.py
+++ b/src/openjarvis/cli/_install_detect.py
@@ -10,8 +10,8 @@ Three install paths are supported today:
   ``uv tool upgrade openjarvis``.
 - **Editable git checkout** (``uv sync`` / ``pip install -e .`` from a
   cloned repo). The package's ``__file__`` is inside a working tree
-  with a ``.git`` directory at the repo root. Upgrade with
-  ``git pull && uv sync`` from the checkout.
+  with a ``.git`` directory at the repo root. Pull the checkout, then
+  sync its project venv or reinstall into the active external venv.
 
 We detect by inspecting ``openjarvis.__file__``. If we can't tell with
 confidence we fall back to the PyPI command — that's the most common
@@ -21,9 +21,17 @@ pull from PyPI.
 
 from __future__ import annotations
 
+import shlex
+import subprocess
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
+
+from openjarvis.cli._install_profile import (
+    load_install_profile,
+    profile_sync_args,
+)
 
 
 @dataclass(frozen=True)
@@ -33,6 +41,69 @@ class InstallInfo:
     kind: str  # "pypi" | "uv-tool" | "editable-git" | "unknown"
     upgrade_command: str
     repo_root: Optional[Path] = None  # only set for editable-git
+    editable_mode: Optional[str] = None  # "project-venv" | "external-venv"
+    sync_args: tuple[str, ...] = ()
+    python_executable: Optional[Path] = None
+    warning: Optional[str] = None
+
+
+def _display_command(argv: list[str]) -> str:
+    """Format trusted argv for display only; execution never parses this text."""
+    if sys.platform == "win32":
+        return subprocess.list2cmdline(argv)
+    return shlex.join(argv)
+
+
+def _editable_install_info(repo_root: Path) -> InstallInfo:
+    git_argv = ["git", "-C", str(repo_root), "pull", "--ff-only"]
+    project_venv = (repo_root / ".venv").resolve()
+
+    if Path(sys.prefix).resolve() == project_venv:
+        profile, profile_warning = load_install_profile(repo_root)
+        if profile is None:
+            sync_args = ("--inexact",)
+            preservation_warning = (
+                "No valid install profile was found. Optional dependencies will "
+                "be preserved with `uv sync --inexact`; re-run the official "
+                "installer to record an exact profile."
+            )
+            warning = (
+                f"{profile_warning}\n{preservation_warning}"
+                if profile_warning
+                else preservation_warning
+            )
+        else:
+            sync_args = profile_sync_args(profile)
+            warning = None
+        uv_argv = ["uv", "sync", *sync_args]
+        return InstallInfo(
+            kind="editable-git",
+            upgrade_command=(
+                f"{_display_command(git_argv)} && {_display_command(uv_argv)}"
+            ),
+            repo_root=repo_root,
+            editable_mode="project-venv",
+            sync_args=sync_args,
+            warning=warning,
+        )
+
+    python_executable = Path(sys.executable)
+    uv_argv = [
+        "uv",
+        "pip",
+        "install",
+        "--python",
+        str(python_executable),
+        "-e",
+        str(repo_root),
+    ]
+    return InstallInfo(
+        kind="editable-git",
+        upgrade_command=f"{_display_command(git_argv)} && {_display_command(uv_argv)}",
+        repo_root=repo_root,
+        editable_mode="external-venv",
+        python_executable=python_executable,
+    )
 
 
 def detect_install() -> InstallInfo:
@@ -66,11 +137,7 @@ def detect_install() -> InstallInfo:
     candidate = pkg_file.parent
     for _ in range(8):
         if (candidate / ".git").exists() and (candidate / "pyproject.toml").exists():
-            return InstallInfo(
-                kind="editable-git",
-                upgrade_command=f"cd {candidate} && git pull && uv sync",
-                repo_root=candidate,
-            )
+            return _editable_install_info(candidate)
         if candidate.parent == candidate:
             break
         candidate = candidate.parent

--- a/src/openjarvis/cli/_install_profile.py
+++ b/src/openjarvis/cli/_install_profile.py
@@ -1,0 +1,149 @@
+"""Persist optional uv features used by editable OpenJarvis installs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import tempfile
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+PROFILE_FILENAME = ".openjarvis-install-profile.json"
+PROFILE_VERSION = 1
+
+_OPTION_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+
+@dataclass(frozen=True)
+class InstallProfile:
+    """The uv feature set selected by a project-local installer."""
+
+    version: int
+    extras: tuple[str, ...]
+    groups: tuple[str, ...]
+
+
+def _normalize_options(options: Sequence[str]) -> tuple[str, ...]:
+    normalized: set[str] = set()
+    for option in options:
+        if not isinstance(option, str) or _OPTION_PATTERN.fullmatch(option) is None:
+            raise ValueError(f"invalid install profile option: {option!r}")
+        normalized.add(option)
+    return tuple(sorted(normalized))
+
+
+def load_install_profile(
+    repo_root: Path,
+) -> tuple[InstallProfile | None, str | None]:
+    """Load a validated profile, returning a user-facing warning on failure."""
+    path = Path(repo_root) / PROFILE_FILENAME
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return None, None
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        return None, f"Invalid install profile at {path}: {exc}"
+
+    if not isinstance(raw, dict):
+        return None, f"Invalid install profile at {path}: expected an object"
+
+    version = raw.get("version")
+    if type(version) is not int or version != PROFILE_VERSION:
+        return None, f"Unsupported install profile version at {path}: {version!r}"
+
+    extras = raw.get("extras")
+    groups = raw.get("groups")
+    if not isinstance(extras, list) or not isinstance(groups, list):
+        return None, f"Invalid install profile at {path}: extras/groups must be lists"
+
+    try:
+        profile = InstallProfile(
+            version=version,
+            extras=_normalize_options(extras),
+            groups=_normalize_options(groups),
+        )
+    except ValueError as exc:
+        return None, f"Invalid install profile at {path}: {exc}"
+    return profile, None
+
+
+def write_install_profile(
+    repo_root: Path,
+    *,
+    extras: Sequence[str],
+    groups: Sequence[str],
+) -> Path:
+    """Atomically write a validated version-1 profile in ``repo_root``."""
+    root = Path(repo_root)
+    profile = InstallProfile(
+        version=PROFILE_VERSION,
+        extras=_normalize_options(extras),
+        groups=_normalize_options(groups),
+    )
+    payload = {
+        "version": profile.version,
+        "extras": list(profile.extras),
+        "groups": list(profile.groups),
+    }
+    path = root / PROFILE_FILENAME
+
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=root,
+            prefix=f"{PROFILE_FILENAME}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temporary:
+            json.dump(payload, temporary, indent=2)
+            temporary.write("\n")
+            temporary.flush()
+            os.fsync(temporary.fileno())
+            temporary_path = Path(temporary.name)
+        temporary_path.replace(path)
+    finally:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)
+    return path
+
+
+def profile_sync_args(profile: InstallProfile) -> tuple[str, ...]:
+    """Build the uv flags needed to reproduce ``profile`` exactly."""
+    args: list[str] = []
+    for extra in profile.extras:
+        args.extend(("--extra", extra))
+    for group in profile.groups:
+        args.extend(("--group", group))
+    return tuple(args)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    record = commands.add_parser("record", help="record the current uv features")
+    record.add_argument("--repo-root", type=Path, default=Path.cwd())
+    record.add_argument("--extra", action="append", default=[])
+    record.add_argument("--group", action="append", default=[])
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the private installer-profile command-line interface."""
+    args = _parser().parse_args(argv)
+    if args.command == "record":
+        path = write_install_profile(
+            args.repo_root,
+            extras=args.extra,
+            groups=args.group,
+        )
+        print(f"Recorded OpenJarvis install profile: {path}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised through ``main``
+    raise SystemExit(main())

--- a/src/openjarvis/cli/self_update_cmd.py
+++ b/src/openjarvis/cli/self_update_cmd.py
@@ -4,7 +4,7 @@ Runs the right upgrade command for how the user installed OpenJarvis:
 
 - PyPI installs get ``pip install --upgrade openjarvis``.
 - uv-tool installs get ``uv tool upgrade openjarvis``.
-- Editable git checkouts get ``git pull && uv sync`` in the checkout.
+- Editable git checkouts pull, then update the environment currently in use.
 
 The detection logic is shared with the post-command "new version
 available" hint in ``_version_check.py`` so both surfaces stay in sync.
@@ -12,14 +12,62 @@ available" hint in ``_version_check.py`` so both surfaces stay in sync.
 
 from __future__ import annotations
 
-import shlex
 import subprocess
 import sys
 
 import click
 
 import openjarvis
-from openjarvis.cli._install_detect import detect_install
+from openjarvis.cli._install_detect import InstallInfo, detect_install
+
+_TRUSTED_UPGRADE_ARGV: dict[str, tuple[str, ...]] = {
+    "pypi": ("pip", "install", "--upgrade", "openjarvis"),
+    "uv-tool": ("uv", "tool", "upgrade", "openjarvis"),
+    "unknown": ("pip", "install", "--upgrade", "openjarvis"),
+}
+
+
+def _run_editable_update(info: InstallInfo) -> int:
+    """Update an editable checkout and its active Python environment."""
+    if info.repo_root is None:
+        raise ValueError("editable install is missing its repository root")
+
+    git_result = subprocess.run(["git", "-C", str(info.repo_root), "pull", "--ff-only"])
+    if git_result.returncode != 0:
+        return git_result.returncode
+
+    if info.editable_mode == "project-venv":
+        uv_argv = ["uv", "sync", *info.sync_args]
+    elif info.editable_mode == "external-venv":
+        if info.python_executable is None:
+            raise ValueError("external editable install is missing its Python path")
+        uv_argv = [
+            "uv",
+            "pip",
+            "install",
+            "--python",
+            str(info.python_executable),
+            "-e",
+            str(info.repo_root),
+        ]
+    else:
+        raise ValueError(f"unknown editable install mode: {info.editable_mode!r}")
+
+    return subprocess.run(uv_argv, cwd=info.repo_root).returncode
+
+
+def _run_packaged_update(info: InstallInfo) -> int:
+    """Run trusted argv for a non-editable install.
+
+    ``upgrade_command`` is deliberately presentation-only: it may contain
+    quoting intended for a shell or terminal and must never become execution
+    input.
+    """
+    try:
+        argv = _TRUSTED_UPGRADE_ARGV[info.kind]
+    except KeyError as exc:
+        raise ValueError(f"unknown packaged install kind: {info.kind!r}") from exc
+    return subprocess.run(list(argv)).returncode
 
 
 @click.command(
@@ -50,6 +98,9 @@ def self_update(check: bool, yes: bool) -> None:
     click.echo(f"Install method: {info.kind}")
     click.echo(f"Upgrade command: {info.upgrade_command}")
 
+    if info.warning:
+        click.echo(f"\nWarning: {info.warning}", err=True)
+
     if check:
         return
 
@@ -68,22 +119,17 @@ def self_update(check: bool, yes: bool) -> None:
 
     click.echo(f"\n→ {info.upgrade_command}\n")
 
-    # ``editable-git`` uses shell features (``&&``); the others are
-    # simple argv-style commands. Use ``shell=True`` only for the
-    # editable case to keep the surface small. The command itself is
-    # constructed from a trusted, locally-detected path — no user
-    # input flows into it.
     if info.kind == "editable-git":
-        result = subprocess.run(info.upgrade_command, shell=True)
+        returncode = _run_editable_update(info)
     else:
-        result = subprocess.run(shlex.split(info.upgrade_command))
+        returncode = _run_packaged_update(info)
 
-    if result.returncode != 0:
+    if returncode != 0:
         click.echo(
-            f"\nUpgrade command exited with code {result.returncode}. "
+            f"\nUpgrade command exited with code {returncode}. "
             "Inspect the output above for the failure mode.",
             err=True,
         )
-        sys.exit(result.returncode)
+        sys.exit(returncode)
 
     click.echo("\nUpgrade complete. Re-run `jarvis --version` to confirm.")

--- a/tests/cli/test_install_detect.py
+++ b/tests/cli/test_install_detect.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
 from openjarvis.cli._install_detect import InstallInfo, detect_install
+from openjarvis.cli._install_profile import write_install_profile
 
 
 def _patch_pkg_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
@@ -31,12 +33,70 @@ def test_editable_git_install_detected(tmp_path, monkeypatch):
     (repo / "pyproject.toml").write_text("[project]\nname='openjarvis'\n")
     src = repo / "src"
     _patch_pkg_file(src, monkeypatch)
+    monkeypatch.setattr(sys, "prefix", str(repo / ".venv"))
 
     info = detect_install()
     assert info.kind == "editable-git"
-    assert "git pull" in info.upgrade_command
+    assert "pull --ff-only" in info.upgrade_command
     assert "uv sync" in info.upgrade_command
     assert info.repo_root == repo
+    assert info.editable_mode == "project-venv"
+
+
+def test_project_venv_uses_recorded_profile(tmp_path, monkeypatch):
+    repo = tmp_path / "repo with spaces"
+    (repo / ".git").mkdir(parents=True)
+    (repo / "pyproject.toml").write_text("[project]\nname='openjarvis'\n")
+    _patch_pkg_file(repo / "src", monkeypatch)
+    write_install_profile(
+        repo,
+        extras=["desktop"],
+        groups=["desktop-native"],
+    )
+    monkeypatch.setattr(sys, "prefix", str(repo / ".venv"))
+
+    info = detect_install()
+
+    assert info.editable_mode == "project-venv"
+    assert info.sync_args == (
+        "--extra",
+        "desktop",
+        "--group",
+        "desktop-native",
+    )
+    assert info.warning is None
+
+
+def test_project_venv_without_profile_preserves_packages(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    (repo / ".git").mkdir(parents=True)
+    (repo / "pyproject.toml").write_text("[project]\nname='openjarvis'\n")
+    _patch_pkg_file(repo / "src", monkeypatch)
+    monkeypatch.setattr(sys, "prefix", str(repo / ".venv"))
+
+    info = detect_install()
+
+    assert info.editable_mode == "project-venv"
+    assert info.sync_args == ("--inexact",)
+    assert "optional dependencies" in (info.warning or "").lower()
+
+
+def test_external_venv_targets_running_python(tmp_path, monkeypatch):
+    repo = tmp_path / "repo with spaces"
+    (repo / ".git").mkdir(parents=True)
+    (repo / "pyproject.toml").write_text("[project]\nname='openjarvis'\n")
+    _patch_pkg_file(repo / "src", monkeypatch)
+    external = tmp_path / "installed env"
+    executable = external / "Scripts" / "python.exe"
+    monkeypatch.setattr(sys, "prefix", str(external))
+    monkeypatch.setattr(sys, "executable", str(executable))
+
+    info = detect_install()
+
+    assert info.editable_mode == "external-venv"
+    assert info.python_executable == executable
+    assert "uv pip install" in info.upgrade_command
+    assert '"' in info.upgrade_command
 
 
 def test_uv_tool_install_detected(tmp_path, monkeypatch):

--- a/tests/cli/test_install_profile.py
+++ b/tests/cli/test_install_profile.py
@@ -1,0 +1,134 @@
+"""Tests for editable-install profile persistence."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from openjarvis.cli._install_profile import (
+    PROFILE_FILENAME,
+    InstallProfile,
+    load_install_profile,
+    main,
+    profile_sync_args,
+    write_install_profile,
+)
+
+
+def test_profile_round_trips_sorted_unique_options(tmp_path: Path) -> None:
+    path = write_install_profile(
+        tmp_path,
+        extras=["tools-search", "desktop", "desktop"],
+        groups=["desktop-native"],
+    )
+
+    profile, warning = load_install_profile(tmp_path)
+
+    assert path == tmp_path / PROFILE_FILENAME
+    assert warning is None
+    assert profile == InstallProfile(
+        version=1,
+        extras=("desktop", "tools-search"),
+        groups=("desktop-native",),
+    )
+    assert profile_sync_args(profile) == (
+        "--extra",
+        "desktop",
+        "--extra",
+        "tools-search",
+        "--group",
+        "desktop-native",
+    )
+
+
+@pytest.mark.parametrize("name", ["--all-extras", "bad name", "", "../dev"])
+def test_profile_rejects_option_injection(tmp_path: Path, name: str) -> None:
+    with pytest.raises(ValueError, match="invalid install profile option"):
+        write_install_profile(tmp_path, extras=[name], groups=[])
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        ({"version": 2, "extras": [], "groups": []}, "unsupported"),
+        ({"version": 1, "extras": "desktop", "groups": []}, "invalid"),
+        ({"version": 1, "extras": ["--all-extras"], "groups": []}, "invalid"),
+    ],
+)
+def test_invalid_profile_returns_warning(
+    tmp_path: Path,
+    payload: dict[str, object],
+    message: str,
+) -> None:
+    (tmp_path / PROFILE_FILENAME).write_text(json.dumps(payload), encoding="utf-8")
+
+    profile, warning = load_install_profile(tmp_path)
+
+    assert profile is None
+    assert message in (warning or "").lower()
+
+
+def test_malformed_profile_returns_warning(tmp_path: Path) -> None:
+    (tmp_path / PROFILE_FILENAME).write_text("{", encoding="utf-8")
+
+    profile, warning = load_install_profile(tmp_path)
+
+    assert profile is None
+    assert "invalid" in (warning or "").lower()
+
+
+def test_non_utf8_profile_returns_warning(tmp_path: Path) -> None:
+    (tmp_path / PROFILE_FILENAME).write_bytes(b"\xff")
+
+    profile, warning = load_install_profile(tmp_path)
+
+    assert profile is None
+    assert "invalid" in (warning or "").lower()
+
+
+def test_missing_profile_is_not_an_error(tmp_path: Path) -> None:
+    assert load_install_profile(tmp_path) == (None, None)
+
+
+@pytest.mark.parametrize(
+    ("args", "expected"),
+    [
+        (
+            ["--extra", "desktop", "--group", "desktop-native"],
+            {
+                "version": 1,
+                "extras": ["desktop"],
+                "groups": ["desktop-native"],
+            },
+        ),
+        (
+            [
+                "--extra",
+                "desktop",
+                "--extra",
+                "tools-search",
+                "--group",
+                "desktop-native",
+            ],
+            {
+                "version": 1,
+                "extras": ["desktop", "tools-search"],
+                "groups": ["desktop-native"],
+            },
+        ),
+    ],
+)
+def test_record_cli_writes_official_installer_profiles(
+    tmp_path: Path,
+    args: list[str],
+    expected: dict[str, object],
+) -> None:
+    exit_code = main(["record", "--repo-root", str(tmp_path), *args])
+
+    assert exit_code == 0
+    assert (
+        json.loads((tmp_path / PROFILE_FILENAME).read_text(encoding="utf-8"))
+        == expected
+    )

--- a/tests/cli/test_self_update.py
+++ b/tests/cli/test_self_update.py
@@ -7,6 +7,8 @@ unit test; the subprocess call is mocked.
 
 from __future__ import annotations
 
+from dataclasses import replace
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner
@@ -16,7 +18,7 @@ from openjarvis.cli.self_update_cmd import self_update
 
 
 def _mock_info(kind: str = "pypi") -> InstallInfo:
-    return InstallInfo(
+    info = InstallInfo(
         kind=kind,
         upgrade_command={
             "pypi": "pip install --upgrade openjarvis",
@@ -25,6 +27,15 @@ def _mock_info(kind: str = "pypi") -> InstallInfo:
             "unknown": "pip install --upgrade openjarvis",
         }[kind],
     )
+    if kind == "editable-git":
+        return InstallInfo(
+            kind=info.kind,
+            upgrade_command=info.upgrade_command,
+            repo_root=Path("/tmp/repo"),
+            editable_mode="project-venv",
+            sync_args=("--inexact",),
+        )
+    return info
 
 
 def test_check_flag_prints_command_and_exits_clean():
@@ -51,12 +62,16 @@ def test_check_does_not_invoke_subprocess():
     mock_run.assert_not_called()
 
 
-def test_yes_skips_confirmation_and_runs():
+def test_yes_skips_confirmation_and_runs_trusted_argv():
+    info = replace(
+        _mock_info("pypi"),
+        upgrade_command="display text that must never be executed",
+    )
     mock_proc = MagicMock(returncode=0)
     with (
         patch(
             "openjarvis.cli.self_update_cmd.detect_install",
-            return_value=_mock_info("pypi"),
+            return_value=info,
         ),
         patch(
             "openjarvis.cli.self_update_cmd.subprocess.run",
@@ -66,28 +81,140 @@ def test_yes_skips_confirmation_and_runs():
         result = CliRunner().invoke(self_update, ["-y"])
     assert result.exit_code == 0
     mock_run.assert_called_once()
-    # PyPI path uses shlex.split (no shell=True)
     args, kwargs = mock_run.call_args
     assert kwargs.get("shell") is not True
     assert args[0] == ["pip", "install", "--upgrade", "openjarvis"]
 
 
-def test_editable_git_uses_shell_true():
-    """The git path uses `&&` so shell=True is needed; the others don't."""
-    mock_proc = MagicMock(returncode=0)
+def test_uv_tool_update_runs_trusted_argv():
+    info = replace(
+        _mock_info("uv-tool"),
+        upgrade_command="display text that must never be executed",
+    )
     with (
         patch(
             "openjarvis.cli.self_update_cmd.detect_install",
-            return_value=_mock_info("editable-git"),
+            return_value=info,
         ),
         patch(
             "openjarvis.cli.self_update_cmd.subprocess.run",
-            return_value=mock_proc,
+            return_value=MagicMock(returncode=0),
         ) as mock_run,
     ):
-        CliRunner().invoke(self_update, ["-y"])
-    _, kwargs = mock_run.call_args
-    assert kwargs.get("shell") is True
+        result = CliRunner().invoke(self_update, ["-y"])
+
+    assert result.exit_code == 0
+    mock_run.assert_called_once_with(["uv", "tool", "upgrade", "openjarvis"])
+
+
+def test_project_venv_runs_git_then_profiled_sync(tmp_path):
+    info = InstallInfo(
+        kind="editable-git",
+        upgrade_command="preview only",
+        repo_root=tmp_path / "repo with spaces",
+        editable_mode="project-venv",
+        sync_args=("--extra", "desktop", "--group", "desktop-native"),
+    )
+    with (
+        patch(
+            "openjarvis.cli.self_update_cmd.detect_install",
+            return_value=info,
+        ),
+        patch(
+            "openjarvis.cli.self_update_cmd.subprocess.run",
+            side_effect=[MagicMock(returncode=0), MagicMock(returncode=0)],
+        ) as mock_run,
+    ):
+        result = CliRunner().invoke(self_update, ["-y"])
+
+    assert result.exit_code == 0
+    assert [call.args[0] for call in mock_run.call_args_list] == [
+        ["git", "-C", str(info.repo_root), "pull", "--ff-only"],
+        [
+            "uv",
+            "sync",
+            "--extra",
+            "desktop",
+            "--group",
+            "desktop-native",
+        ],
+    ]
+    assert mock_run.call_args_list[1].kwargs["cwd"] == info.repo_root
+    assert all(call.kwargs.get("shell") is not True for call in mock_run.call_args_list)
+
+
+def test_external_venv_reinstalls_into_running_python(tmp_path):
+    repo = tmp_path / "repo with spaces"
+    python = tmp_path / "installed env" / "Scripts" / "python.exe"
+    info = InstallInfo(
+        kind="editable-git",
+        upgrade_command="preview only",
+        repo_root=repo,
+        editable_mode="external-venv",
+        python_executable=python,
+    )
+    with (
+        patch(
+            "openjarvis.cli.self_update_cmd.detect_install",
+            return_value=info,
+        ),
+        patch(
+            "openjarvis.cli.self_update_cmd.subprocess.run",
+            side_effect=[MagicMock(returncode=0), MagicMock(returncode=0)],
+        ) as mock_run,
+    ):
+        result = CliRunner().invoke(self_update, ["-y"])
+
+    assert result.exit_code == 0
+    assert mock_run.call_args_list[1].args[0] == [
+        "uv",
+        "pip",
+        "install",
+        "--python",
+        str(python),
+        "-e",
+        str(repo),
+    ]
+    assert mock_run.call_args_list[1].kwargs["cwd"] == repo
+
+
+def test_git_failure_does_not_run_uv(tmp_path):
+    info = InstallInfo(
+        kind="editable-git",
+        upgrade_command="preview only",
+        repo_root=tmp_path,
+        editable_mode="project-venv",
+        sync_args=("--inexact",),
+    )
+    with (
+        patch(
+            "openjarvis.cli.self_update_cmd.detect_install",
+            return_value=info,
+        ),
+        patch(
+            "openjarvis.cli.self_update_cmd.subprocess.run",
+            return_value=MagicMock(returncode=7),
+        ) as mock_run,
+    ):
+        result = CliRunner().invoke(self_update, ["-y"])
+
+    assert result.exit_code == 7
+    assert mock_run.call_count == 1
+
+
+def test_install_profile_warning_is_printed():
+    info = replace(
+        _mock_info("editable-git"),
+        warning="Optional dependencies will be preserved.",
+    )
+    with patch(
+        "openjarvis.cli.self_update_cmd.detect_install",
+        return_value=info,
+    ):
+        result = CliRunner().invoke(self_update, ["--check"])
+
+    assert result.exit_code == 0
+    assert "Optional dependencies will be preserved" in result.output
 
 
 def test_failed_upgrade_propagates_exit_code():

--- a/tests/deployment/test_packaging.py
+++ b/tests/deployment/test_packaging.py
@@ -63,6 +63,17 @@ def test_windows_installer_syncs_the_native_group() -> None:
 
 
 def test_quickstart_installs_web_search_dependencies() -> None:
-    quickstart = QUICKSTART_SH.read_text()
+    quickstart = QUICKSTART_SH.read_text(encoding="utf-8")
     assert "--extra tools-search" in quickstart
     assert "already running on port 8000" in quickstart
+
+
+def test_quickstart_records_native_extension_in_install_profile() -> None:
+    quickstart = QUICKSTART_SH.read_text(encoding="utf-8")
+    assert quickstart.count("--group desktop-native") >= 2, (
+        "quickstart must select and record desktop-native so exact self-updates "
+        "retain openjarvis-rust"
+    )
+    assert "maturin develop" not in quickstart, (
+        "desktop-native should build the extension without a redundant second build"
+    )


### PR DESCRIPTION
Closes #712.

## Summary

- persist the extras and dependency groups selected by official editable installers
- reproduce that profile during project-venv self-updates and preserve packages when no valid profile exists
- reinstall external editable environments into their active Python interpreter
- execute packaged updates from trusted argv instead of parsing display text
- stop before dependency changes when `git pull --ff-only` fails

## Root cause

Editable installs were treated as one generic case. Self-update ran an exact `uv sync` without knowing which optional features the installer selected, so valid packages could be removed. The command also did not distinguish the repository's own `.venv` from an external editable environment.

## Impact

Official Windows and quickstart installations record a small validated profile that future updates reproduce. Existing checkouts without a profile use `uv sync --inexact` with a warning, avoiding destructive package pruning. PyPI and uv-tool display strings are now presentation-only and never become execution input.

## Validation

- 40 focused CLI, profile, and packaging tests passed
- Ruff check and format check passed
- Git Bash syntax validation passed for `scripts/quickstart.sh`
- PowerShell AST validation passed for `deploy/windows/install.ps1`
- independent re-review found no Critical, Important, or Minor issues
