### PR TITLE
fix(channels): fix Telegram send() dropping messages and false success

### DIFF
--- a/src/openjarvis/channels/telegram.py
+++ b/src/openjarvis/channels/telegram.py
@@ -127,6 +127,12 @@ class TelegramChannel(BaseChannel):
                 break_long_words=True,
                 replace_whitespace=False,
             )
+            if not chunks:
+                # Empty content wraps to an empty chunk list -- there is
+                # nothing to send, so this must not fall through to the
+                # success path below and report a message that was never
+                # transmitted (#783).
+                return False
             for chunk in chunks:
                 payload: Dict[str, Any] = {
                     "chat_id": chat_id,
@@ -139,12 +145,28 @@ class TelegramChannel(BaseChannel):
 
                 resp = httpx.post(url, json=payload, timeout=10.0)
                 if resp.status_code >= 300:
-                    logger.warning(
-                        "Telegram API returned status %d: %s",
-                        resp.status_code,
-                        resp.text,
-                    )
-                    return False
+                    # Telegram rejects unparseable Markdown (lone asterisks,
+                    # unclosed code fences, unescaped snake_case
+                    # identifiers, etc.) with a 400 naming the cause in the
+                    # response body. Retry once as plain text instead of
+                    # dropping the message outright (#783).
+                    if self._parse_mode and "can't parse entities" in resp.text.lower():
+                        logger.warning(
+                            "Telegram rejected Markdown formatting, "
+                            "retrying as plain text: %s",
+                            resp.text,
+                        )
+                        plain_payload = {
+                            k: v for k, v in payload.items() if k != "parse_mode"
+                        }
+                        resp = httpx.post(url, json=plain_payload, timeout=10.0)
+                    if resp.status_code >= 300:
+                        logger.warning(
+                            "Telegram API returned status %d: %s",
+                            resp.status_code,
+                            resp.text,
+                        )
+                        return False
             self._publish_sent(channel, content, conversation_id)
             return True
         except Exception:

--- a/tests/channels/test_telegram.py
+++ b/tests/channels/test_telegram.py
@@ -123,6 +123,68 @@ class TestSend:
             # conversation_id becomes the reply reference, not the chat id.
             assert payload["reply_to_message_id"] == "55"
 
+    def test_send_empty_content_returns_false_without_request(self):
+        """Regression for #783: textwrap.wrap("") returns an empty list,
+        so the send loop never runs any HTTP request -- but the method
+        still fell through to publish CHANNEL_MESSAGE_SENT and return
+        True, falsely reporting success for a message that was never
+        transmitted."""
+        bus = EventBus(record_history=True)
+        ch = TelegramChannel(bot_token="123:ABC", bus=bus)
+
+        with patch("httpx.post") as mock_post:
+            result = ch.send("12345678", "")
+            assert result is False
+            mock_post.assert_not_called()
+
+        event_types = [e.event_type for e in bus.history]
+        assert EventType.CHANNEL_MESSAGE_SENT not in event_types
+
+    def test_send_retries_without_markdown_on_parse_error(self):
+        """Regression for #783: Telegram returns 400 with a "can't parse
+        entities" body for unparseable Markdown (lone asterisks, unclosed
+        code fences, snake_case identifiers). The old code treated this
+        the same as any other failure and dropped the message outright
+        instead of retrying as plain text."""
+        ch = TelegramChannel(bot_token="123:ABC")
+
+        markdown_failure = MagicMock()
+        markdown_failure.status_code = 400
+        markdown_failure.text = (
+            '{"ok":false,"description":"Bad Request: can\'t parse entities: '
+            'Character \'_\' is reserved and must be escaped"}'
+        )
+        plain_success = MagicMock()
+        plain_success.status_code = 200
+
+        with patch(
+            "httpx.post", side_effect=[markdown_failure, plain_success]
+        ) as mock_post:
+            result = ch.send("12345678", "some_snake_case_text")
+            assert result is True
+            assert mock_post.call_count == 2
+
+            first_payload = mock_post.call_args_list[0][1]["json"]
+            assert first_payload["parse_mode"] == "Markdown"
+
+            retry_payload = mock_post.call_args_list[1][1]["json"]
+            assert "parse_mode" not in retry_payload
+            assert retry_payload["text"] == "some_snake_case_text"
+
+    def test_send_non_markdown_failure_does_not_retry(self):
+        """A 4xx/5xx that isn't a Markdown parse error must still fail
+        outright, not silently retry and mask a real problem."""
+        ch = TelegramChannel(bot_token="123:ABC")
+
+        server_error = MagicMock()
+        server_error.status_code = 500
+        server_error.text = '{"ok":false,"description":"Internal Server Error"}'
+
+        with patch("httpx.post", return_value=server_error) as mock_post:
+            result = ch.send("12345678", "Hello!")
+            assert result is False
+            mock_post.assert_called_once()
+
     def test_send_legacy_conversation_id_only_still_targets_chat(self):
         """Backwards compatibility: a legacy caller passing the chat id via
         ``conversation_id`` (with an empty ``channel``) still delivers."""


### PR DESCRIPTION
## Summary
- Fixes #783 — two bugs in `TelegramChannel.send()`:
  1. **Empty content silently reports success.** `textwrap.wrap("")` returns an empty list, so the send loop never made any HTTP request, yet the method still fell through to `self._publish_sent(...)` and `return True` — reporting a message as sent when nothing was ever transmitted.
  2. **Markdown parse errors drop messages outright.** Telegram rejects unparseable Markdown (lone asterisks, unclosed code fences, unescaped snake_case identifiers, etc.) with an HTTP 400 whose body names the cause (`"can't parse entities: ..."`). The old code treated this identically to every other 4xx/5xx and dropped the message with no fallback.
- Fix: return `False` immediately when there are no chunks to send. On a `>=300` response, check specifically for `"can't parse entities"` in the body — only for that failure mode, retry the same chunk once as plain text (parse_mode omitted) before giving up. Any other 4xx/5xx still fails immediately and is not retried, so a real problem (bad token, rate limit, etc.) isn't masked.

## Test plan
- [x] `test_send_empty_content_returns_false_without_request`: empty content must return `False`, make no HTTP call, and publish no `CHANNEL_MESSAGE_SENT` event.
- [x] `test_send_retries_without_markdown_on_parse_error`: a 400 with a `"can't parse entities"` body triggers exactly one retry without `parse_mode`, and a subsequent 200 succeeds.
- [x] `test_send_non_markdown_failure_does_not_retry`: a 500 (or any non-Markdown failure) must still fail immediately with no retry, so this fix doesn't mask unrelated errors.
- [x] Confirmed all three fail against the old code (false `True`, false `False`, respectively for the first two — the third already passed as a useful negative control) and pass after the fix.
- [x] `uv run pytest tests/channels/test_telegram.py` — 27 passed
- [x] `uv run pytest tests/channels/` — 782 passed, 1 pre-existing unrelated failure (`whatsapp_baileys` trying to spawn a Node.js subprocess not installed in this environment — nothing to do with Telegram)
- [x] `uv run ruff check` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)