### PR TITLE
fix(skills): log discover_skills() failures instead of swallowing them

### DIFF
--- a/src/openjarvis/skills/loader.py
+++ b/src/openjarvis/skills/loader.py
@@ -281,7 +281,8 @@ def discover_skills(directory: str | Path) -> list[SkillManifest]:
     for toml_file in sorted(directory.glob("*.toml")):
         try:
             manifests.append(load_skill(toml_file))
-        except Exception:
+        except Exception as exc:
+            LOGGER.warning("Failed to load skill from %s: %s", toml_file, exc)
             continue
 
     # Walk one or two levels deep looking for skill packages
@@ -292,7 +293,8 @@ def discover_skills(directory: str | Path) -> list[SkillManifest]:
         if (child / "skill.toml").exists() or (child / "SKILL.md").exists():
             try:
                 manifests.append(load_skill_directory(child))
-            except Exception:
+            except Exception as exc:
+                LOGGER.warning("Failed to load skill from %s: %s", child, exc)
                 continue
             continue
 
@@ -305,7 +307,10 @@ def discover_skills(directory: str | Path) -> list[SkillManifest]:
             ).exists():
                 try:
                     manifests.append(load_skill_directory(grandchild))
-                except Exception:
+                except Exception as exc:
+                    LOGGER.warning(
+                        "Failed to load skill from %s: %s", grandchild, exc
+                    )
                     continue
 
     return manifests

--- a/tests/skills/test_loader_discover.py
+++ b/tests/skills/test_loader_discover.py
@@ -1,0 +1,75 @@
+"""Tests for discover_skills() failure diagnostics (#780).
+
+All three discovery branches (flat *.toml files, direct skill
+directories, sourced-layout skill directories) used a bare
+`except Exception: continue` with no logging, so a malformed skill
+vanished from the returned list with zero diagnostic output — unlike
+`_read_source_metadata` and `SkillOverlayLoader.load` elsewhere in the
+codebase, which both log a warning on similar failures.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from openjarvis.skills.loader import discover_skills
+
+
+def _write_valid_toml_skill(directory: Path, name: str) -> None:
+    skill_dir = directory / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "skill.toml").write_text(
+        f'[skill]\nname = "{name}"\ndescription = "{name}"\n'
+    )
+
+
+def _write_malformed_toml_skill(directory: Path, name: str) -> None:
+    skill_dir = directory / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "skill.toml").write_text("this is not [valid toml")
+
+
+class TestDiscoverSkillsLogsFailures:
+    def test_malformed_flat_toml_logged(self, tmp_path, caplog):
+        (tmp_path / "broken.toml").write_text("this is not [valid toml")
+
+        with caplog.at_level(logging.WARNING):
+            manifests = discover_skills(tmp_path)
+
+        assert manifests == []
+        messages = [r.message for r in caplog.records]
+        assert any("broken.toml" in m for m in messages), (
+            f"no warning mentioning the bad file; got: {messages}"
+        )
+
+    def test_malformed_skill_directory_logged(self, tmp_path, caplog):
+        _write_malformed_toml_skill(tmp_path, "broken")
+
+        with caplog.at_level(logging.WARNING):
+            manifests = discover_skills(tmp_path)
+
+        assert manifests == []
+        assert any("broken" in r.message for r in caplog.records)
+
+    def test_malformed_sourced_skill_logged(self, tmp_path, caplog):
+        source_dir = tmp_path / "some_source"
+        _write_malformed_toml_skill(source_dir, "broken")
+
+        with caplog.at_level(logging.WARNING):
+            manifests = discover_skills(tmp_path)
+
+        assert manifests == []
+        assert any("broken" in r.message for r in caplog.records)
+
+    def test_valid_skill_alongside_malformed_still_loads(self, tmp_path, caplog):
+        """A malformed skill must not prevent its valid siblings from
+        loading, and its failure must still be logged."""
+        _write_valid_toml_skill(tmp_path, "good")
+        _write_malformed_toml_skill(tmp_path, "bad")
+
+        with caplog.at_level(logging.WARNING):
+            manifests = discover_skills(tmp_path)
+
+        assert [m.name for m in manifests] == ["good"]
+        assert any("bad" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- Fixes #780: all three discovery branches in `discover_skills()` (flat `*.toml` files, direct skill directories, sourced-layout directories) used a bare `except Exception: continue` with no logging. Any skill with a malformed `skill.toml`/`SKILL.md`, invalid TOML syntax, or a missing required field silently vanished from the returned list with zero diagnostic output at any log level — unlike `_read_source_metadata` and `SkillOverlayLoader.load` elsewhere in the same module, which both log a warning on similar failures.
- Added `LOGGER.warning("Failed to load skill from %s: %s", path, exc)` to each of the three handlers before `continue`, matching the module's existing pattern exactly.

## Test plan
- [x] Added `tests/skills/test_loader_discover.py` (`TestDiscoverSkillsLogsFailures`, 4 tests): a malformed flat `.toml` file, a malformed skill directory, and a malformed sourced-layout skill directory each produce a warning-level log record naming the failing path; a valid skill discovered alongside a malformed one still loads successfully while the malformed one's failure is still logged.
- [x] Confirmed all four fail against the old code (`assert False` — no log records at all) and pass after the fix.
- [x] `uv run pytest tests/skills/test_loader_discover.py` — 4 passed
- [x] `uv run pytest tests/skills/` — 285 passed, 4 pre-existing unrelated failures (`test_integration_live.py` — requires a real running inference engine, e.g. `ollama serve`)
- [x] `uv run ruff check` on changed files — clean

Branched directly off `main`; applies cleanly independent of #809 (the dependency-cycle pruning fix for #781, also currently open) — that PR touches `dependency.py`/`manager.py`, this one only touches `loader.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)