### PR TITLE
feat(desktop): auto-create desktop shortcut on install

### DIFF
--- a/frontend/src-tauri/installer-hooks.nsh
+++ b/frontend/src-tauri/installer-hooks.nsh
@@ -1,0 +1,15 @@
+; NSIS installer hooks for OpenJarvis desktop build.
+; Called by tauri-bundler via bundle.windows.nsis.installerHooks.
+;
+; NSIS_HOOK_POSTINSTALL runs after files are copied, registry keys are set,
+; and the default Start Menu shortcut is created. We use it to ALSO drop a
+; desktop shortcut automatically (the default Tauri finish-page checkbox is
+; opt-in; we want it on by default).
+;
+; CreateOrUpdateDesktopShortcut is defined in Tauri's generated installer.nsi
+; (creates $DESKTOP\${PRODUCTNAME}.lnk -> $INSTDIR\${MAINBINARYNAME}.exe) and is
+; already in scope, so we just invoke it.
+
+!macro NSIS_HOOK_POSTINSTALL
+  Call CreateOrUpdateDesktopShortcut
+!macroend

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -52,7 +52,10 @@
     "windows": {
       "certificateThumbprint": null,
       "digestAlgorithm": "sha256",
-      "timestampUrl": "http://timestamp.digicert.com"
+      "timestampUrl": "http://timestamp.digicert.com",
+      "nsis": {
+        "installerHooks": "installer-hooks.nsh"
+      }
     }
   },
   "plugins": {


### PR DESCRIPTION
## Summary
Makes the OpenJarvis desktop installer drop a **desktop shortcut automatically** on every install, without requiring the user to tick the finish-page checkbox.

- Adds `frontend/src-tauri/installer-hooks.nsh` — an NSIS `NSIS_HOOK_POSTINSTALL` hook that calls Tauri's built-in `CreateOrUpdateDesktopShortcut` (creates `$DESKTOP\OpenJarvis.lnk` -> the installed `openjarvis-desktop.exe`).
- Wires it into `frontend/src-tauri/tauri.conf.json` via `bundle.windows.nsis.installerHooks`.

## Why
Tauri v2's default NSIS installer only creates a desktop shortcut behind an opt-in finish-page checkbox (unchecked by default). This makes the desktop icon appear automatically, matching user expectation for a desktop app.

## How it was verified
- Rebuilt the NSIS installer: `BUILD_EXIT=0`; generated `installer.nsi` includes `!include "installer-hooks.nsh"` and `!insertmacro NSIS_HOOK_POSTINSTALL` post-install.
- Silent-install test (`setup.exe /S`) created `OpenJarvis.lnk` on the desktop automatically; target verified to exist; icon resolves to the exe's embedded `icon.ico`.

## Notes / scope
- This PR is intentionally **independent of the pubkey rotation (PR #829)** — it only touches the `nsis` subkey of `bundle.windows`, so the two PRs do not conflict.
- `installer-hooks.nsh` is a build-time input only; the signing key is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)