### PR TITLE
fix(mcp): drain stdio transport stderr to prevent deadlock

### DIFF
--- a/src/openjarvis/mcp/transport.py
+++ b/src/openjarvis/mcp/transport.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import logging
 import subprocess
+import threading
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, List, Optional
 
@@ -10,6 +12,8 @@ from openjarvis.mcp.protocol import MCPRequest, MCPResponse
 
 if TYPE_CHECKING:
     from openjarvis.mcp.server import MCPServer
+
+logger = logging.getLogger(__name__)
 
 
 class MCPTransport(ABC):
@@ -61,6 +65,7 @@ class StdioTransport(MCPTransport):
     def __init__(self, command: List[str]) -> None:
         self._command = command
         self._process: Optional[subprocess.Popen[str]] = None
+        self._stderr_thread: Optional[threading.Thread] = None
         self._start()
 
     def _start(self) -> None:
@@ -72,6 +77,25 @@ class StdioTransport(MCPTransport):
             stderr=subprocess.PIPE,
             text=True,
         )
+        # Nothing else reads stderr. Once the child writes more than the OS
+        # pipe buffer to it, the child blocks on that write and never gets
+        # to answer on stdout, deadlocking send()'s readline() (#750). Drain
+        # it continuously on a background thread instead.
+        self._stderr_thread = threading.Thread(
+            target=self._drain_stderr,
+            args=(self._process,),
+            daemon=True,
+        )
+        self._stderr_thread.start()
+
+    def _drain_stderr(self, proc: subprocess.Popen[str]) -> None:
+        """Continuously read the child's stderr so its pipe never fills."""
+        if proc.stderr is None:
+            return
+        for line in proc.stderr:
+            line = line.rstrip("\n")
+            if line:
+                logger.debug("[%s stderr] %s", self._command[0], line)
 
     def send(self, request: MCPRequest) -> MCPResponse:
         """Write request as JSON line, read response line."""
@@ -108,6 +132,9 @@ class StdioTransport(MCPTransport):
             self._process.terminate()
             self._process.wait(timeout=5)
             self._process = None
+        if self._stderr_thread is not None:
+            self._stderr_thread.join(timeout=5)
+            self._stderr_thread = None
 
 
 class StreamableHTTPTransport(MCPTransport):

--- a/tests/mcp/test_transport.py
+++ b/tests/mcp/test_transport.py
@@ -184,6 +184,67 @@ class TestStdioTransport:
         finally:
             transport.close()
 
+    def test_survives_large_stderr_output(self, tmp_path):
+        """Regression for #750: a child that fills the stderr pipe buffer
+        before responding on stdout must not deadlock the transport.
+
+        ``StdioTransport`` spawns the child with ``stderr=subprocess.PIPE``
+        but nothing drains it. Once the child writes more than the OS pipe
+        buffer to stderr, its write blocks and it never gets to read stdin
+        or answer on stdout, so ``proc.stdout.readline()`` hangs forever.
+        """
+        import threading
+
+        script = tmp_path / "noisy_server.py"
+        script.write_text(
+            textwrap.dedent("""\
+            import sys
+            import json
+
+            # Write well past any OS pipe buffer before touching stdin.
+            for _ in range(20000):
+                sys.stderr.write("noisy line filling the pipe buffer\\n")
+            sys.stderr.flush()
+
+            for line in sys.stdin:
+                line = line.strip()
+                if not line:
+                    continue
+                req = json.loads(line)
+                resp = {
+                    "jsonrpc": "2.0",
+                    "id": req.get("id", 0),
+                    "result": {"echo": req.get("method", "")},
+                }
+                sys.stdout.write(json.dumps(resp) + "\\n")
+                sys.stdout.flush()
+        """)
+        )
+
+        transport = StdioTransport([sys.executable, str(script)])
+        try:
+            result_box: dict = {}
+
+            def call():
+                try:
+                    req = MCPRequest(method="test/echo", id=1)
+                    result_box["resp"] = transport.send(req)
+                except Exception as exc:  # noqa: BLE001
+                    result_box["error"] = exc
+
+            worker = threading.Thread(target=call, daemon=True)
+            worker.start()
+            worker.join(timeout=10.0)
+            assert not worker.is_alive(), (
+                "send() deadlocked on a full stderr pipe buffer"
+            )
+            assert "error" not in result_box, result_box.get("error")
+            resp = result_box["resp"]
+            assert resp.error is None
+            assert resp.result["echo"] == "test/echo"
+        finally:
+            transport.close()
+
     def test_close_terminates_process(self, tmp_path):
         script = tmp_path / "sleep_server.py"
         script.write_text(


### PR DESCRIPTION
## Summary
- Fixes #750: `StdioTransport` spawns its subprocess with `stderr=subprocess.PIPE` but nothing ever reads from that pipe. Once the child writes more than the OS pipe buffer to stderr (a few KB), the child blocks on its own write and never gets to read stdin or answer on stdout — deadlocking `proc.stdout.readline()` in `send()` forever.
- Adds a daemon background thread that continuously drains `proc.stderr` (logging each line at debug level) for the lifetime of the transport, started in `_start()` and joined in `close()`.

## Test plan
- [x] Added `test_survives_large_stderr_output` (`tests/mcp/test_transport.py`): spawns a child that writes 20,000 lines to stderr before touching stdin, then calls `send()` from a worker thread with a join timeout. Confirmed it deadlocks (times out) against the old code and passes after the fix.
- [x] `uv run pytest tests/mcp/` — 149 passed
- [x] `uv run pytest tests/security/test_tool_confirmation.py tests/security/test_security_wiring.py tests/security/test_boundary_guard.py` — 30 passed
- [x] `uv run ruff check` on changed files — clean
- [x] Ran the full suite with the same extras/markers as CI (`uv sync --extra dev --extra framework-comparison --extra server`, `pytest tests/ -n auto -m "not live and not cloud and not hub"`). 162 pre-existing failures unrelated to this change (missing compiled `openjarvis_rust` extension, Linux-only RAPL sysfs paths invalid on this Windows box, etc.) — verified identical on a clean `main` checkout via `git stash`, so none are caused by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)