### PR TITLE
fix(agents): repair ClaudeCodeAgent's Node runner build and auth precedence

### DIFF
--- a/src/openjarvis/agents/claude_code.py
+++ b/src/openjarvis/agents/claude_code.py
@@ -1,6 +1,6 @@
 """ClaudeCodeAgent -- wraps the Claude Agent SDK via Node.js subprocess bridge.
 
-Spawns a Node.js runner process that calls the ``@anthropic-ai/claude-code``
+Spawns a Node.js runner process that calls the ``@anthropic-ai/claude-agent-sdk``
 SDK, communicating via JSON over stdin/stdout with sentinel-delimited output.
 
 The engine parameter is accepted for interface conformance with BaseAgent but
@@ -45,7 +45,7 @@ class ClaudeCodeAgent(BaseAgent):
     """Agent that wraps the Claude Agent SDK via a Node.js subprocess.
 
     Spawns a Node.js process running ``dist/index.js`` which imports
-    ``@anthropic-ai/claude-code`` and streams agentic responses.  Results
+    ``@anthropic-ai/claude-agent-sdk`` and streams agentic responses.  Results
     are communicated back via sentinel-delimited JSON on stdout.
 
     The ``engine`` parameter is accepted for BaseAgent interface conformance
@@ -79,7 +79,7 @@ class ClaudeCodeAgent(BaseAgent):
             temperature=temperature,
             max_tokens=max_tokens,
         )
-        self._api_key = api_key or os.environ.get("ANTHROPIC_API_KEY", "")
+        self._api_key = api_key
         self._workspace = workspace or os.getcwd()
         self._session_id = session_id
         self._allowed_tools = allowed_tools
@@ -107,8 +107,10 @@ class ClaudeCodeAgent(BaseAgent):
         dest = get_config_dir() / "claude_code_runner"
         dest.mkdir(parents=True, exist_ok=True)
 
-        # Copy runner files if missing or outdated
-        for sub in ("package.json", "dist"):
+        # Copy runner source files if missing or outdated. The runner ships as
+        # TypeScript source (no prebuilt dist/) -- see the npm install/build
+        # steps below.
+        for sub in ("package.json", "tsconfig.json", "src"):
             src = _RUNNER_SRC / sub
             dst = dest / sub
             if src.is_file():
@@ -118,16 +120,43 @@ class ClaudeCodeAgent(BaseAgent):
                     shutil.rmtree(dst)
                 shutil.copytree(src, dst)
 
-        # Install npm dependencies if node_modules missing
+        # Install npm dependencies (including the typescript devDependency
+        # needed to build) if node_modules is missing or older than the
+        # package.json we just copied -- catches a stale node_modules left
+        # over from a previous version of this runner's dependency list
+        # (copy2 preserves package.json's source mtime, same trick used for
+        # the dist staleness check below).
         node_modules = dest / "node_modules"
-        if not node_modules.exists():
+        pkg_json = dest / "package.json"
+        if not node_modules.exists() or (
+            pkg_json.exists()
+            and pkg_json.stat().st_mtime > node_modules.stat().st_mtime
+        ):
             logger.info("Installing claude_code_runner dependencies...")
             subprocess.run(
-                ["npm", "install", "--production"],
+                ["npm", "install"],
                 cwd=str(dest),
                 check=True,
                 capture_output=True,
-                timeout=120,
+                timeout=180,
+            )
+
+        # Build if dist/index.js is missing or older than the source we just
+        # copied (copy2 preserves the source mtime, so an updated bundled
+        # runner naturally triggers a rebuild here).
+        dist_entry = dest / "dist" / "index.js"
+        src_entry = dest / "src" / "index.ts"
+        if not dist_entry.exists() or (
+            src_entry.exists()
+            and src_entry.stat().st_mtime > dist_entry.stat().st_mtime
+        ):
+            logger.info("Building claude_code_runner...")
+            subprocess.run(
+                ["npm", "run", "build"],
+                cwd=str(dest),
+                check=True,
+                capture_output=True,
+                timeout=60,
             )
 
         return dest

