### PR TITLE
fix(tests): fix three Windows-only test failures

### DIFF
--- a/tests/evals/comparison/test_openclaw_runner_contract.py
+++ b/tests/evals/comparison/test_openclaw_runner_contract.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -35,9 +36,17 @@ def test_openclaw_runner_parses_real_agent_json_shape(tmp_path: Path) -> None:
         / "src/openjarvis/evals/backends/external/_runners/openclaw_runner.mjs"
     )
     out_json = tmp_path / "out.json"
+    # subprocess.run's `env` REPLACES the environment rather than merging
+    # it, so passing just these two keys wiped everything Node needs to
+    # even start on Windows (TEMP/TMP/SystemRoot/PATH) -- os.tmpdir()
+    # falls back to the literal string 'undefined' when those are unset,
+    # and mkdtemp then fails with ENOENT (#785). Inherit the parent
+    # environment and layer the test-specific overrides on top.
     env = {
+        **os.environ,
         "OPENCLAW_PATH": str(tmp_path),
         "HOME": str(tmp_path / "home"),
+        "USERPROFILE": str(tmp_path / "home"),
     }
     result = subprocess.run(
         [

--- a/tests/evals/core/test_config_split_parsing.py
+++ b/tests/evals/core/test_config_split_parsing.py
@@ -15,7 +15,7 @@ def _write_config(tmp_path: Path, split_value: str | None) -> Path:
 name = "split-parse-test"
 
 [run]
-output_dir = "{tmp_path / "out"}"
+output_dir = "{(tmp_path / "out").as_posix()}"
 seed = 42
 
 [[models]]

--- a/tests/learning/test_trial_runner.py
+++ b/tests/learning/test_trial_runner.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from openjarvis.evals.core.types import RunConfig, RunSummary
@@ -137,7 +138,9 @@ class TestBuildRunConfig:
         cfg = runner._build_run_config(trial, recipe)
 
         assert "trial-abc" in cfg.output_path
-        assert cfg.output_path.startswith("out/")
+        # Path(...) / "..." legitimately produces backslashes on Windows,
+        # so compare path components rather than a hard-coded "out/".
+        assert Path(cfg.output_path).parts[0] == "out"
 
     def test_default_model_fallback(self) -> None:
         runner = TrialRunner(benchmark="supergpqa")


### PR DESCRIPTION
## Summary
Fixes #785 — three independent platform assumptions that broke these tests on Windows while the underlying application code worked correctly:

1. **`test_config_split_parsing.py`**: a raw Windows path (`C:\Users\...\out`) was interpolated directly into a TOML basic string. TOML treats backslashes as escape introducers, so `\Users` parsed as the invalid escape `\U` and `tomllib` rejected the whole config with `TOMLDecodeError: Invalid hex value`. Fixed by rendering the path with `.as_posix()`.
2. **`test_trial_runner.py`**: asserted `cfg.output_path.startswith("out/")`, but `Path(...) / "..."` legitimately produces backslashes on Windows (`'out\trial-abc_qwen3-8b.jsonl'`). Fixed by comparing path components instead: `Path(cfg.output_path).parts[0] == "out"`.
3. **`test_openclaw_runner_contract.py`**: `subprocess.run`'s `env` kwarg **replaces** the environment rather than merging it, so passing only `{OPENCLAW_PATH, HOME}` wiped `TEMP`/`TMP`/`SystemRoot`/`PATH`. Node needs those to even initialize on Windows. Fixed by building env as `{**os.environ, ...overrides}` to inherit the parent's critical variables.

## Test plan
- [x] Confirmed all three fail on this Windows dev machine with the exact failures described in the issue (`tomllib.TOMLDecodeError: Invalid hex value`; `AssertionError` on `startswith("out/")`; for #3, reproduced as a Node native crash — `Assertion failed: ncrypto::CSPRNG(nullptr, 0)` — same root cause of a wiped Windows environment, different visible symptom depending on Node version, since this environment's Node 24 fails earlier during crypto init rather than at `mkdtempSync`).
- [x] Confirmed all three pass after their respective fixes.
- [x] `uv run pytest tests/evals/core/ tests/learning/test_trial_runner.py tests/evals/comparison/` — 103 passed, 3 skipped (unrelated skips)
- [x] `uv run ruff check` on all three changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)