### PR TITLE
chore(desktop): rotate Tauri updater pubkey to match new signing key

### DIFF
--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -58,7 +58,7 @@
   "plugins": {
     "updater": {
       "active": true,
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDFFNzUzMzhEOEY2MjNEMDMKUldRRFBXS1BqVE4xSG8vK0lkUWN4WnZQYVIrbmc4RmpoOGlJWTBLTE15RlIya3JvQisvdUR3a0QK",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEQ2Njc2MUY0NENEQTkxMkIKUldRcmtkcE05R0ZuMXVZTzExVkJtcjZLMzRIM0Q4bmk1QWVmVFM5bjkyZEYwS0krTXg0aE9ybGkK",
       "endpoints": [
         "https://github.com/open-jarvis/OpenJarvis/releases/download/desktop-latest/latest.json"
       ]


### PR DESCRIPTION
## What

Rotates the committed Tauri updater `pubkey` in `frontend/src-tauri/tauri.conf.json` to the newly generated keypair.

## Why

The updater keypair was regenerated locally. The previously shipped `pubkey` no longer has a matching private key, so CI-signed releases (which read `TAURI_SIGNING_PRIVATE_KEY` from repo secrets) would be rejected by the installed app's verification step. This commits the new public key so the two stay in sync.

## Action required before next desktop release

The matching private key must be set as the repo secret `TAURI_SIGNING_PRIVATE_KEY` (and `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` if the key is encrypted). The new key is unencrypted, so only `TAURI_SIGNING_PRIVATE_KEY` is needed.

The existing `desktop.yml` workflow already signs on publish via `tauri-action` with `includeUpdaterJson: true` and passes these secrets through (lines 351-354, 367) — no workflow change is required, only the secret value rotation.

## Note

This PR deliberately touches only `tauri.conf.json`. Other locally modified files (Cargo.toml, tsconfig.tsbuildinfo, research_loop.py) are unrelated to this change and were left out.