### PR TITLE
ci(desktop): preflight Apple notarization credentials before the build

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -121,6 +121,104 @@ jobs:
           # latest release tag (#526).
           fetch-depth: 0
 
+      # Validate Apple credentials BEFORE the expensive work. Notarization is
+      # the very last thing `tauri-action` does, so a bad credential or a
+      # lapsed account agreement previously surfaced ~10 minutes in — after the
+      # Rust toolchain, npm install, two Ollama sidecar downloads and a
+      # universal cargo build — as a single opaque line:
+      #
+      #   failed to bundle project: failed codesign application: failed to
+      #   notarize app: Error: HTTP status code: 403. ...
+      #
+      # `notarytool history` is a read-only call (it submits nothing) that
+      # exercises the identical auth path, so every credential/account failure
+      # mode reaches us here first, in seconds, with the specific cause named.
+      # `xcrun` is preinstalled on macOS runners, hence placement before the
+      # toolchain steps rather than next to "Configure Apple signing".
+      - name: Preflight Apple notarization credentials
+        if: matrix.platform == 'macos-14'
+        env:
+          CERT: ${{ secrets.APPLE_CERTIFICATE }}
+          A_ID: ${{ secrets.APPLE_ID }}
+          A_PASS: ${{ secrets.APPLE_PASSWORD }}
+          A_TEAM: ${{ secrets.APPLE_TEAM_ID }}
+        shell: bash
+        run: |
+          set -uo pipefail
+
+          # Mirror the skip logic in "Configure Apple signing": without a
+          # certificate the build is unsigned and never notarizes, so there is
+          # nothing to preflight. Tag builds still hard-fail there.
+          if [ -z "$CERT" ]; then
+            echo "No Apple certificate configured; skipping notarization preflight."
+            exit 0
+          fi
+
+          missing=""
+          [ -z "$A_ID" ]   && missing="$missing APPLE_ID"
+          [ -z "$A_PASS" ] && missing="$missing APPLE_PASSWORD"
+          [ -z "$A_TEAM" ] && missing="$missing APPLE_TEAM_ID"
+          if [ -n "$missing" ]; then
+            echo "::error::APPLE_CERTIFICATE is set but notarization secrets are missing:$missing"
+            echo "::error::Signing would succeed and notarization would then fail. Set them or clear APPLE_CERTIFICATE."
+            exit 1
+          fi
+
+          # Retry only to absorb transient network faults. Credential and
+          # account errors are deterministic, so we classify and exit on the
+          # first definitive answer rather than retrying into the same wall.
+          attempt=1
+          while [ "$attempt" -le 3 ]; do
+            out=$(xcrun notarytool history \
+              --apple-id "$A_ID" \
+              --team-id "$A_TEAM" \
+              --password "$A_PASS" \
+              --output-format json 2>&1)
+            rc=$?
+
+            if [ $rc -eq 0 ]; then
+              echo "Apple notarization preflight OK — credentials valid, team reachable, agreements in effect."
+              exit 0
+            fi
+
+            case "$out" in
+              *"Invalid credentials"*|*"401"*)
+                echo "::error::Apple notarization preflight failed: invalid credentials (HTTP 401)."
+                echo "::error::APPLE_PASSWORD must be an app-specific password from appleid.apple.com,"
+                echo "::error::generated while signed in as the SAME Apple ID as APPLE_ID. A regular"
+                echo "::error::Apple ID password will not work, and a password minted under a different"
+                echo "::error::Apple ID authenticates as that other account."
+                exit 1
+                ;;
+              *"Invalid or inaccessible developer team ID"*)
+                echo "::error::Apple notarization preflight failed: APPLE_ID is not a member of team APPLE_TEAM_ID (HTTP 403)."
+                echo "::error::The Team ID must match the signing certificate. Read it from the cert's"
+                echo "::error::subject, where it appears as: Developer ID Application: NAME (TEAMID)."
+                echo "::error::If you belong to several teams, confirm APPLE_ID is a member of this one."
+                exit 1
+                ;;
+              *"required agreement"*|*"agreement"*)
+                echo "::error::Apple notarization preflight failed: the team has no in-effect agreement (HTTP 403)."
+                echo "::error::Apple reissues the Developer Program License Agreement periodically and"
+                echo "::error::notarization is refused until it is accepted. ONLY THE ACCOUNT HOLDER can"
+                echo "::error::accept it — team Admins cannot. Sign in to the account that owns this team:"
+                echo "::error::  1. https://developer.apple.com/account -> review any pending agreement"
+                echo "::error::  2. App Store Connect -> Business -> accept anything pending there too"
+                echo "::error::Certificates stay valid while this is outstanding, so signing still works."
+                exit 1
+                ;;
+            esac
+
+            echo "Preflight attempt ${attempt}/3 failed with a non-credential error."
+            echo "$out" | tail -5
+            attempt=$((attempt + 1))
+            [ "$attempt" -le 3 ] && sleep 10
+          done
+
+          echo "::error::Apple notarization preflight failed after 3 attempts. Last output:"
+          echo "$out" | tail -20
+          exit 1
+
       - name: Install system dependencies (Linux)
         if: matrix.platform == 'ubuntu-22.04'
         run: |


