### PR TITLE
test(server): fix flaky /metrics assertion, missing the third response state

### DIFF
--- a/tests/server/test_api_routes.py
+++ b/tests/server/test_api_routes.py
@@ -120,11 +120,28 @@ class TestBudgetRoutes:
 
 
 class TestMetricsRoute:
-    def test_metrics_endpoint(self):
+    def test_metrics_endpoint(self, tmp_path, monkeypatch):
+        """Regression for #792: /metrics has three valid response states
+        (Prometheus output, "No metrics available" for a reachable-but-
+        empty store, or "no telemetry data" when no telemetry.db exists
+        at all), but the old assertion only covered two of them. Pin
+        DEFAULT_CONFIG_DIR to an empty directory so this deterministically
+        exercises the third state instead of depending on whether the
+        machine running the test happens to already have telemetry data
+        under its real ~/.openjarvis.
+        """
+        import openjarvis.core.config as config_mod
+
+        monkeypatch.setattr(config_mod, "DEFAULT_CONFIG_DIR", tmp_path)
+
         client = TestClient(_make_app())
         resp = client.get("/metrics")
         assert resp.status_code == 200
-        assert "openjarvis" in resp.text or "No metrics" in resp.text
+        assert (
+            "openjarvis" in resp.text
+            or "No metrics" in resp.text
+            or "no telemetry data" in resp.text
+        )
 
 
 class TestSkillRoutes:

--- a/tests/server/test_api_routes.py
+++ b/tests/server/test_api_routes.py
@@ -121,14 +121,11 @@ class TestBudgetRoutes:
 
 class TestMetricsRoute:
     def test_metrics_endpoint(self, tmp_path, monkeypatch):
-        """Regression for #792: /metrics has three valid response states
-        (Prometheus output, "No metrics available" for a reachable-but-
-        empty store, or "no telemetry data" when no telemetry.db exists
-        at all), but the old assertion only covered two of them. Pin
-        DEFAULT_CONFIG_DIR to an empty directory so this deterministically
-        exercises the third state instead of depending on whether the
-        machine running the test happens to already have telemetry data
-        under its real ~/.openjarvis.
+        """An isolated empty config dir returns the exact no-data response.
+
+        Pinning ``DEFAULT_CONFIG_DIR`` keeps the test independent of the
+        machine's real telemetry database and makes any other response a
+        regression rather than accepting all possible production states.
         """
         import openjarvis.core.config as config_mod
 
@@ -137,11 +134,8 @@ class TestMetricsRoute:
         client = TestClient(_make_app())
         resp = client.get("/metrics")
         assert resp.status_code == 200
-        assert (
-            "openjarvis" in resp.text
-            or "No metrics" in resp.text
-            or "no telemetry data" in resp.text
-        )
+        assert resp.text == "# no telemetry data\n"
+        assert resp.headers["content-type"].startswith("text/plain")
 
 
 class TestSkillRoutes:


### PR DESCRIPTION
## Summary
- Fixes #792: `/metrics` has three valid response states depending on telemetry data availability — Prometheus-formatted output, `"# No metrics available"` for a reachable-but-empty store, or `"# no telemetry data"` when no `telemetry.db` exists at all (the `DEFAULT_CONFIG_DIR` branch). `test_metrics_endpoint`'s assertion only covered the first two (`"openjarvis" in resp.text or "No metrics" in resp.text`) and didn't pin `DEFAULT_CONFIG_DIR` anywhere, so it depended entirely on whether the machine running the test happened to already have telemetry data under its real `~/.openjarvis` — failing on fresh installs and CI where no `telemetry.db` exists yet, and only passing after running `jarvis` normally once.
- Pinned `DEFAULT_CONFIG_DIR` to an empty `tmp_path` (deterministically exercising the "no telemetry data" state instead of leaving it up to chance) and expanded the assertion to accept all three valid states.

## Test plan
- [x] Reproduced the exact failure: with the hermetic `tmp_path` setup in place but the *old* 2-clause assertion, the test fails with `AssertionError: assert ('openjarvis' in '# no telemetry data\n' or 'No metrics' in '# no telemetry data\n')` — the precise flake described in the issue.
- [x] Confirmed it passes with the 3-clause assertion.
- [x] `uv run pytest tests/server/test_api_routes.py` — 14 passed
- [x] `uv run ruff check` on changed files — clean

Branched directly off `main`; applies cleanly independent of #803 (the `/metrics` handler fix for #760, also currently open — that PR adds two more tests to this same class, but this diff doesn't touch them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)