### PR TITLE
fix(memory): reject non-positive max_facts instead of disabling the cap

### DIFF
--- a/src/openjarvis/memory/store.py
+++ b/src/openjarvis/memory/store.py
@@ -80,10 +80,15 @@ class LocalFactStore(FactStore):
         *,
         max_facts: int = 1000,
     ) -> None:
+        max_facts = int(max_facts)
+        if max_facts <= 0:
+            raise ValueError(
+                f"max_facts must be a positive integer, got {max_facts}"
+            )
         self._path = (
             Path(path).expanduser() if path is not None else _default_fact_path()
         )
-        self._max_facts = max(0, int(max_facts))
+        self._max_facts = max_facts
         self._lock = threading.Lock()
         self._facts: List[Fact] = self._load()
 
@@ -143,8 +148,11 @@ class LocalFactStore(FactStore):
             if any(f.text.lower() == lowered for f in self._facts):
                 return False  # dedupe
             self._facts.append(Fact(text=text, source=source, created_at=time.time()))
-            # Enforce the cap by evicting the oldest entries.
-            if self._max_facts and len(self._facts) > self._max_facts:
+            # Enforce the cap by evicting the oldest entries. max_facts is
+            # always positive (validated in __init__), so this slice can't
+            # hit Python's `list[-0:]` footgun, which returns the whole
+            # list instead of emptying it.
+            if len(self._facts) > self._max_facts:
                 self._facts = self._facts[-self._max_facts :]
             self._flush()
         return True

--- a/tests/memory/test_fact_store.py
+++ b/tests/memory/test_fact_store.py
@@ -57,6 +57,24 @@ def test_max_facts_evicts_oldest(tmp_path):
     assert facts == ["second", "third"]  # oldest dropped
 
 
+def test_max_facts_zero_rejected(tmp_path):
+    """Regression for #757: max_facts=0 must not silently disable the cap.
+
+    ``self._max_facts and len(self._facts) > self._max_facts`` short-
+    circuits on 0 (falsy), so eviction never ran and the store grew
+    without bound -- the opposite of what a "cap on stored facts" should
+    do for its minimum value. Reject non-positive values outright instead
+    of accepting one that means the opposite of what it says.
+    """
+    with pytest.raises(ValueError):
+        LocalFactStore(tmp_path / "facts.jsonl", max_facts=0)
+
+
+def test_max_facts_negative_rejected(tmp_path):
+    with pytest.raises(ValueError):
+        LocalFactStore(tmp_path / "facts.jsonl", max_facts=-5)
+
+
 def test_persistence_across_instances(tmp_path):
     path = tmp_path / "facts.jsonl"
     store = LocalFactStore(path)


### PR DESCRIPTION
## Summary
- Fixes #757: `LocalFactStore(max_facts=0)` silently disabled eviction entirely instead of enforcing a zero-fact cap. `if self._max_facts and len(self._facts) > self._max_facts:` short-circuits on `0` (falsy in Python), so the cap check never even ran — the opposite of "cap on stored facts" at its minimum value. Repeated `add()` calls grew the store without bound, continuously rewriting `memory_facts.jsonl`.
- `LocalFactStore.__init__` now rejects non-positive `max_facts` with `ValueError`, matching the codebase's existing error-handling convention for bad config (`create_fact_store` already raises `ValueError` for an unknown backend).
- Also simplified the eviction check now that `max_facts` is guaranteed positive: `self._facts[-self._max_facts:]` would otherwise be exposed to Python's `list[-0:]` footgun for `max_facts=0` — negative-zero doesn't exist for ints, so `-0 == 0`, and slicing `list[-0:]` returns the *whole* list rather than emptying it. That's now moot since 0 is rejected at construction, but worth calling out since a naive "just drop the truthy check" fix would have hit it.

## Test plan
- [x] Added `test_max_facts_zero_rejected` and `test_max_facts_negative_rejected` to `tests/memory/test_fact_store.py`.
- [x] Confirmed both fail against the old code (`DID NOT RAISE ValueError`) and pass after the fix.
- [x] `uv run pytest tests/memory/test_fact_store.py` — 18 passed
- [x] `uv run ruff check` on changed files — clean

Branched directly off `main`; applies cleanly independent of #797 (the LocalFactStore cross-process locking fix, also currently open on the same file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)