--- a/src/openjarvis/agents/claude_code_runner/package.json
+++ b/src/openjarvis/agents/claude_code_runner/package.json
@@ -1,8 +1,20 @@
 {
   "name": "openjarvis-claude-code-runner",
   "version": "0.1.0",
+  "private": true,
+  "type": "module",
   "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc -p ."
+  },
   "dependencies": {
-    "@anthropic-ai/claude-code": "^0.2"
+    "@anthropic-ai/claude-agent-sdk": "^0.3.0",
+    "@anthropic-ai/sdk": "^0.93.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.0",
+    "typescript": "^5.7.0"
   }
 }

--- a/src/openjarvis/agents/claude_code_runner/src/index.ts
+++ b/src/openjarvis/agents/claude_code_runner/src/index.ts
@@ -13,7 +13,7 @@
  *   ---OPENJARVIS_OUTPUT_END---
  */
 
-import { query, type Tool } from "@anthropic-ai/claude-code";
+import { query } from "@anthropic-ai/claude-agent-sdk";
 
 const OUTPUT_START = "---OPENJARVIS_OUTPUT_START---";
 const OUTPUT_END = "---OPENJARVIS_OUTPUT_END---";
@@ -78,75 +78,91 @@ async function main(): Promise<void> {
   } catch (err) {
     emitError(`Failed to parse input: ${err}`);
     process.exit(1);
+    return;
   }
 
-  // Set the API key in the environment for the SDK
+  // Auth: forward an explicit API key only when one was actually given.
+  // Otherwise strip any ambient ANTHROPIC_API_KEY from the child's env so
+  // the SDK falls back to the stored `claude login` session (Pro/Max
+  // subscription billing) instead of silently billing metered API credits.
+  const env: Record<string, string | undefined> = { ...process.env };
   if (request.api_key) {
-    process.env.ANTHROPIC_API_KEY = request.api_key;
+    env.ANTHROPIC_API_KEY = request.api_key;
+  } else {
+    delete env.ANTHROPIC_API_KEY;
   }
