### PR TITLE
test(evals): skip table_gen roundtrip test cleanly when polars is absent

### DIFF
--- a/tests/evals/comparison/test_export_to_table_gen_roundtrip.py
+++ b/tests/evals/comparison/test_export_to_table_gen_roundtrip.py
@@ -14,7 +14,11 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from openjarvis.evals.comparison.table_gen import (
+import pytest
+
+pytest.importorskip("polars")
+
+from openjarvis.evals.comparison.table_gen import (  # noqa: E402
     _build_t1,
     load_results,
 )

--- a/tests/evals/comparison/test_export_to_table_gen_roundtrip.py
+++ b/tests/evals/comparison/test_export_to_table_gen_roundtrip.py
@@ -16,18 +16,25 @@ from pathlib import Path
 
 import pytest
 
-pytest.importorskip("polars")
 
-from openjarvis.evals.comparison.table_gen import (  # noqa: E402
-    _build_t1,
-    load_results,
-)
+@pytest.fixture
+def table_gen():
+    """Load the optional Polars-backed helpers only for tests that need them."""
+    pytest.importorskip("polars")
+    from openjarvis.evals.comparison.table_gen import _build_t1, load_results
+
+    return _build_t1, load_results
 
 
 class TestExportToTableGenRoundtrip:
-    def test_summary_json_loads_via_table_gen(self, tmp_path: Path) -> None:
+    def test_summary_json_loads_via_table_gen(
+        self,
+        tmp_path: Path,
+        table_gen,
+    ) -> None:
         """Construct a summary.json mimicking _summary_to_dict output;
         verify table_gen.load_results parses it without skipping."""
+        _, load_results = table_gen
         summary = {
             # Existing rich schema (unchanged)
             "hardware_info": {"gpu": "H100"},
@@ -83,8 +90,13 @@ class TestExportToTableGenRoundtrip:
         assert frame.df["framework"].to_list()[0] == "hermes"
         assert frame.df["framework_commit"].to_list()[0] == "5d3be898a"
 
-    def test_table_gen_builds_t1_from_export_schema(self, tmp_path: Path) -> None:
+    def test_table_gen_builds_t1_from_export_schema(
+        self,
+        tmp_path: Path,
+        table_gen,
+    ) -> None:
         """T1 builder produces non-empty LaTeX from realistic schema."""
+        _build_t1, load_results = table_gen
         for fwk, acc in [("hermes", 0.30), ("openjarvis", 0.45)]:
             summary = {
                 "framework": fwk,


### PR DESCRIPTION
## Summary
- Fixes #786: `openjarvis.evals.comparison.table_gen` does an unconditional `import polars as pl` at module scope and raises `ImportError` if it's missing. `polars` is only in the optional `framework-comparison` extra, not the standard `dev` extra, so importing from `table_gen` at module scope in `test_export_to_table_gen_roundtrip.py` aborted pytest **collection** entirely (`Interrupted: 1 error during collection`) — taking down the whole collection pass, not just skipping this one file.
- Added `pytest.importorskip("polars")` before the `table_gen` import, mirroring the existing pattern already used in the sibling file `tests/evals/comparison/test_table_gen.py`.

## Test plan
- [x] Reproduced the exact collection failure: synced dependencies without the `framework-comparison` extra (`uv sync --extra dev --extra server ...`, no polars) and confirmed `pytest tests/evals/comparison/test_export_to_table_gen_roundtrip.py` aborts with `Interrupted: 1 error during collection` — the precise failure from the issue.
- [x] Applied the fix; same invocation now skips cleanly (`1 skipped`) instead of aborting.
- [x] `uv run pytest tests/evals/ -q --co` — 636 tests collected cleanly (no collection abort) without polars installed.
- [x] Restored polars (`uv sync --extra framework-comparison ...`) and reran both this file and its sibling `test_table_gen.py` — 20 passed, confirming the fix doesn't change behavior when the dependency *is* available.
- [x] `uv run ruff check` on the changed file — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)