### PR TITLE
Fix silent TTS failure in morning digest

### DIFF
--- a/src/openjarvis/cli/digest_cmd.py
+++ b/src/openjarvis/cli/digest_cmd.py
@@ -201,7 +201,7 @@ def digest(
 
         audio_path = str(artifact.audio_path)
         console.print(f"[dim]Audio path: '{audio_path}'[/dim]")
-        has_audio = bool(audio_path) and artifact.audio_path.exists()
+        has_audio = bool(audio_path) and artifact.audio_path.is_file()
         console.print(f"[dim]Audio available: {has_audio}[/dim]")
         if has_audio:
             audio_thread = threading.Thread(
@@ -245,7 +245,7 @@ def digest(
 
     # Play audio in background while text renders
     audio_path = str(artifact.audio_path)
-    if not text_only and audio_path and artifact.audio_path.exists():
+    if not text_only and audio_path and artifact.audio_path.is_file():
         audio_thread = threading.Thread(
             target=_play_audio, args=(audio_path,), daemon=True
         )

--- a/src/openjarvis/speech/cartesia_tts.py
+++ b/src/openjarvis/speech/cartesia_tts.py
@@ -58,7 +58,7 @@ class CartesiaTTSBackend(TTSBackend):
     backend_id = "cartesia"
 
     def __init__(
-        self, *, api_key: str = "", model: str = "sonic", language: str = "en"
+        self, *, api_key: str = "", model: str = "sonic-2", language: str = "en"
     ) -> None:
         self._api_key = api_key or os.environ.get("CARTESIA_API_KEY", "")
         self._model = model


### PR DESCRIPTION
Fix silent TTS failure in morning digest

Cartesia's default "sonic" model was sunsetted, causing every TTS call
to fail with a 400. The failure was masked because digest_cmd checked
Path.exists() on the audio path, and an empty path stringifies to ".",
which always exists as a directory. Switch the default model to
"sonic-2" and check is_file() instead so a failed TTS run is reported
accurately.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>