### PR TITLE
fix(skills): prune cyclic skills instead of crashing discovery

### DIFF
--- a/src/openjarvis/skills/dependency.py
+++ b/src/openjarvis/skills/dependency.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections import deque
-from typing import TYPE_CHECKING, Dict, List, Set
+from typing import TYPE_CHECKING, Dict, List, Optional, Set
 
 if TYPE_CHECKING:
     from openjarvis.skills.types import SkillManifest
@@ -11,6 +11,13 @@ if TYPE_CHECKING:
 
 class DependencyCycleError(Exception):
     """Raised when a cycle is detected in the skill dependency graph."""
+
+    def __init__(self, message: str, skills: Optional[Set[str]] = None) -> None:
+        super().__init__(message)
+        # The skills involved in (or downstream of) the cycle, so callers
+        # can prune exactly those rather than parsing the message string
+        # or discarding the whole graph (#781).
+        self.skills: Set[str] = skills if skills is not None else set()
 
 
 class DepthExceededError(Exception):
@@ -101,9 +108,11 @@ def validate_dependencies(
                 queue.append(dependent)
 
     if len(order) != len(graph):
+        cyclic = set(graph) - set(order)
         raise DependencyCycleError(
             "Cycle detected in skill dependency graph. "
-            f"Skills involved: {set(graph) - set(order)}"
+            f"Skills involved: {cyclic}",
+            skills=cyclic,
         )
 
     # --- Depth enforcement via DFS ---

--- a/src/openjarvis/skills/manager.py
+++ b/src/openjarvis/skills/manager.py
@@ -3,17 +3,20 @@
 from __future__ import annotations
 
 import html
+import logging
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from openjarvis.core.events import EventBus
 from openjarvis.core.paths import get_config_dir
-from openjarvis.skills.dependency import validate_dependencies
+from openjarvis.skills.dependency import DependencyCycleError, validate_dependencies
 from openjarvis.skills.executor import SkillExecutor, SkillResult
 from openjarvis.skills.loader import discover_skills
 from openjarvis.skills.tool_adapter import SkillTool
 from openjarvis.skills.types import SkillManifest
 from openjarvis.tools._stubs import BaseTool, ToolExecutor
+
+logger = logging.getLogger(__name__)
 
 
 class SkillManager:
@@ -86,12 +89,40 @@ class SkillManager:
 
             # Validate the dependency graph after loading skills
             if self._skills:
-                validate_dependencies(self._skills)
+                self._prune_dependency_cycles()
 
         # Load optimization overlays (Plan 2A) — always runs, even when no
         # paths are provided, so callers can apply overlays to skills loaded
         # via other means.
         self._load_overlays()
+
+    def _prune_dependency_cycles(self) -> None:
+        """Validate the dependency graph, iteratively dropping any skills
+        involved in a cycle so the rest of discovery still succeeds (#781).
+
+        Previously ``validate_dependencies`` was called unguarded: a single
+        cyclic pair raised ``DependencyCycleError`` straight out of
+        ``discover()``, which crashed CLI callers outright and, in
+        ``SystemBuilder``, was caught by a broad exception handler that
+        silently discarded every discovered skill — not just the cyclic
+        ones. Each pass removes exactly the skills the error identifies as
+        cyclic and re-validates, since removing them can resolve skills
+        that only *looked* stuck because of an edge into the cycle.
+        """
+        while self._skills:
+            try:
+                validate_dependencies(self._skills)
+                return
+            except DependencyCycleError as exc:
+                if not exc.skills:
+                    # No indication of which skills to drop; bail out
+                    # rather than looping forever.
+                    return
+                for name in sorted(exc.skills):
+                    logger.warning(
+                        "Skill '%s' removed: part of a dependency cycle", name
+                    )
+                    self._skills.pop(name, None)
 
     def _load_overlays(self) -> None:
         """Apply optimization overlays to discovered skills.

--- a/tests/skills/test_dependency.py
+++ b/tests/skills/test_dependency.py
@@ -117,6 +117,24 @@ class TestValidateDependencies:
         with pytest.raises(DependencyCycleError):
             validate_dependencies(skills)
 
+    def test_cycle_error_carries_cyclic_skill_names(self):
+        """Regression for #781: callers that want to recover from a cycle
+        (rather than just crash) need to know *which* skills are cyclic
+        without parsing the exception message string."""
+        from openjarvis.skills.dependency import (
+            DependencyCycleError,
+            validate_dependencies,
+        )
+
+        skills = {
+            "a": _manifest("a", depends=["b"]),
+            "b": _manifest("b", depends=["a"]),
+            "c": _manifest("c"),
+        }
+        with pytest.raises(DependencyCycleError) as exc_info:
+            validate_dependencies(skills)
+        assert exc_info.value.skills == {"a", "b"}
+
     def test_cycle_detection_three_nodes(self):
         from openjarvis.skills.dependency import (
             DependencyCycleError,

--- a/tests/skills/test_manager.py
+++ b/tests/skills/test_manager.py
@@ -17,16 +17,22 @@ from openjarvis.tools._stubs import BaseTool, ToolExecutor, ToolSpec  # noqa: F4
 # ---------------------------------------------------------------------------
 
 
-def _write_toml_skill(directory: Path, name: str, description: str = "") -> None:
+def _write_toml_skill(
+    directory: Path,
+    name: str,
+    description: str = "",
+    depends: list[str] | None = None,
+) -> None:
     skill_dir = directory / name
     skill_dir.mkdir(parents=True, exist_ok=True)
+    depends_line = f"depends = {depends!r}\n" if depends else ""
     (skill_dir / "skill.toml").write_text(
         textwrap.dedent(f"""\
             [skill]
             name = "{name}"
             description = "{description or name}"
             tags = ["test"]
-
+            {depends_line}
             [[skill.steps]]
             tool_name = "echo"
             arguments_template = '{{"text": "{{input}}"}}'
@@ -112,6 +118,57 @@ class TestSkillManagerDiscovery:
         names = mgr.skill_names()
         assert "skill_a" in names
         assert "skill_b" in names
+
+
+# ---------------------------------------------------------------------------
+# TestSkillManagerDependencyCycles
+# ---------------------------------------------------------------------------
+
+
+class TestSkillManagerDependencyCycles:
+    """Regression for #781: a dependency cycle between two skills must not
+    crash discovery for every skill. validate_dependencies(self._skills)
+    ran unguarded, so an uncaught DependencyCycleError propagated out of
+    discover() -- in SystemBuilder this was caught by a broad exception
+    handler that silently discarded ALL discovered skills, not just the
+    cyclic pair."""
+
+    def test_discover_does_not_raise_on_cycle(self, tmp_path: Path) -> None:
+        _write_toml_skill(tmp_path, "alpha", depends=["beta"])
+        _write_toml_skill(tmp_path, "beta", depends=["alpha"])
+
+        mgr = SkillManager(bus=EventBus())
+        mgr.discover(paths=[tmp_path])  # must not raise DependencyCycleError
+
+    def test_discover_prunes_only_the_cyclic_pair(self, tmp_path: Path) -> None:
+        """The two mutually-dependent skills are removed; an unrelated,
+        acyclic skill discovered alongside them must remain usable."""
+        _write_toml_skill(tmp_path, "alpha", depends=["beta"])
+        _write_toml_skill(tmp_path, "beta", depends=["alpha"])
+        _write_toml_skill(tmp_path, "gamma")
+
+        mgr = SkillManager(bus=EventBus())
+        mgr.discover(paths=[tmp_path])
+
+        names = mgr.skill_names()
+        assert "alpha" not in names
+        assert "beta" not in names
+        assert "gamma" in names
+        # The surviving skill must still be fully usable, not a stub.
+        manifest = mgr.resolve("gamma")
+        assert manifest.name == "gamma"
+
+    def test_discover_prunes_three_way_cycle(self, tmp_path: Path) -> None:
+        _write_toml_skill(tmp_path, "a", depends=["c"])
+        _write_toml_skill(tmp_path, "b", depends=["a"])
+        _write_toml_skill(tmp_path, "c", depends=["b"])
+        _write_toml_skill(tmp_path, "safe")
+
+        mgr = SkillManager(bus=EventBus())
+        mgr.discover(paths=[tmp_path])
+
+        names = mgr.skill_names()
+        assert names == ["safe"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Fixes #781: `SkillManager.discover()` called `validate_dependencies(self._skills)` unguarded, so a dependency cycle between even one pair of skills raised `DependencyCycleError` uncaught. This propagated through both CLI commands and `SystemBuilder`, where a broad exception handler caught it and silently discarded **every** discovered skill, not just the cyclic pair.
- `DependencyCycleError` now carries a `skills: Set[str]` attribute — the set Kahn's algorithm identified as unresolved (`set(graph) - set(order)`) — instead of only encoding it into the message string, so callers can act on it programmatically.
- New `SkillManager._prune_dependency_cycles()` iteratively removes exactly the skills each cycle involves and re-validates. Repeating (rather than a single pass) matters because removing a cyclic skill can resolve others that only looked stuck due to an edge pointing into the cycle — `build_dependency_graph` already silently drops edges to skills no longer present in the dict, so once the cyclic skills are gone, dependents on them just lose that edge instead of failing again. Acyclic skills remain discoverable and usable; cyclic ones are dropped with a `logger.warning`.
- No changes needed in `SystemBuilder` — it just calls `SkillManager.discover()`, so fixing the root cause there fixes both the CLI and builder paths the issue mentions.

## Test plan
- [x] `test_cycle_error_carries_cyclic_skill_names` (`tests/skills/test_dependency.py`): asserts `DependencyCycleError.skills` matches the actual cyclic pair.
- [x] `TestSkillManagerDependencyCycles` (`tests/skills/test_manager.py`, 3 tests): a 2-skill cycle no longer raises out of `discover()`; an unrelated acyclic skill discovered alongside a cyclic pair survives and remains fully resolvable; a 3-way cycle (a→c→b→a) is pruned entirely, leaving only the unrelated skill.
- [x] Confirmed all four fail against the old code (`AttributeError: no attribute 'skills'`, and uncaught `DependencyCycleError` crashing `discover()`) and pass after the fix.
- [x] `uv run pytest tests/skills/test_dependency.py tests/skills/test_manager.py` — 54 passed
- [x] `uv run pytest tests/skills/` — 281 passed, 4 pre-existing unrelated failures (`test_integration_live.py` — requires a real running inference engine, e.g. `ollama serve`; matches the `-m "not live"` category CI already excludes)
- [x] `uv run ruff check` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)