### PR TITLE
fix(cli): preserve extras during self-update

### DIFF
--- a/src/openjarvis/cli/_install_detect.py
+++ b/src/openjarvis/cli/_install_detect.py
@@ -70,9 +70,7 @@ def detect_install() -> InstallInfo:
         if (candidate / ".git").exists() and (candidate / "pyproject.toml").exists():
             return InstallInfo(
                 kind="editable-git",
-                upgrade_command=(
-                    f"cd {candidate} && git pull && uv sync --inexact"
-                ),
+                upgrade_command=(f"cd {candidate} && git pull && uv sync --inexact"),
                 repo_root=candidate,
             )
         if candidate.parent == candidate:

--- a/src/openjarvis/cli/_install_detect.py
+++ b/src/openjarvis/cli/_install_detect.py
@@ -11,7 +11,9 @@ Three install paths are supported today:
 - **Editable git checkout** (``uv sync`` / ``pip install -e .`` from a
   cloned repo). The package's ``__file__`` is inside a working tree
   with a ``.git`` directory at the repo root. Upgrade with
-  ``git pull && uv sync`` from the checkout.
+  ``git pull && uv sync --inexact`` from the checkout. ``--inexact`` is
+  important here: a bare ``uv sync`` removes packages installed by extras or
+  dependency groups that are not part of the base project.
 
 We detect by inspecting ``openjarvis.__file__``. If we can't tell with
 confidence we fall back to the PyPI command — that's the most common
@@ -68,7 +70,9 @@ def detect_install() -> InstallInfo:
         if (candidate / ".git").exists() and (candidate / "pyproject.toml").exists():
             return InstallInfo(
                 kind="editable-git",
-                upgrade_command=f"cd {candidate} && git pull && uv sync",
+                upgrade_command=(
+                    f"cd {candidate} && git pull && uv sync --inexact"
+                ),
                 repo_root=candidate,
             )
         if candidate.parent == candidate:

--- a/src/openjarvis/cli/self_update_cmd.py
+++ b/src/openjarvis/cli/self_update_cmd.py
@@ -4,7 +4,9 @@ Runs the right upgrade command for how the user installed OpenJarvis:
 
 - PyPI installs get ``pip install --upgrade openjarvis``.
 - uv-tool installs get ``uv tool upgrade openjarvis``.
-- Editable git checkouts get ``git pull && uv sync`` in the checkout.
+- Editable git checkouts get ``git pull && uv sync --inexact`` in the checkout.
+  The inexact sync preserves packages previously installed through extras and
+  dependency groups.
 
 The detection logic is shared with the post-command "new version
 available" hint in ``_version_check.py`` so both surfaces stay in sync.

--- a/tests/cli/test_install_detect.py
+++ b/tests/cli/test_install_detect.py
@@ -35,7 +35,7 @@ def test_editable_git_install_detected(tmp_path, monkeypatch):
     info = detect_install()
     assert info.kind == "editable-git"
     assert "git pull" in info.upgrade_command
-    assert "uv sync" in info.upgrade_command
+    assert info.upgrade_command.endswith("uv sync --inexact")
     assert info.repo_root == repo
 
 

--- a/tests/cli/test_self_update.py
+++ b/tests/cli/test_self_update.py
@@ -21,7 +21,7 @@ def _mock_info(kind: str = "pypi") -> InstallInfo:
         upgrade_command={
             "pypi": "pip install --upgrade openjarvis",
             "uv-tool": "uv tool upgrade openjarvis",
-            "editable-git": "cd /tmp/repo && git pull && uv sync",
+            "editable-git": "cd /tmp/repo && git pull && uv sync --inexact",
             "unknown": "pip install --upgrade openjarvis",
         }[kind],
     )
@@ -88,6 +88,26 @@ def test_editable_git_uses_shell_true():
         CliRunner().invoke(self_update, ["-y"])
     _, kwargs = mock_run.call_args
     assert kwargs.get("shell") is True
+
+
+def test_editable_git_preserves_extra_dependencies():
+    """The update sync must not remove packages from prior extras/groups."""
+    mock_proc = MagicMock(returncode=0)
+    with (
+        patch(
+            "openjarvis.cli.self_update_cmd.detect_install",
+            return_value=_mock_info("editable-git"),
+        ),
+        patch(
+            "openjarvis.cli.self_update_cmd.subprocess.run",
+            return_value=mock_proc,
+        ) as mock_run,
+    ):
+        result = CliRunner().invoke(self_update, ["-y"])
+
+    assert result.exit_code == 0
+    assert "uv sync --inexact" in result.output
+    assert "uv sync --inexact" in mock_run.call_args.args[0]
 
 
 def test_failed_upgrade_propagates_exit_code():


### PR DESCRIPTION
## Summary

- use `uv sync --inexact` for editable-git self-updates
- preserve packages previously installed through extras and dependency groups
- add regression coverage for the generated and executed update command

Closes #712.

## Testing

- `.venv/bin/python -m pytest tests/cli/test_install_detect.py tests/cli/test_self_update.py -q` (14 passed)
- Ruff on changed Python files (passed)
- `git diff --check` (passed)
- `.venv/bin/python -m pytest tests/cli -q` (439 passed, 2 skipped, 6 existing environment-dependent failures because `openjarvis_rust` is not installed in the local venv)

Note: local `uv` 0.5.9 cannot parse the current lockfile, so tests were run directly through the existing virtual environment.