### PR TITLE
fix(frontend): send Bearer auth header on connectors API calls

### DIFF
--- a/frontend/src/lib/connectors-api.auth.test.ts
+++ b/frontend/src/lib/connectors-api.auth.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Regression: every call in connectors-api.ts must go through apiFetch()
+// (not a bare fetch()) so the Bearer auth header is attached when
+// OPENJARVIS_API_KEY is set. Direct fetch() calls silently 401 against an
+// authenticated server -- the same bug class #266 fixed in api.ts, which
+// this file was missed by. Confirmed live: with a real server + API key
+// configured, /v1/connectors 401'd from the browser while every other
+// endpoint (which already went through apiFetch) worked.
+
+const SETTINGS_KEY = 'openjarvis-settings';
+const fetchMock = vi.fn<typeof fetch>();
+
+// Minimal in-memory localStorage stub so the helpers can run under node
+// (no jsdom dependency) -- mirrors api.auth.test.ts.
+class MemoryStorage {
+  private store = new Map<string, string>();
+  getItem(k: string): string | null {
+    return this.store.has(k) ? (this.store.get(k) as string) : null;
+  }
+  setItem(k: string, v: string): void {
+    this.store.set(k, String(v));
+  }
+  removeItem(k: string): void {
+    this.store.delete(k);
+  }
+  clear(): void {
+    this.store.clear();
+  }
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.stubEnv('VITE_SUPABASE_ANON_KEY', 'test-anon-key');
+  fetchMock.mockReset();
+  globalThis.fetch = fetchMock;
+  (globalThis as unknown as { localStorage: MemoryStorage }).localStorage =
+    new MemoryStorage();
+  localStorage.setItem(
+    SETTINGS_KEY,
+    JSON.stringify({ apiKey: 'sk-local-123' }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  (globalThis as unknown as { localStorage?: MemoryStorage }).localStorage =
+    undefined;
+});
+
+async function freshConnectorsApi() {
+  // Re-import to pick up the current localStorage stub.
+  return await import('./connectors-api');
+}
+
+function okJson(body: unknown = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function authHeaderSent(): string | undefined {
+  const [, init] = fetchMock.mock.calls[0] as [string, RequestInit?];
+  const headers = init?.headers as Record<string, string> | undefined;
+  return headers?.Authorization;
+}
+
+describe('connectors-api sends the Bearer auth header', () => {
+  it('listConnectors', async () => {
+    fetchMock.mockResolvedValue(okJson({ connectors: [] }));
+    const { listConnectors } = await freshConnectorsApi();
+    await listConnectors();
+    expect(authHeaderSent()).toBe('Bearer sk-local-123');
+  });
+
+  it('getConnector', async () => {
+    fetchMock.mockResolvedValue(okJson({}));
+    const { getConnector } = await freshConnectorsApi();
+    await getConnector('gmail');
+    expect(authHeaderSent()).toBe('Bearer sk-local-123');
+  });
+
+  it('connectSource', async () => {
+    fetchMock.mockResolvedValue(okJson({}));
+    const { connectSource } = await freshConnectorsApi();
+    await connectSource('gmail', {});
+    expect(authHeaderSent()).toBe('Bearer sk-local-123');
+  });
+
+  it('disconnectSource', async () => {
+    fetchMock.mockResolvedValue(okJson({}));
+    const { disconnectSource } = await freshConnectorsApi();
+    await disconnectSource('gmail');
+    expect(authHeaderSent()).toBe('Bearer sk-local-123');
+  });
+
+  it('getSyncStatus', async () => {
+    fetchMock.mockResolvedValue(okJson({}));
+    const { getSyncStatus } = await freshConnectorsApi();
+    await getSyncStatus('gmail');
+    expect(authHeaderSent()).toBe('Bearer sk-local-123');
+  });
+
+  it('triggerSync', async () => {
+    fetchMock.mockResolvedValue(okJson({}));
+    const { triggerSync } = await freshConnectorsApi();
+    await triggerSync('gmail');
+    expect(authHeaderSent()).toBe('Bearer sk-local-123');
+  });
+});

--- a/frontend/src/lib/connectors-api.ts
+++ b/frontend/src/lib/connectors-api.ts
@@ -1,25 +1,31 @@
-import { getBase } from './api';
+import { apiFetch, getBase } from './api';
 import type { ConnectorInfo, SyncStatus, ConnectRequest, ConnectResponse } from '../types/connectors';
 
 // ---------------------------------------------------------------------------
 // Connectors API
 // ---------------------------------------------------------------------------
+//
+// Every call here must go through apiFetch() (not a bare fetch()) so the
+// Bearer auth header is attached when OPENJARVIS_API_KEY is set -- direct
+// fetch() calls silently 401 against an authenticated server, exactly the
+// bug apiFetch was introduced to prevent elsewhere (#266). This file was
+// missed when that fix landed.
 
 export async function listConnectors(): Promise<ConnectorInfo[]> {
-  const res = await fetch(`${getBase()}/v1/connectors`);
+  const res = await apiFetch('/v1/connectors');
   if (!res.ok) throw new Error(`Failed to list connectors: ${res.status}`);
   const data = await res.json();
   return data.connectors || [];
 }
 
 export async function getConnector(id: string): Promise<ConnectorInfo> {
-  const res = await fetch(`${getBase()}/v1/connectors/${encodeURIComponent(id)}`);
+  const res = await apiFetch(`/v1/connectors/${encodeURIComponent(id)}`);
   if (!res.ok) throw new Error(`Failed to get connector ${id}: ${res.status}`);
   return res.json();
 }
 
 export async function connectSource(id: string, req: ConnectRequest): Promise<ConnectResponse> {
-  const res = await fetch(`${getBase()}/v1/connectors/${encodeURIComponent(id)}/connect`, {
+  const res = await apiFetch(`/v1/connectors/${encodeURIComponent(id)}/connect`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(req),
@@ -60,20 +66,20 @@ export function startServerOAuth(id: string, oauthStartPath?: string): Promise<v
 }
 
 export async function disconnectSource(id: string): Promise<void> {
-  const res = await fetch(`${getBase()}/v1/connectors/${encodeURIComponent(id)}/disconnect`, {
+  const res = await apiFetch(`/v1/connectors/${encodeURIComponent(id)}/disconnect`, {
     method: 'POST',
   });
   if (!res.ok) throw new Error(`Failed to disconnect ${id}: ${res.status}`);
 }
 
 export async function getSyncStatus(id: string): Promise<SyncStatus> {
-  const res = await fetch(`${getBase()}/v1/connectors/${encodeURIComponent(id)}/sync`);
+  const res = await apiFetch(`/v1/connectors/${encodeURIComponent(id)}/sync`);
   if (!res.ok) throw new Error(`Failed to get sync status for ${id}: ${res.status}`);
   return res.json();
 }
 
 export async function triggerSync(id: string): Promise<{ connector_id: string; chunks_indexed: number; status: string }> {
-  const res = await fetch(`${getBase()}/v1/connectors/${encodeURIComponent(id)}/sync`, {
+  const res = await apiFetch(`/v1/connectors/${encodeURIComponent(id)}/sync`, {
     method: 'POST',
   });
   if (!res.ok) {


### PR DESCRIPTION
## Summary
Found this live while walking through first-time setup with an API key configured (required whenever the server binds to a non-loopback address, which `jarvis start`'s default `0.0.0.0` triggers).

- `frontend/src/lib/connectors-api.ts` called `fetch()` directly instead of the shared `apiFetch()` helper (`lib/api.ts`), so every `/v1/connectors` request silently 401'd against a server started with an API key — while every other API module the UI calls (models, info, savings, managed-agents, approvals, ...) worked fine, since they already go through `apiFetch()`.
- This is the exact bug class **#266** fixed elsewhere (`apiFetch()`'s own comment references it directly: *"the bug in #266 was that direct fetch() calls omitted the header and 401'd"*) — this file was just missed when that fix landed.
- **Confirmed live**, not just by reading the code: with a real `jarvis serve` instance running and an API key configured, `GET /v1/connectors` 401'd from the browser (via the Vite dev proxy) while an identical `curl` request with the same Bearer token succeeded against the backend directly, and every other endpoint the frontend called worked normally — isolating the bug specifically to this file's missing auth header, not a server- or proxy-side issue. The user-facing symptom: the entire **Data Sources** page gets stuck on "Loading sources..." forever whenever an API key is set.
- Switched all six `fetch()` calls (`listConnectors`, `getConnector`, `connectSource`, `disconnectSource`, `getSyncStatus`, `triggerSync`) to `apiFetch()`, which injects the header automatically. The OAuth popup flow (`window.open`) is unaffected — browser navigation can't carry custom headers regardless, and that consent-flow entry point is exempted server-side through a different mechanism.

## Test plan
- [x] Added `connectors-api.auth.test.ts` (mirrors the existing `api.auth.test.ts` pattern for #266): asserts all six functions send `Authorization: Bearer <key>` when a key is configured.
- [x] Confirmed all six fail against the old code (`expected undefined to be 'Bearer sk-local-123'`) and pass after the fix.
- [x] `npx vitest run` (full frontend suite) — 38 passed, no regressions.
- [x] `npx tsc -b --noEmit` — clean.
- [x] Re-verified in the actual running app after the fix: the Data Sources page loads correctly, showing all 24 available connectors plus the one already connected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)