### PR TITLE
fix(mcp): close MCPClient on failed initialize() to prevent leaks

### DIFF
--- a/src/openjarvis/mcp/loader.py
+++ b/src/openjarvis/mcp/loader.py
@@ -101,7 +101,14 @@ def load_mcp_tools_from_config(
                 continue
 
             client = MCPClient(transport)
-            client.initialize()
+            try:
+                client.initialize()
+            except Exception:
+                # Not yet in `clients`, so nothing else will ever close it
+                # (and the underlying subprocess/connection pool) if we
+                # don't do it here (#753).
+                client.close()
+                raise
             clients.append(client)
 
             provider = MCPToolProvider(client)

--- a/src/openjarvis/mcp/loader.py
+++ b/src/openjarvis/mcp/loader.py
@@ -107,7 +107,19 @@ def load_mcp_tools_from_config(
                 # Not yet in `clients`, so nothing else will ever close it
                 # (and the underlying subprocess/connection pool) if we
                 # don't do it here (#753).
-                client.close()
+                try:
+                    client.close()
+                except Exception as cleanup_exc:
+                    # Cleanup is best-effort here.  Preserve the initialize()
+                    # exception as the discovery failure while still making a
+                    # failed cleanup visible to operators.
+                    logger.warning(
+                        "Failed to close MCP client for '%s' after "
+                        "initialization failed: %s",
+                        name,
+                        cleanup_exc,
+                        exc_info=True,
+                    )
                 raise
             clients.append(client)
 

--- a/src/openjarvis/system/builder.py
+++ b/src/openjarvis/system/builder.py
@@ -681,7 +681,19 @@ class SystemBuilder:
             # Not yet in self._mcp_clients, so nothing else will ever
             # close it (and the underlying subprocess/connection pool) if
             # we don't do it here (#753).
-            client.close()
+            try:
+                client.close()
+            except Exception as cleanup_exc:
+                # Do not let a cleanup failure mask the original handshake
+                # error; callers need the initialize() failure to diagnose
+                # the server while operators still need the cleanup signal.
+                logger.warning(
+                    "Failed to close MCP client for '%s' after "
+                    "initialization failed: %s",
+                    name,
+                    cleanup_exc,
+                    exc_info=True,
+                )
             raise
 
         self._mcp_clients.append(client)

--- a/src/openjarvis/system/builder.py
+++ b/src/openjarvis/system/builder.py
@@ -675,7 +675,14 @@ class SystemBuilder:
             return []
 
         client = MCPClient(transport)
-        client.initialize()
+        try:
+            client.initialize()
+        except Exception:
+            # Not yet in self._mcp_clients, so nothing else will ever
+            # close it (and the underlying subprocess/connection pool) if
+            # we don't do it here (#753).
+            client.close()
+            raise
 
         self._mcp_clients.append(client)
 

--- a/tests/mcp/test_loader.py
+++ b/tests/mcp/test_loader.py
@@ -226,3 +226,29 @@ class TestLoaderFailureIsolation:
         assert [t.spec.name for t in tools] == ["survivor"]
         assert len(clients) == 1
         assert any("broken" in r.message for r in caplog.records)
+
+    def test_failed_initialize_closes_the_client(self, _mock_mcp_stack, caplog):
+        """Regression for #753: a client whose initialize() fails must
+        still be closed.
+
+        ``client.initialize()`` was called before ``clients.append(client)``,
+        so a failed handshake left the client out of the returned list --
+        nothing the caller holds ever calls ``close()`` on it, leaking the
+        underlying StdioTransport subprocess or StreamableHTTPTransport
+        connection pool.
+        """
+        from openjarvis.mcp.loader import load_mcp_tools_from_config
+
+        bad_client = MagicMock()
+        bad_client.initialize.side_effect = RuntimeError("handshake failed")
+        _mock_mcp_stack["client"].return_value = bad_client
+
+        cfg = _make_mcp_cfg(
+            enabled=True,
+            servers=[{"name": "broken", "url": "http://broken"}],
+        )
+        with caplog.at_level("WARNING"):
+            tools, clients = load_mcp_tools_from_config(cfg)
+
+        assert clients == []
+        bad_client.close.assert_called_once()

--- a/tests/mcp/test_loader.py
+++ b/tests/mcp/test_loader.py
@@ -252,3 +252,31 @@ class TestLoaderFailureIsolation:
 
         assert clients == []
         bad_client.close.assert_called_once()
+
+    def test_cleanup_failure_does_not_mask_initialize_error(
+        self, _mock_mcp_stack, caplog
+    ):
+        """The handshake remains the reported discovery failure if close fails."""
+        from openjarvis.mcp.loader import load_mcp_tools_from_config
+
+        bad_client = MagicMock()
+        bad_client.initialize.side_effect = RuntimeError("handshake failed")
+        bad_client.close.side_effect = RuntimeError("cleanup failed")
+        _mock_mcp_stack["client"].return_value = bad_client
+        cfg = _make_mcp_cfg(
+            enabled=True,
+            servers=[{"name": "broken", "url": "http://broken"}],
+        )
+
+        with caplog.at_level("WARNING"):
+            tools, clients = load_mcp_tools_from_config(cfg)
+
+        assert tools == []
+        assert clients == []
+        bad_client.close.assert_called_once()
+        messages = [record.getMessage() for record in caplog.records]
+        assert any("cleanup failed" in message for message in messages)
+        assert any(
+            "Failed to discover MCP tools" in message and "handshake failed" in message
+            for message in messages
+        )

--- a/tests/sdk/test_builder_mcp_cleanup.py
+++ b/tests/sdk/test_builder_mcp_cleanup.py
@@ -1,0 +1,53 @@
+"""Regression test for #753: a failed MCP handshake in
+``SystemBuilder._discover_external_mcp`` must not leak the spawned
+subprocess / HTTP client.
+
+``client.initialize()`` used to be called before the client was appended
+to ``self._mcp_clients``. When ``initialize()`` raised (malformed JSON
+output, auth errors, protocol issues), the client was never appended --
+and since nothing else holds a reference to it, ``close()`` never ran,
+leaving the underlying ``StdioTransport`` subprocess or
+``StreamableHTTPTransport`` connection pool running indefinitely.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from openjarvis.core.config import JarvisConfig
+from openjarvis.system.builder import SystemBuilder
+
+
+@pytest.fixture
+def _mock_mcp_stack():
+    """Patch MCPClient / transports / MCPToolProvider so no real I/O happens."""
+    with (
+        patch("openjarvis.mcp.client.MCPClient") as MockClient,
+        patch("openjarvis.mcp.transport.StreamableHTTPTransport") as MockHttp,
+        patch("openjarvis.mcp.transport.StdioTransport") as MockStdio,
+        patch("openjarvis.tools.mcp_adapter.MCPToolProvider") as MockProvider,
+    ):
+        MockProvider.return_value.discover.return_value = []
+        MockClient.return_value.initialize.return_value = None
+        yield {
+            "client": MockClient,
+            "http": MockHttp,
+            "stdio": MockStdio,
+            "provider": MockProvider,
+        }
+
+
+def test_failed_initialize_closes_the_client(_mock_mcp_stack):
+    builder = SystemBuilder(config=JarvisConfig())
+
+    bad_client = MagicMock()
+    bad_client.initialize.side_effect = RuntimeError("handshake failed")
+    _mock_mcp_stack["client"].return_value = bad_client
+
+    with pytest.raises(RuntimeError, match="handshake failed"):
+        builder._discover_external_mcp({"name": "broken", "url": "http://broken"})
+
+    assert bad_client not in builder._mcp_clients
+    bad_client.close.assert_called_once()

--- a/tests/sdk/test_builder_mcp_cleanup.py
+++ b/tests/sdk/test_builder_mcp_cleanup.py
@@ -39,15 +39,20 @@ def _mock_mcp_stack():
         }
 
 
-def test_failed_initialize_closes_the_client(_mock_mcp_stack):
+def test_failed_initialize_closes_the_client(_mock_mcp_stack, caplog):
     builder = SystemBuilder(config=JarvisConfig())
 
     bad_client = MagicMock()
     bad_client.initialize.side_effect = RuntimeError("handshake failed")
+    bad_client.close.side_effect = RuntimeError("cleanup failed")
     _mock_mcp_stack["client"].return_value = bad_client
 
-    with pytest.raises(RuntimeError, match="handshake failed"):
+    with (
+        caplog.at_level("WARNING"),
+        pytest.raises(RuntimeError, match="handshake failed"),
+    ):
         builder._discover_external_mcp({"name": "broken", "url": "http://broken"})
 
     assert bad_client not in builder._mcp_clients
     bad_client.close.assert_called_once()
+    assert any("cleanup failed" in record.getMessage() for record in caplog.records)


### PR DESCRIPTION
## Summary
- Fixes #753: both `openjarvis.mcp.loader.load_mcp_tools_from_config` and `SystemBuilder._discover_external_mcp` created an `MCPClient` and called `initialize()` *before* appending it to the `clients` list they return/hold:
  ```python
  client = MCPClient(transport)
  client.initialize()
  clients.append(client)
  ```
  When `initialize()` raised (malformed JSON output, auth errors, protocol issues), control jumped straight to the per-server exception handler — the client never reached `append()`, so nothing the caller holds ever calls `close()` on it, leaking the underlying `StdioTransport` subprocess or `StreamableHTTPTransport` connection pool. In `jarvis serve` with repeated agent reloads these accumulate.
- Both now wrap `initialize()` in try/except, close the client on failure, and re-raise (so existing per-server error logging/isolation upstream is unaffected):
  ```python
  client = MCPClient(transport)
  try:
      client.initialize()
  except Exception:
      client.close()
      raise
  clients.append(client)
  ```
- `server/agent_manager_routes.py` (the issue's third code pointer, `:725`) already had correct cleanup — a `client = None` sentinel plus an `except Exception` clause that closes and unregisters the client on failure — so it needed no changes.

## Test plan
- [x] Added `test_failed_initialize_closes_the_client` to `tests/mcp/test_loader.py`: a client whose `initialize()` raises must have `close()` called on it exactly once, and must not appear in the returned `clients` list.
- [x] Added `tests/sdk/test_builder_mcp_cleanup.py::test_failed_initialize_closes_the_client`: same assertion against `SystemBuilder._discover_external_mcp`.
- [x] Confirmed both fail against the old code (`close()` called 0 times) and pass after the fix.
- [x] `uv run pytest tests/mcp/ tests/sdk/` — 223 passed
- [x] `uv run pytest` on all other test files touching `SystemBuilder` (`tests/cli/test_serve_single_build.py`, `tests/evals/test_eval_telemetry_wiring.py`, `tests/evals/test_jarvis_agent_backend_fields.py`, `tests/evals/test_jarvis_agent_backend_skills.py`, `tests/learning/test_system_learning.py`, `tests/mcp/test_discovery.py`, `tests/skills/test_native_react_few_shot.py`) — 89 passed
- [x] `uv run ruff check` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)