+
+  let content = "";
+  const toolResults: ToolResultEntry[] = [];
+  const toolUseIdToIndex = new Map<string, number>();
+  let isError = false;
+  let resultMetadata: Record<string, unknown> = {};
 
   try {
-    // Build options for the claude-code SDK query
-    const options: Parameters<typeof query>[0] = {
+    const stream = query({
       prompt: request.prompt,
       options: {
+        cwd: request.workspace || undefined,
+        systemPrompt: request.system_prompt || undefined,
+        allowedTools: request.allowed_tools?.length
+          ? request.allowed_tools
+          : undefined,
+        resume: request.session_id || undefined,
         maxTurns: 30,
+        env,
       },
-    };
+    });
 
-    if (request.workspace) {
-      options.options!.cwd = request.workspace;
-    }
-
-    if (request.system_prompt) {
-      options.options!.systemPrompt = request.system_prompt;
-    }
-
-    if (request.allowed_tools && request.allowed_tools.length > 0) {
-      options.options!.allowedTools = request.allowed_tools as Tool[];
-    }
-
-    if (request.session_id) {
-      options.options!.sessionId = request.session_id;
-    }
-
-    // Execute the query
-    const messages = await query(options);
-
-    // Extract the final assistant text and any tool results
-    let content = "";
-    const toolResults: ToolResultEntry[] = [];
-
-    for (const msg of messages) {
-      if (msg.type === "text") {
-        content = msg.text;
-      } else if (msg.type === "tool_use") {
-        toolResults.push({
-          tool_name: msg.name,
-          content: JSON.stringify(msg.input),
-          success: true,
-        });
-      } else if (msg.type === "tool_result") {
-        // Update last tool result with actual output
-        if (toolResults.length > 0) {
-          const last = toolResults[toolResults.length - 1];
-          last.content =
-            typeof msg.content === "string"
-              ? msg.content
-              : JSON.stringify(msg.content);
-          last.success = !msg.is_error;
+    for await (const msg of stream) {
+      if (msg.type === "assistant") {
+        for (const block of msg.message.content) {
+          if (block.type === "text") {
+            content = block.text;
+          } else if (block.type === "tool_use") {
+            toolResults.push({
+              tool_name: block.name,
+              content: JSON.stringify(block.input),
+              success: true,
+            });
+            toolUseIdToIndex.set(block.id, toolResults.length - 1);
+          }
         }
+      } else if (msg.type === "user") {
+        const blocks = Array.isArray(msg.message.content)
+          ? msg.message.content
+          : [];
+        for (const block of blocks) {
+          if (block.type === "tool_result") {
+            const idx = toolUseIdToIndex.get(block.tool_use_id);
+            if (idx !== undefined) {
+              const entry = toolResults[idx];
+              entry.content =
+                typeof block.content === "string"
+                  ? block.content
+                  : JSON.stringify(block.content);
+              entry.success = !block.is_error;
+            }
+          }
+        }
+      } else if (msg.type === "result") {
+        isError = msg.is_error;
+        if (msg.subtype === "success") {
+          content = msg.result || content;
+        }
+        resultMetadata = {
+          session_id: msg.session_id,
+          num_turns: msg.num_turns,
+          total_cost_usd: msg.total_cost_usd,
+        };
       }
     }
 
     emitResult({
       content,
       tool_results: toolResults,
-      metadata: {
-        message_count: messages.length,
-        session_id: request.session_id || undefined,
-      },
+      metadata: { ...resultMetadata, error: isError || undefined },
     });
+    if (isError) process.exit(1);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     emitError(`Claude Code SDK error: ${message}`);

--- a/src/openjarvis/agents/claude_code_runner/tsconfig.json
+++ b/src/openjarvis/agents/claude_code_runner/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": false
+  },
+  "include": ["src"]
+}

--- a/tests/agents/test_claude_code.py
+++ b/tests/agents/test_claude_code.py
@@ -84,7 +84,13 @@ class TestEnsureRunner:
             with pytest.raises(RuntimeError, match="Node.js"):
                 agent._ensure_runner()
 
-    def test_creates_runner_dir(self, tmp_path):
+    def test_creates_runner_dir(self, tmp_path, monkeypatch):
+        # get_config_dir() checks $OPENJARVIS_HOME/$XDG_DATA_HOME before
+        # Path.home(); a dev machine with either set would otherwise ignore
+        # the patched home below and hit its real, already-built runner dir.
+        monkeypatch.delenv("OPENJARVIS_HOME", raising=False)
+        monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+
         engine = MagicMock()
         engine.engine_id = "mock"
         agent = ClaudeCodeAgent(engine, "test-model")
@@ -108,7 +114,10 @@ class TestEnsureRunner:
             assert install_args[:2] == ["npm", "install"]
             assert build_args[:2] == ["npm", "run"]
 
-    def test_skips_npm_install_when_node_modules_exists(self, tmp_path):
+    def test_skips_npm_install_when_node_modules_exists(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("OPENJARVIS_HOME", raising=False)
+        monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+
         engine = MagicMock()
         engine.engine_id = "mock"
         agent = ClaudeCodeAgent(engine, "test-model")
@@ -130,11 +139,16 @@ class TestEnsureRunner:
             call_args = mock_run.call_args[0][0]
             assert call_args[:2] == ["npm", "run"]
 
-    def test_reinstalls_when_node_modules_older_than_package_json(self, tmp_path):
+    def test_reinstalls_when_node_modules_older_than_package_json(
+        self, tmp_path, monkeypatch
+    ):
         """Regression test: a node_modules installed against an older
         package.json (missing a since-added devDependency, e.g. typescript)
         must not be treated as fresh just because the directory exists.
         """
+        monkeypatch.delenv("OPENJARVIS_HOME", raising=False)
+        monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+
         engine = MagicMock()
         engine.engine_id = "mock"
         agent = ClaudeCodeAgent(engine, "test-model")
@@ -145,7 +159,14 @@ class TestEnsureRunner:
         node_modules.mkdir(parents=True)
         # Force node_modules to look older than the package.json that's
         # about to be copied in (copy2 preserves the real source's mtime).
-        past = node_modules.stat().st_mtime - 3600
+        # Must be backdated relative to that *source* file's actual mtime,
+        # not "now" -- on a checkout where package.json hasn't been touched
+        # recently, "now - 1h" can still be newer than the source, which
+        # silently skips the reinstall this test exists to catch.
+        from openjarvis.agents.claude_code import _RUNNER_SRC
+
+        src_mtime = (_RUNNER_SRC / "package.json").stat().st_mtime
+        past = src_mtime - 3600
         os.utime(node_modules, (past, past))
 
         with (
@@ -160,7 +181,10 @@ class TestEnsureRunner:
             assert install_args[:2] == ["npm", "install"]
             assert build_args[:2] == ["npm", "run"]
 
-    def test_skips_everything_when_dist_is_up_to_date(self, tmp_path):
+    def test_skips_everything_when_dist_is_up_to_date(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("OPENJARVIS_HOME", raising=False)
+        monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+
         engine = MagicMock()
         engine.engine_id = "mock"
         agent = ClaudeCodeAgent(engine, "test-model")

--- a/tests/agents/test_claude_code.py
+++ b/tests/agents/test_claude_code.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 from unittest.mock import MagicMock, patch
 
@@ -100,9 +101,12 @@ class TestEnsureRunner:
             dest = home_dir / ".openjarvis" / "claude_code_runner"
             result = agent._ensure_runner()
             assert result == dest
-            mock_run.assert_called_once()
-            call_args = mock_run.call_args
-            assert "npm" in call_args[0][0][0]
+            # node_modules and dist/index.js are both missing, so this
+            # triggers both an install and a build.
+            assert mock_run.call_count == 2
+            install_args, build_args = (c[0][0] for c in mock_run.call_args_list)
+            assert install_args[:2] == ["npm", "install"]
+            assert build_args[:2] == ["npm", "run"]
 
     def test_skips_npm_install_when_node_modules_exists(self, tmp_path):
         engine = MagicMock()
@@ -113,6 +117,63 @@ class TestEnsureRunner:
         dest = home_dir / ".openjarvis" / "claude_code_runner"
         dest.mkdir(parents=True)
         (dest / "node_modules").mkdir()
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/node"),
+            patch("pathlib.Path.home", return_value=home_dir),
+            patch("subprocess.run") as mock_run,
+        ):
+            agent._ensure_runner()
+            # node_modules exists (skip install) but dist/index.js still
+            # doesn't (skip-build condition not met) -- a build still runs.
+            mock_run.assert_called_once()
+            call_args = mock_run.call_args[0][0]
+            assert call_args[:2] == ["npm", "run"]
+
+    def test_reinstalls_when_node_modules_older_than_package_json(self, tmp_path):
+        """Regression test: a node_modules installed against an older
+        package.json (missing a since-added devDependency, e.g. typescript)
+        must not be treated as fresh just because the directory exists.
+        """
+        engine = MagicMock()
+        engine.engine_id = "mock"
+        agent = ClaudeCodeAgent(engine, "test-model")
+
+        home_dir = tmp_path / "home"
+        dest = home_dir / ".openjarvis" / "claude_code_runner"
+        node_modules = dest / "node_modules"
+        node_modules.mkdir(parents=True)
+        # Force node_modules to look older than the package.json that's
+        # about to be copied in (copy2 preserves the real source's mtime).
+        past = node_modules.stat().st_mtime - 3600
+        os.utime(node_modules, (past, past))
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/node"),
+            patch("pathlib.Path.home", return_value=home_dir),
+            patch("subprocess.run") as mock_run,
+        ):
+            agent._ensure_runner()
+            # Stale node_modules -> reinstall; dist also missing -> build.
+            assert mock_run.call_count == 2
+            install_args, build_args = (c[0][0] for c in mock_run.call_args_list)
+            assert install_args[:2] == ["npm", "install"]
+            assert build_args[:2] == ["npm", "run"]
+
+    def test_skips_everything_when_dist_is_up_to_date(self, tmp_path):
+        engine = MagicMock()
+        engine.engine_id = "mock"
+        agent = ClaudeCodeAgent(engine, "test-model")
+
+        home_dir = tmp_path / "home"
+        dest = home_dir / ".openjarvis" / "claude_code_runner"
+        (dest / "node_modules").mkdir(parents=True)
+        (dest / "dist").mkdir()
+        dist_entry = dest / "dist" / "index.js"
+        dist_entry.write_text("// built")
+        # Make the built artifact newer than every copied source file.
+        future = dist_entry.stat().st_mtime + 3600
+        os.utime(dist_entry, (future, future))
 
         with (
             patch("shutil.which", return_value="/usr/bin/node"),
@@ -500,12 +561,18 @@ class TestParseOutput:
 
 
 class TestClaudeCodeDefaults:
-    def test_default_api_key_from_env(self, monkeypatch):
+    def test_default_api_key_ignores_ambient_env(self, monkeypatch):
+        """No api_key given -- must NOT pick up ambient ANTHROPIC_API_KEY.
+
+        Picking it up here would make the runner always authenticate with a
+        metered API key even when a Claude Pro/Max subscription session is
+        logged in, silently overriding subscription billing.
+        """
         monkeypatch.setenv("ANTHROPIC_API_KEY", "env-key-123")
         engine = MagicMock()
         engine.engine_id = "mock"
         agent = ClaudeCodeAgent(engine, "test-model")
-        assert agent._api_key == "env-key-123"
+        assert agent._api_key == ""
 
     def test_explicit_api_key_overrides_env(self, monkeypatch):
         monkeypatch.setenv("ANTHROPIC_API_KEY", "env-key")


### PR DESCRIPTION
## Summary
- The runner imported `query()`/`Tool` from `@anthropic-ai/claude-code`, but that package has never published an importable SDK — it's the `claude` CLI binary only. Swapped to the real package, `@anthropic-ai/claude-agent-sdk`, rewrote the runner against its actual `AsyncGenerator<SDKMessage>` API, and added the `tsconfig.json`/build script that were missing entirely (the runner shipped as bare TypeScript source with nothing to compile it).
- Fixed the coupled auth-precedence bug: `ClaudeCodeAgent` no longer defaults `api_key` from the ambient `ANTHROPIC_API_KEY` env var, and the runner strips that var from the subprocess env unless a key was explicitly passed, so a Claude Pro/Max login session is used instead of silently billing metered API credits.
- `_ensure_runner()` now detects a stale `node_modules` (missing a newly-added devDependency) via mtime instead of just presence.
- Included a follow-up test-isolation fix: `get_config_dir()` checks `$OPENJARVIS_HOME`/`$XDG_DATA_HOME` before `Path.home()`, so on a machine with either set, the `TestEnsureRunner` tests' patched `Path.home()` was silently ignored and `_ensure_runner()` wrote into the real runner dir, breaking the `subprocess.run` call-count assertions. Also fixed the reinstall-staleness test backdating `node_modules`'s mtime relative to "now" instead of the actual source `package.json`'s mtime, which could silently never trigger the staleness check it exists to catch.

## Test plan
- [x] `pytest tests/agents/test_claude_code.py -q` — 28/28 pass
- [x] `npm install && npm run build` in `claude_code_runner/` — clean `tsc` build
- [x] `ruff check` / `ruff format --check` — clean