### PR DESCRIPTION
## Problem

Notarization is the **last** thing `tauri-action` does. Any credential or Apple-account fault therefore surfaced ~10 minutes into the macOS job — after the Rust toolchain, `npm install`, two Ollama sidecar downloads and a full universal `cargo build` — as a single opaque line:

```
failed to bundle project: failed codesign application: failed to notarize app:
Error: HTTP status code: 403. A required agreement is missing or has expired.
```

Two things make this worse than a slow failure. The message conflates **three unrelated causes**, and **code signing succeeds in all of them** — the log shows `found cert … Signing with identity …` right before the error, so it reads like a certificate problem when the certificate is fine.

This bit us on 2026-08-10/11: four failed builds (~40 min of CI) narrowing down what turned out to be a lapsed Developer Program License Agreement. Along the way we hit two *other* distinct Apple errors that present almost identically, including accepting the agreement on an Apple ID that wasn't a member of the signing team — a mistake the existing log gives you no way to detect.

## Change

One step, added immediately after `actions/checkout`, gated to `macos-14`. It runs a read-only `xcrun notarytool history` — it **submits nothing** — which exercises the identical auth path as the notarization at the end of the build. Every credential/account failure mode now reaches us in ~2 seconds with the cause and the fix named:

| Apple response | Diagnosis surfaced |
|---|---|
| `401 Invalid credentials` | `APPLE_PASSWORD` isn't an app-specific password, or was minted under a different Apple ID than `APPLE_ID` |
| `403 Invalid or inaccessible developer team ID` | `APPLE_ID` is not a member of `APPLE_TEAM_ID`; read the correct ID from the cert subject `Developer ID Application: NAME (TEAMID)` |
| `403 A required agreement is missing` | Program License Agreement lapsed — **only the Account Holder** can accept it, at developer.apple.com **and** App Store Connect → Business |

`xcrun` is preinstalled on macOS runners, which is why this sits before the toolchain steps rather than next to `Configure Apple signing` — it fails before anything expensive has run.

Two edge cases:

- **No `APPLE_CERTIFICATE`** → skips cleanly. Unsigned builds never notarize; mirrors the existing skip logic in `Configure Apple signing`, and tag builds still hard-fail there as before.
- **Certificate present, notarization secrets missing** → now fails immediately. Previously that combination signed successfully and only fell over at the very end.

Transient network faults retry 3× with a 10s backoff. Credential errors are deterministic, so they exit on the first definitive answer rather than retrying into the same wall.

## Testing

Verified against the live Notary API and via a stubbed `xcrun` replaying the three real error strings captured from the failing builds:

| Case | Expected | Result |
|---|---|---|
| Valid credentials | exit 0, proceed | PASS |
| `401` bad password | exit 1, credential guidance | PASS |
| `403` wrong team | exit 1, team guidance | PASS |
| `403` lapsed agreement | exit 1, Account Holder guidance | PASS |
| No certificate | exit 0, skip | PASS |
| Cert without `APPLE_ID` | exit 1, missing-secret error | PASS |
| Transient network error | exit 1 after 3 attempts (~20s) | PASS |

Exit codes and error shapes were confirmed against the real API rather than assumed: `notarytool` exits `1` on failure, `0` on success, and prints errors as plain text even under `--output-format json`.

No behavior change on Linux or Windows, and none on macOS when credentials are healthy — the step passes in about two seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)