### PR TITLE
Add App Launcher tool — open/close installed desktop apps by name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,7 @@ desktop = [
     "faster-whisper>=1.0",
 ]
 openhands = ["openhands-sdk>=1.0; python_version >= '3.12'"]
+app-launcher = ["pywin32>=306; sys_platform == 'win32'"]
 gpu-metrics = ["pynvml>=12.0"]
 energy-amd = ["amdsmi>=6.1"]
 energy-apple = ["zeus-ml[apple]"]

--- a/src/openjarvis/tools/__init__.py
+++ b/src/openjarvis/tools/__init__.py
@@ -152,4 +152,9 @@ try:
 except ImportError:
     pass
 
+try:
+    import openjarvis.tools.app_launcher  # noqa: F401
+except ImportError:
+    pass
+
 __all__ = ["BaseTool", "ToolExecutor", "ToolSpec"]

--- a/src/openjarvis/tools/app_launcher.py
+++ b/src/openjarvis/tools/app_launcher.py
@@ -1,0 +1,642 @@
+"""App Launcher tool — open/close already-installed desktop applications by name.
+
+Discovers installed programs from the OS's own registries of installed
+software (Windows: the ``App Paths`` registry key and Start Menu shortcuts)
+rather than depending on a hardcoded path. Deliberately narrow in scope:
+
+- Never installs new software (no "install" action exists at all).
+- Never runs a file the caller supplies directly — the only input is a free-
+  text ``app_name``; every launchable path comes from OS-level discovery of
+  *already installed* programs, never from an arbitrary caller-provided path.
+- Never requests administrator elevation (plain, unelevated process start).
+
+Currently implements full discovery on Windows (the ``sys.platform`` this
+project is being used on); macOS/Linux fall back to a minimal PATH-only
+lookup rather than crashing.
+"""
+
+from __future__ import annotations
+
+import difflib
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+import unicodedata
+import webbrowser
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from openjarvis.core.registry import ToolRegistry
+from openjarvis.core.types import ToolResult
+from openjarvis.tools._stubs import BaseTool, ToolSpec
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class AppEntry:
+    """A discovered installed application (or a running process, for close)."""
+
+    name: str
+    path: str
+    source: str = ""  # "app_paths" | "start_menu" | "path" | "process"
+
+
+@dataclass(slots=True)
+class MatchOutcome:
+    """Result of matching a spoken/typed name against discovered candidates."""
+
+    status: str  # "found" | "not_found" | "ambiguous"
+    match: Optional[AppEntry] = None
+    candidates: List[AppEntry] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Nickname normalization — maps a spoken generic term to search terms or a
+# well-known OS command name (never a hardcoded absolute install path).
+# ---------------------------------------------------------------------------
+
+_DEFAULT_BROWSER_TERMS = {"navegador", "navegador padrao", "browser", "default browser"}
+
+_ALIASES: Dict[str, List[str]] = {
+    "calculadora": ["calc", "calculator"],
+    "calculator": ["calc", "calculator"],
+    "bloco de notas": ["notepad"],
+    "notepad": ["notepad"],
+    "paint": ["mspaint", "paint"],
+    "explorador de arquivos": ["explorer", "file explorer"],
+    "file explorer": ["explorer", "file explorer"],
+    "terminal": ["windows terminal", "wt"],
+    "prompt de comando": ["cmd"],
+    "chrome": ["chrome", "google chrome"],
+    "google chrome": ["chrome", "google chrome"],
+    "edge": ["msedge", "microsoft edge"],
+    "microsoft edge": ["msedge", "microsoft edge"],
+    "firefox": ["firefox", "mozilla firefox"],
+    "word": ["winword", "microsoft word"],
+    "excel": ["excel", "microsoft excel"],
+    "vscode": ["code", "visual studio code"],
+    "vs code": ["code", "visual studio code"],
+    "visual studio code": ["code", "visual studio code"],
+}
+
+
+def _strip_accents(text: str) -> str:
+    return "".join(
+        c for c in unicodedata.normalize("NFKD", text) if not unicodedata.combining(c)
+    )
+
+
+def _normalize(text: str) -> str:
+    text = _strip_accents((text or "").strip().lower())
+    text = re.sub(r"\.(exe|lnk|app)$", "", text)
+    text = re.sub(r"[^a-z0-9 ]+", " ", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    return text
+
+
+def _expand_query_terms(query: str) -> List[str]:
+    norm = _normalize(query)
+    terms = [norm]
+    if norm in _ALIASES:
+        terms.extend(_normalize(t) for t in _ALIASES[norm])
+    return terms
+
+
+def is_default_browser_query(app_name: str) -> bool:
+    return _normalize(app_name) in _DEFAULT_BROWSER_TERMS
+
+
+# ---------------------------------------------------------------------------
+# Discovery — Windows: App Paths registry + Start Menu shortcuts + PATH.
+# Best-effort PATH-only fallback on other platforms.
+# ---------------------------------------------------------------------------
+
+
+def _discover_app_paths_registry() -> List[AppEntry]:
+    if sys.platform != "win32":
+        return []
+    try:
+        import winreg
+    except ImportError:
+        return []
+
+    entries: List[AppEntry] = []
+    roots = [
+        (
+            winreg.HKEY_LOCAL_MACHINE,
+            r"SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths",
+        ),
+        (
+            winreg.HKEY_CURRENT_USER,
+            r"SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths",
+        ),
+    ]
+    for hive, subkey in roots:
+        try:
+            with winreg.OpenKey(hive, subkey) as key:
+                i = 0
+                while True:
+                    try:
+                        name = winreg.EnumKey(key, i)
+                    except OSError:
+                        break
+                    i += 1
+                    try:
+                        with winreg.OpenKey(key, name) as app_key:
+                            path, _ = winreg.QueryValueEx(app_key, "")
+                    except OSError:
+                        continue
+                    if path:
+                        display = re.sub(r"\.exe$", "", name, flags=re.IGNORECASE)
+                        entries.append(
+                            AppEntry(name=display, path=path, source="app_paths")
+                        )
+        except OSError:
+            continue
+    return entries
+
+
+def _start_menu_dirs() -> List[Path]:
+    dirs: List[Path] = []
+    program_data = os.environ.get("ProgramData")
+    if program_data:
+        dirs.append(
+            Path(program_data) / "Microsoft" / "Windows" / "Start Menu" / "Programs"
+        )
+    app_data = os.environ.get("APPDATA")
+    if app_data:
+        dirs.append(
+            Path(app_data) / "Microsoft" / "Windows" / "Start Menu" / "Programs"
+        )
+    return [d for d in dirs if d.is_dir()]
+
+
+def _resolve_shortcut_target(lnk_path: str) -> Optional[str]:
+    """Resolve a .lnk shortcut's target path via the Windows Shell COM API."""
+    try:
+        import win32com.client  # type: ignore[import-not-found]
+
+        shell = win32com.client.Dispatch("WScript.Shell")
+        shortcut = shell.CreateShortcut(lnk_path)
+        target = shortcut.Targetpath
+        return target or None
+    except Exception:  # noqa: BLE001 - pywin32 missing, or a malformed shortcut
+        return None
+
+
+def _discover_start_menu_apps() -> List[AppEntry]:
+    if sys.platform != "win32":
+        return []
+    entries: List[AppEntry] = []
+    for base in _start_menu_dirs():
+        try:
+            lnk_files = list(base.rglob("*.lnk"))
+        except OSError:
+            continue
+        for lnk in lnk_files:
+            target = _resolve_shortcut_target(str(lnk))
+            if not target:
+                continue
+            entries.append(AppEntry(name=lnk.stem, path=target, source="start_menu"))
+    return entries
+
+
+# Small in-memory cache: Start Menu scanning resolves each shortcut via COM,
+# which has real per-call overhead — avoid re-scanning on every tool call.
+_CACHE_TTL_SECONDS = 300.0
+_discovery_cache: Optional[Tuple[float, List[AppEntry]]] = None
+
+
+def discover_apps(*, force_refresh: bool = False) -> List[AppEntry]:
+    """Return all discovered installed applications (cached for a few minutes)."""
+    global _discovery_cache
+    now = time.time()
+    if (
+        not force_refresh
+        and _discovery_cache is not None
+        and now - _discovery_cache[0] < _CACHE_TTL_SECONDS
+    ):
+        return _discovery_cache[1]
+
+    entries = _discover_app_paths_registry() + _discover_start_menu_apps()
+    _discovery_cache = (now, entries)
+    return entries
+
+
+# ---------------------------------------------------------------------------
+# Matching — pure functions, independent of discovery, for easy testing.
+# ---------------------------------------------------------------------------
+
+
+def find_app(query: str, candidates: List[AppEntry]) -> MatchOutcome:
+    """Match *query* (a free-text app name) against discovered *candidates*.
+
+    Three ordered phases, each trying exact-then-substring matching only
+    (no fuzzy matching yet):
+      1. The raw query term alone.
+      2. Alias-expansion terms (e.g. "calculadora" -> "calc"), only if (1)
+         found nothing — this matters for ambiguity: if the user says
+         "chrome" and both "Google Chrome" and "Google Chrome Canary" are
+         installed, the raw term "chrome" substring-matches both and
+         correctly asks which one; pulling in an alias's exact-match term
+         at the same time would instead silently pick one and hide the
+         other.
+      4. Fuzzy matching (difflib) against every term (raw + alias) combined,
+         tried last and only when phases 1-2 found nothing at all — kept
+         separate from the earlier phases because a lenient fuzzy cutoff can
+         produce coincidental false positives (e.g. "calculadora" ~ "CapCut")
+         that would otherwise block a perfectly good alias match.
+    """
+    if not candidates:
+        return MatchOutcome(status="not_found")
+
+    raw_term = _normalize(query)
+    if not raw_term:
+        return MatchOutcome(status="not_found")
+
+    outcome = _match_precise([raw_term], candidates)
+    if outcome.status != "not_found":
+        return outcome
+
+    alias_terms = [_normalize(t) for t in _ALIASES.get(raw_term, []) if t]
+    if alias_terms:
+        outcome = _match_precise(alias_terms, candidates)
+        if outcome.status != "not_found":
+            return outcome
+
+    # Fuzzy matching is deliberately only tried against the user's own raw
+    # term, never against alias terms — an alias is already a precise,
+    # curated name; if it has no exact/substring match, that means the app
+    # genuinely isn't discoverable, and fuzzy-matching a short alias like
+    # "calc" against unrelated app names produces false positives (e.g.
+    # "calc"/"calculator" ~ "CapCut" both score above a 0.6 cutoff).
+    return _match_fuzzy([raw_term], candidates)
+
+
+def _match_precise(terms: List[str], candidates: List[AppEntry]) -> MatchOutcome:
+    """Exact, then substring, matching for *terms* against *candidates*."""
+    terms = [t for t in terms if t]
+    if not terms:
+        return MatchOutcome(status="not_found")
+
+    exact = _unique_by_path([c for c in candidates if _normalize(c.name) in terms])
+    if exact:
+        return _group_outcome(exact)
+
+    substring_matches = _unique_by_path(
+        [
+            c
+            for c in candidates
+            if any(
+                t in (norm_name := _normalize(c.name)) or norm_name in t for t in terms
+            )
+        ]
+    )
+    if substring_matches:
+        return _group_outcome(substring_matches)
+
+    return MatchOutcome(status="not_found")
+
+
+def _match_fuzzy(terms: List[str], candidates: List[AppEntry]) -> MatchOutcome:
+    """Fuzzy (difflib) matching for *terms* against *candidates* — last resort."""
+    name_to_entries: Dict[str, List[AppEntry]] = {}
+    for c in candidates:
+        name_to_entries.setdefault(_normalize(c.name), []).append(c)
+
+    fuzzy_matches: List[AppEntry] = []
+    for term in terms:
+        close = difflib.get_close_matches(
+            term, list(name_to_entries.keys()), n=5, cutoff=0.6
+        )
+        for name in close:
+            fuzzy_matches.extend(name_to_entries[name])
+
+    fuzzy_matches = _unique_by_path(fuzzy_matches)[:5]
+    if fuzzy_matches:
+        return _group_outcome(fuzzy_matches)
+    return MatchOutcome(status="not_found")
+
+
+def _unique_by_path(entries: List[AppEntry]) -> List[AppEntry]:
+    seen: set = set()
+    unique: List[AppEntry] = []
+    for e in entries:
+        if e.path not in seen:
+            seen.add(e.path)
+            unique.append(e)
+    return unique
+
+
+def _group_outcome(matches: List[AppEntry]) -> MatchOutcome:
+    """Collapse matches into found/ambiguous, grouping by *display name*.
+
+    Candidates that share the same normalized display name but different
+    paths (e.g. two shortcuts both literally named "Discord" — one via the
+    Update.exe wrapper, one pointing at the versioned exe) are not
+    meaningfully distinguishable to the user either, so they collapse to one
+    representative entry (preferring an ``app_paths``-sourced entry, the
+    more canonical source, over a Start Menu shortcut). Genuine ambiguity —
+    different *names* — is what actually gets surfaced.
+    """
+    by_name: Dict[str, List[AppEntry]] = {}
+    for m in matches:
+        by_name.setdefault(_normalize(m.name), []).append(m)
+
+    if len(by_name) == 1:
+        group = next(iter(by_name.values()))
+        representative = next((e for e in group if e.source == "app_paths"), group[0])
+        return MatchOutcome(status="found", match=representative)
+
+    representatives = [group[0] for group in by_name.values()]
+    return MatchOutcome(status="ambiguous", candidates=representatives)
+
+
+# ---------------------------------------------------------------------------
+# Launching / closing
+# ---------------------------------------------------------------------------
+
+
+def _executable_exists(path: str) -> bool:
+    """Check whether *path* is a real file or resolvable via PATH."""
+    return Path(path).exists() or bool(shutil.which(path))
+
+
+def _launch_default_browser() -> Tuple[bool, str]:
+    try:
+        ok = webbrowser.open("about:blank")
+        return (
+            (True, "")
+            if ok
+            else (False, "Nenhum navegador padrão configurado no sistema.")
+        )
+    except Exception as exc:  # noqa: BLE001
+        return False, str(exc)
+
+
+def _launch_path(path: str) -> Tuple[bool, str]:
+    """Start *path* as a normal, unelevated process (never via a shell)."""
+    try:
+        if sys.platform == "win32":
+            os.startfile(path)  # noqa: S606 - path came from OS-level app discovery only
+        else:
+            subprocess.Popen([path])
+        return True, ""
+    except Exception as exc:  # noqa: BLE001
+        return False, str(exc)
+
+
+def _list_running_processes() -> List[AppEntry]:
+    if sys.platform != "win32":
+        return []
+    try:
+        result = subprocess.run(
+            ["tasklist", "/FO", "CSV", "/NH"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except Exception:  # noqa: BLE001
+        return []
+    entries: List[AppEntry] = []
+    for line in result.stdout.splitlines():
+        parts = [p.strip('"') for p in line.split('","')]
+        if len(parts) < 2:
+            continue
+        name = parts[0].lstrip('"')
+        try:
+            pid = int(parts[1])
+        except ValueError:
+            continue
+        entries.append(
+            AppEntry(
+                name=re.sub(r"\.exe$", "", name, flags=re.IGNORECASE),
+                path=str(pid),
+                source="process",
+            )
+        )
+    return entries
+
+
+def _terminate_process(pid: int) -> Tuple[bool, str]:
+    """Gracefully close a process by PID, escalating to a forced kill if needed."""
+    try:
+        graceful = subprocess.run(
+            ["taskkill", "/PID", str(pid), "/T"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if graceful.returncode == 0:
+            return True, ""
+        forced = subprocess.run(
+            ["taskkill", "/PID", str(pid), "/T", "/F"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if forced.returncode == 0:
+            return True, ""
+        return False, (forced.stderr or graceful.stderr or "").strip()
+    except Exception as exc:  # noqa: BLE001
+        return False, str(exc)
+
+
+# ---------------------------------------------------------------------------
+# Tool
+# ---------------------------------------------------------------------------
+
+
+@ToolRegistry.register("app_launcher")
+class AppLauncherTool(BaseTool):
+    """Open or close an already-installed desktop application by name."""
+
+    tool_id = "app_launcher"
+
+    @property
+    def spec(self) -> ToolSpec:
+        return ToolSpec(
+            name="app_launcher",
+            description=(
+                "Open or close an already-installed desktop application by name "
+                "(e.g. 'Chrome', 'calculadora', 'Discord'). Discovers installed "
+                "programs from the OS's own registry of installed software and "
+                "Start Menu shortcuts — never installs new software, never runs "
+                "a caller-supplied file path, and never requests administrator "
+                "elevation. If the name is ambiguous, returns the list of "
+                "matching applications instead of guessing."
+            ),
+            parameters={
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["open", "close"],
+                        "description": "Whether to open or close the application.",
+                    },
+                    "app_name": {
+                        "type": "string",
+                        "description": (
+                            "The application's name as spoken/typed by the user "
+                            "(e.g. 'Chrome', 'calculadora', 'navegador')."
+                        ),
+                    },
+                },
+                "required": ["action", "app_name"],
+            },
+            category="system",
+            required_capabilities=["code:execute"],
+            timeout_seconds=15.0,
+        )
+
+    def execute(self, **params: Any) -> ToolResult:
+        action = params.get("action", "open")
+        app_name = (params.get("app_name") or "").strip()
+        if not app_name:
+            return ToolResult(
+                tool_name="app_launcher",
+                content="Informe o nome do aplicativo.",
+                success=False,
+            )
+
+        if action == "open":
+            return self._open(app_name)
+        if action == "close":
+            return self._close(app_name)
+        return ToolResult(
+            tool_name="app_launcher",
+            content=f"Ação desconhecida: {action!r} (use 'open' ou 'close').",
+            success=False,
+        )
+
+    def _open(self, app_name: str) -> ToolResult:
+        if is_default_browser_query(app_name):
+            ok, err = _launch_default_browser()
+            if ok:
+                return ToolResult(
+                    tool_name="app_launcher",
+                    content="Abrindo o navegador padrão.",
+                    success=True,
+                    metadata={"app": "default_browser"},
+                )
+            return ToolResult(
+                tool_name="app_launcher",
+                content=f"Não consegui abrir o navegador padrão: {err}",
+                success=False,
+            )
+
+        candidates = discover_apps()
+        outcome = find_app(app_name, candidates)
+
+        if outcome.status == "not_found":
+            return ToolResult(
+                tool_name="app_launcher",
+                content=f"Não encontrei o aplicativo '{app_name}' instalado.",
+                success=False,
+            )
+
+        if outcome.status == "ambiguous":
+            names = sorted({c.name for c in outcome.candidates})
+            return ToolResult(
+                tool_name="app_launcher",
+                content=(
+                    f"Encontrei mais de um aplicativo parecido com '{app_name}': "
+                    f"{', '.join(names)}. Qual deles você quer abrir?"
+                ),
+                success=False,
+                metadata={"ambiguous": True, "candidates": names},
+            )
+
+        entry = outcome.match
+        assert entry is not None
+        if not _executable_exists(entry.path):
+            return ToolResult(
+                tool_name="app_launcher",
+                content=(
+                    f"O executável de '{entry.name}' não foi encontrado em "
+                    f"'{entry.path}' (pode ter sido desinstalado)."
+                ),
+                success=False,
+            )
+
+        ok, err = _launch_path(entry.path)
+        if not ok:
+            return ToolResult(
+                tool_name="app_launcher",
+                content=f"Não consegui abrir '{entry.name}': {err}",
+                success=False,
+            )
+        return ToolResult(
+            tool_name="app_launcher",
+            content=f"Abrindo {entry.name}.",
+            success=True,
+            metadata={"app": entry.name, "path": entry.path},
+        )
+
+    def _close(self, app_name: str) -> ToolResult:
+        running = _list_running_processes()
+        if not running:
+            return ToolResult(
+                tool_name="app_launcher",
+                content=(
+                    "Não consegui listar os processos em execução neste sistema."
+                    if sys.platform == "win32"
+                    else "Fechar aplicativos por nome não é suportado nesta plataforma."
+                ),
+                success=False,
+            )
+
+        outcome = find_app(app_name, running)
+
+        if outcome.status == "not_found":
+            return ToolResult(
+                tool_name="app_launcher",
+                content=f"'{app_name}' não parece estar em execução.",
+                success=False,
+            )
+
+        if outcome.status == "ambiguous":
+            names = sorted({c.name for c in outcome.candidates})
+            return ToolResult(
+                tool_name="app_launcher",
+                content=(
+                    f"Encontrei mais de um processo parecido com '{app_name}': "
+                    f"{', '.join(names)}. Qual deles você quer fechar?"
+                ),
+                success=False,
+                metadata={"ambiguous": True, "candidates": names},
+            )
+
+        entry = outcome.match
+        assert entry is not None
+        pid = int(entry.path)
+        ok, err = _terminate_process(pid)
+        if not ok:
+            return ToolResult(
+                tool_name="app_launcher",
+                content=f"Não consegui fechar '{entry.name}': {err}",
+                success=False,
+            )
+        return ToolResult(
+            tool_name="app_launcher",
+            content=f"{entry.name} foi fechado.",
+            success=True,
+            metadata={"app": entry.name, "pid": pid},
+        )
+
+
+__all__ = [
+    "AppEntry",
+    "AppLauncherTool",
+    "MatchOutcome",
+    "discover_apps",
+    "find_app",
+    "is_default_browser_query",
+]

--- a/tests/tools/test_app_launcher.py
+++ b/tests/tools/test_app_launcher.py
@@ -1,0 +1,204 @@
+"""Tests for the app_launcher tool."""
+
+from __future__ import annotations
+
+import openjarvis.tools.app_launcher as app_launcher
+from openjarvis.tools.app_launcher import (
+    AppEntry,
+    AppLauncherTool,
+    find_app,
+    is_default_browser_query,
+)
+
+
+def _entries(*pairs):
+    return [AppEntry(name=name, path=path, source="test") for name, path in pairs]
+
+
+class TestNormalizeAndAliases:
+    def test_default_browser_terms_recognized(self):
+        assert is_default_browser_query("navegador") is True
+        assert is_default_browser_query("browser") is True
+        assert is_default_browser_query("Navegador Padrão") is True
+        assert is_default_browser_query("chrome") is False
+
+
+class TestFindApp:
+    def test_exact_match(self):
+        candidates = _entries(
+            ("Chrome", "C:/chrome.exe"), ("Discord", "C:/discord.exe")
+        )
+        outcome = find_app("Chrome", candidates)
+        assert outcome.status == "found"
+        assert outcome.match.name == "Chrome"
+
+    def test_no_candidates_not_found(self):
+        outcome = find_app("Chrome", [])
+        assert outcome.status == "not_found"
+
+    def test_no_match_not_found(self):
+        candidates = _entries(("Discord", "C:/discord.exe"))
+        outcome = find_app("Photoshop", candidates)
+        assert outcome.status == "not_found"
+
+    def test_ambiguous_close_matches(self):
+        candidates = _entries(
+            ("Google Chrome", "C:/chrome.exe"),
+            ("Google Chrome Canary", "C:/chrome_canary.exe"),
+        )
+        outcome = find_app("chrome", candidates)
+        assert outcome.status == "ambiguous"
+        names = {c.name for c in outcome.candidates}
+        assert "Google Chrome" in names
+        assert "Google Chrome Canary" in names
+
+    def test_alias_resolves_to_known_command(self):
+        candidates = _entries(("calc", "C:/Windows/System32/calc.exe"))
+        outcome = find_app("calculadora", candidates)
+        assert outcome.status == "found"
+        assert outcome.match.name == "calc"
+
+    def test_duplicate_path_collapses_to_single_match(self):
+        # Same underlying app discovered twice (e.g. App Paths + Start Menu).
+        candidates = _entries(
+            ("Discord", "C:/discord.exe"), ("Discord", "C:/discord.exe")
+        )
+        outcome = find_app("Discord", candidates)
+        assert outcome.status == "found"
+
+
+class TestAppLauncherToolOpen:
+    def test_open_missing_app_name(self):
+        tool = AppLauncherTool()
+        result = tool.execute(action="open", app_name="")
+        assert result.success is False
+
+    def test_open_unknown_action(self):
+        tool = AppLauncherTool()
+        result = tool.execute(action="frobnicate", app_name="Chrome")
+        assert result.success is False
+
+    def test_open_found_launches(self, monkeypatch):
+        candidates = _entries(("Chrome", "C:/chrome.exe"))
+        monkeypatch.setattr(app_launcher, "discover_apps", lambda: candidates)
+        monkeypatch.setattr(app_launcher, "_executable_exists", lambda p: True)
+        launched = {}
+
+        def fake_launch(path):
+            launched["path"] = path
+            return True, ""
+
+        monkeypatch.setattr(app_launcher, "_launch_path", fake_launch)
+
+        tool = AppLauncherTool()
+        result = tool.execute(action="open", app_name="Chrome")
+        assert result.success is True
+        assert "Chrome" in result.content
+        assert launched["path"] == "C:/chrome.exe"
+
+    def test_open_not_found_warns_clearly(self, monkeypatch):
+        monkeypatch.setattr(app_launcher, "discover_apps", lambda: [])
+        tool = AppLauncherTool()
+        result = tool.execute(action="open", app_name="Photoshop")
+        assert result.success is False
+        assert "Photoshop" in result.content
+        assert "não encontrei" in result.content.lower()
+
+    def test_open_ambiguous_asks_which_one(self, monkeypatch):
+        candidates = _entries(
+            ("Google Chrome", "C:/chrome.exe"),
+            ("Google Chrome Canary", "C:/chrome_canary.exe"),
+        )
+        monkeypatch.setattr(app_launcher, "discover_apps", lambda: candidates)
+        tool = AppLauncherTool()
+        result = tool.execute(action="open", app_name="chrome")
+        assert result.success is False
+        assert result.metadata.get("ambiguous") is True
+        assert "Google Chrome" in result.content
+        assert "Google Chrome Canary" in result.content
+
+    def test_open_missing_executable_reports_clearly(self, monkeypatch):
+        candidates = _entries(("Uninstalled App", "C:/nowhere/app.exe"))
+        monkeypatch.setattr(app_launcher, "discover_apps", lambda: candidates)
+        monkeypatch.setattr(app_launcher, "_executable_exists", lambda p: False)
+        tool = AppLauncherTool()
+        result = tool.execute(action="open", app_name="Uninstalled App")
+        assert result.success is False
+        assert "desinstalado" in result.content.lower()
+
+    def test_open_launch_failure_surfaces_error(self, monkeypatch):
+        candidates = _entries(("Chrome", "C:/chrome.exe"))
+        monkeypatch.setattr(app_launcher, "discover_apps", lambda: candidates)
+        monkeypatch.setattr(app_launcher, "_executable_exists", lambda p: True)
+        monkeypatch.setattr(
+            app_launcher, "_launch_path", lambda path: (False, "access denied")
+        )
+        tool = AppLauncherTool()
+        result = tool.execute(action="open", app_name="Chrome")
+        assert result.success is False
+        assert "access denied" in result.content
+
+    def test_open_default_browser(self, monkeypatch):
+        monkeypatch.setattr(app_launcher, "_launch_default_browser", lambda: (True, ""))
+        tool = AppLauncherTool()
+        result = tool.execute(action="open", app_name="navegador")
+        assert result.success is True
+        assert result.metadata["app"] == "default_browser"
+
+    def test_open_never_receives_raw_path_parameter(self):
+        # The tool's spec only exposes app_name/action — no raw path param
+        # a caller could use to bypass discovery.
+        tool = AppLauncherTool()
+        assert set(tool.spec.parameters["properties"].keys()) == {"action", "app_name"}
+
+
+class TestAppLauncherToolClose:
+    def test_close_found_terminates(self, monkeypatch):
+        running = _entries(("Spotify", "1234"))
+        monkeypatch.setattr(app_launcher, "_list_running_processes", lambda: running)
+        terminated = {}
+
+        def fake_terminate(pid):
+            terminated["pid"] = pid
+            return True, ""
+
+        monkeypatch.setattr(app_launcher, "_terminate_process", fake_terminate)
+
+        tool = AppLauncherTool()
+        result = tool.execute(action="close", app_name="Spotify")
+        assert result.success is True
+        assert terminated["pid"] == 1234
+
+    def test_close_not_running(self, monkeypatch):
+        monkeypatch.setattr(
+            app_launcher, "_list_running_processes", lambda: _entries(("Discord", "1"))
+        )
+        tool = AppLauncherTool()
+        result = tool.execute(action="close", app_name="Spotify")
+        assert result.success is False
+        assert "não parece estar em execução" in result.content
+
+    def test_close_ambiguous(self, monkeypatch):
+        running = _entries(("Google Chrome", "111"), ("Google Chrome Canary", "222"))
+        monkeypatch.setattr(app_launcher, "_list_running_processes", lambda: running)
+        tool = AppLauncherTool()
+        result = tool.execute(action="close", app_name="chrome")
+        assert result.success is False
+        assert result.metadata.get("ambiguous") is True
+
+    def test_close_no_processes_listed(self, monkeypatch):
+        monkeypatch.setattr(app_launcher, "_list_running_processes", lambda: [])
+        tool = AppLauncherTool()
+        result = tool.execute(action="close", app_name="Spotify")
+        assert result.success is False
+
+
+class TestAppLauncherToolSpec:
+    def test_spec_requires_code_execute_capability(self):
+        tool = AppLauncherTool()
+        assert "code:execute" in tool.spec.required_capabilities
+
+    def test_spec_name_and_category(self):
+        tool = AppLauncherTool()
+        assert tool.spec.name == "app_launcher"
+        assert tool.spec.category == "system"

--- a/uv.lock
+++ b/uv.lock
@@ -44,7 +44,7 @@ name = "aiofile"
 version = "3.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "caio", marker = "python_full_version >= '3.12'" },
+    { name = "caio" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/67/e2/d7cb819de8df6b5c1968a2756c3cb4122d4fa2b8fc768b53b7c9e5edb646/aiofile-3.9.0.tar.gz", hash = "sha256:e5ad718bb148b265b6df1b3752c4d1d83024b93da9bd599df74b9d9ffcf7919b", size = 17943, upload-time = "2024-10-08T10:39:35.846Z" }
 wheels = [
@@ -359,7 +359,7 @@ name = "authlib"
 version = "1.6.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "python_full_version >= '3.12'" },
+    { name = "cryptography" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6b/6c/c88eac87468c607f88bc24df1f3b31445ee6fc9ba123b09e666adf687cd9/authlib-1.6.8.tar.gz", hash = "sha256:41ae180a17cf672bc784e4a518e5c82687f1fe1e98b0cafaeda80c8e4ab2d1cb", size = 165074, upload-time = "2026-02-14T04:02:17.941Z" }
 wheels = [
@@ -1147,7 +1147,7 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform == 'linux'",
 ]
 dependencies = [
-    { name = "cuda-pathfinder", marker = "sys_platform == 'linux'" },
+    { name = "cuda-pathfinder" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/37/31/bfcc870f69c6a017c4ad5c42316207fc7551940db6f3639aa4466ec5faf3/cuda_bindings-12.9.4-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a022c96b8bd847e8dc0675523431149a4c3e872f440e3002213dbb9e08f0331a", size = 11800959, upload-time = "2025-10-21T14:51:26.458Z" },
@@ -1179,7 +1179,7 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'linux'",
 ]
 dependencies = [
-    { name = "cuda-pathfinder", marker = "sys_platform != 'linux'" },
+    { name = "cuda-pathfinder" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/ea/81999d01375645f34596c76eb046b4b36d58cc6fe2bddb2410f8a7b7a827/cuda_bindings-13.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:845025438a1b9e20718b9fb42add3e0eb72e85458bcab3eeb80bfd8f0a9dab33", size = 5600047, upload-time = "2026-03-11T00:12:34.848Z" },
@@ -1207,7 +1207,7 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform == 'linux'",
 ]
 dependencies = [
-    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "cuda-bindings", version = "12.9.4", source = { registry = "https://pypi.org/simple" } },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/af/f3/6b032a554019cfb3447e671798c1bd3e79b5f1af20d10253f56cea269ef2/cuda_python-12.9.4-py3-none-any.whl", hash = "sha256:d2cacea882a69863f1e7d27ee71d75f0684f4c76910aff839067e4f89c902279", size = 7594, upload-time = "2025-10-21T14:55:12.846Z" },
@@ -1230,8 +1230,8 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'linux'",
 ]
 dependencies = [
-    { name = "cuda-bindings", version = "13.2.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
-    { name = "cuda-pathfinder", marker = "sys_platform != 'linux'" },
+    { name = "cuda-bindings", version = "13.2.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "cuda-pathfinder" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/da/b4dbe129f941afe1c24a09ba53521b78875626763d96414798a74763282f/cuda_python-13.2.0-py3-none-any.whl", hash = "sha256:2f092b0ec13a860115fa595411889ee939ad203450ea4f91e9461b174ea7b084", size = 8145, upload-time = "2026-03-11T13:55:19.143Z" },
@@ -1242,10 +1242,10 @@ name = "cyclopts"
 version = "4.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs", marker = "python_full_version >= '3.12'" },
-    { name = "docstring-parser", marker = "python_full_version >= '3.12'" },
-    { name = "rich", marker = "python_full_version >= '3.12'" },
-    { name = "rich-rst", marker = "python_full_version >= '3.12'" },
+    { name = "attrs" },
+    { name = "docstring-parser" },
+    { name = "rich" },
+    { name = "rich-rst" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/49/5c/88a4068c660a096bbe87efc5b7c190080c9e86919c36ec5f092cb08d852f/cyclopts-4.6.0.tar.gz", hash = "sha256:483c4704b953ea6da742e8de15972f405d2e748d19a848a4d61595e8e5360ee5", size = 162724, upload-time = "2026-02-23T15:44:49.286Z" }
 wheels = [
@@ -1334,7 +1334,7 @@ name = "deprecation"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "packaging", marker = "python_full_version >= '3.12'" },
+    { name = "packaging" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5a/d3/8ae2869247df154b64c1884d7346d412fed0c49df84db635aab2d1c40e62/deprecation-2.1.0.tar.gz", hash = "sha256:72b3bde64e5d778694b0cf68178aed03d15e15477116add3fb773e581f9518ff", size = 173788, upload-time = "2020-04-20T14:23:38.738Z" }
 wheels = [
@@ -1505,7 +1505,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11' or python_full_version == '3.12.*'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1725,26 +1725,26 @@ name = "fastmcp"
 version = "3.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "authlib", marker = "python_full_version >= '3.12'" },
-    { name = "cyclopts", marker = "python_full_version >= '3.12'" },
-    { name = "exceptiongroup", marker = "python_full_version >= '3.12'" },
-    { name = "httpx", marker = "python_full_version >= '3.12'" },
-    { name = "jsonref", marker = "python_full_version >= '3.12'" },
-    { name = "jsonschema-path", marker = "python_full_version >= '3.12'" },
-    { name = "mcp", marker = "python_full_version >= '3.12'" },
-    { name = "openapi-pydantic", marker = "python_full_version >= '3.12'" },
-    { name = "opentelemetry-api", marker = "python_full_version >= '3.12'" },
-    { name = "packaging", marker = "python_full_version >= '3.12'" },
-    { name = "platformdirs", marker = "python_full_version >= '3.12'" },
-    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"], marker = "python_full_version >= '3.12'" },
-    { name = "pydantic", extra = ["email"], marker = "python_full_version >= '3.12'" },
-    { name = "pyperclip", marker = "python_full_version >= '3.12'" },
-    { name = "python-dotenv", marker = "python_full_version >= '3.12'" },
-    { name = "pyyaml", marker = "python_full_version >= '3.12'" },
-    { name = "rich", marker = "python_full_version >= '3.12'" },
-    { name = "uvicorn", marker = "python_full_version >= '3.12'" },
-    { name = "watchfiles", marker = "python_full_version >= '3.12'" },
-    { name = "websockets", marker = "python_full_version >= '3.12'" },
+    { name = "authlib" },
+    { name = "cyclopts" },
+    { name = "exceptiongroup" },
+    { name = "httpx" },
+    { name = "jsonref" },
+    { name = "jsonschema-path" },
+    { name = "mcp" },
+    { name = "openapi-pydantic" },
+    { name = "opentelemetry-api" },
+    { name = "packaging" },
+    { name = "platformdirs" },
+    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
+    { name = "pydantic", extra = ["email"] },
+    { name = "pyperclip" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "uvicorn" },
+    { name = "watchfiles" },
+    { name = "websockets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/11/6b/1a7ec89727797fb07ec0928e9070fa2f45e7b35718e1fe01633a34c35e45/fastmcp-3.0.2.tar.gz", hash = "sha256:6bd73b4a3bab773ee6932df5249dcbcd78ed18365ed0aeeb97bb42702a7198d7", size = 17239351, upload-time = "2026-02-22T16:32:28.843Z" }
 wheels = [
@@ -2546,7 +2546,7 @@ name = "jaraco-classes"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "more-itertools", marker = "python_full_version >= '3.12'" },
+    { name = "more-itertools" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
 wheels = [
@@ -2567,7 +2567,7 @@ name = "jaraco-functools"
 version = "4.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "more-itertools", marker = "python_full_version >= '3.12'" },
+    { name = "more-itertools" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/27/056e0638a86749374d6f57d0b0db39f29509cce9313cf91bdc0ac4d91084/jaraco_functools-4.4.0.tar.gz", hash = "sha256:da21933b0417b89515562656547a77b4931f98176eb173644c0d35032a33d6bb", size = 19943, upload-time = "2025-12-21T09:29:43.6Z" }
 wheels = [
@@ -2723,9 +2723,9 @@ name = "jsonschema-path"
 version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pathable", marker = "python_full_version >= '3.12'" },
-    { name = "pyyaml", marker = "python_full_version >= '3.12'" },
-    { name = "referencing", marker = "python_full_version >= '3.12'" },
+    { name = "pathable" },
+    { name = "pyyaml" },
+    { name = "referencing" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b3/da/1ebeb1c0ff579c330e200e8b06e6200653e3d0758136d8bd86762d63e7de/jsonschema_path-0.4.2.tar.gz", hash = "sha256:5f5ff183150030ea24bb51cf1ddac9bf5dbf030272e2792a7ffe8262f7eea2a5", size = 13417, upload-time = "2026-02-23T16:21:36.602Z" }
 wheels = [
@@ -2749,12 +2749,12 @@ name = "keyring"
 version = "25.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jaraco-classes", marker = "python_full_version >= '3.12'" },
-    { name = "jaraco-context", marker = "python_full_version >= '3.12'" },
-    { name = "jaraco-functools", marker = "python_full_version >= '3.12'" },
-    { name = "jeepney", marker = "python_full_version >= '3.12' and sys_platform == 'linux'" },
-    { name = "pywin32-ctypes", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
-    { name = "secretstorage", marker = "python_full_version >= '3.12' and sys_platform == 'linux'" },
+    { name = "jaraco-classes" },
+    { name = "jaraco-context" },
+    { name = "jaraco-functools" },
+    { name = "jeepney", marker = "sys_platform == 'linux'" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "secretstorage", marker = "sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
 wheels = [
@@ -2885,22 +2885,22 @@ name = "lmnr"
 version = "0.7.42"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "grpcio", marker = "python_full_version >= '3.12'" },
-    { name = "httpx", marker = "python_full_version >= '3.12'" },
-    { name = "opentelemetry-api", marker = "python_full_version >= '3.12'" },
-    { name = "opentelemetry-exporter-otlp-proto-grpc", marker = "python_full_version >= '3.12'" },
-    { name = "opentelemetry-exporter-otlp-proto-http", marker = "python_full_version >= '3.12'" },
-    { name = "opentelemetry-instrumentation", marker = "python_full_version >= '3.12'" },
-    { name = "opentelemetry-instrumentation-threading", marker = "python_full_version >= '3.12'" },
-    { name = "opentelemetry-sdk", marker = "python_full_version >= '3.12'" },
-    { name = "opentelemetry-semantic-conventions", marker = "python_full_version >= '3.12'" },
-    { name = "opentelemetry-semantic-conventions-ai", marker = "python_full_version >= '3.12'" },
-    { name = "orjson", marker = "python_full_version >= '3.12'" },
-    { name = "packaging", marker = "python_full_version >= '3.12'" },
-    { name = "pydantic", marker = "python_full_version >= '3.12'" },
-    { name = "python-dotenv", marker = "python_full_version >= '3.12'" },
-    { name = "tenacity", marker = "python_full_version >= '3.12'" },
-    { name = "tqdm", marker = "python_full_version >= '3.12'" },
+    { name = "grpcio" },
+    { name = "httpx" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-instrumentation-threading" },
+    { name = "opentelemetry-sdk" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-semantic-conventions-ai" },
+    { name = "orjson" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "tenacity" },
+    { name = "tqdm" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0a/95/5b9dac7022e81494871aa228ccb0578668781cbc4241b59bd89ebe37536e/lmnr-0.7.42.tar.gz", hash = "sha256:2bea334ca201470120f1c5dd18eccf6aee503c8d962addda2761dfa681f74845", size = 240415, upload-time = "2026-02-23T14:23:24.39Z" }
 wheels = [
@@ -3386,7 +3386,7 @@ name = "mlx"
 version = "0.31.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mlx-metal", marker = "sys_platform == 'darwin'" },
+    { name = "mlx-metal" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/29/7c/c16d52494a1ba6d90443f31fa26bc810bf878d532dfa9a7a13f49ef9542d/mlx-0.31.2-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:b29cf940f34205f09bb552ac60465ae833c4ae640b52777c6d725ddbad8461ca", size = 586942, upload-time = "2026-04-22T03:14:21.97Z" },
@@ -3409,7 +3409,7 @@ version = "0.31.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jinja2" },
-    { name = "mlx", marker = "sys_platform == 'darwin'" },
+    { name = "mlx" },
     { name = "numpy" },
     { name = "protobuf" },
     { name = "pyyaml" },
@@ -3835,7 +3835,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cublas-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -3865,7 +3865,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -3892,9 +3892,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cusparse-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cusparse-cu12" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -3905,7 +3905,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
@@ -4079,7 +4079,7 @@ name = "openapi-pydantic"
 version = "0.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "pydantic" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/02/2e/58d83848dd1a79cb92ed8e63f6ba901ca282c5f09d04af9423ec26c56fd7/openapi_pydantic-0.5.1.tar.gz", hash = "sha256:ff6835af6bde7a459fb93eb93bb92b8749b754fc6e51b2f1590a19dc3005ee0d", size = 60892, upload-time = "2025-01-08T19:29:27.083Z" }
 wheels = [
@@ -4109,17 +4109,17 @@ name = "openhands-sdk"
 version = "1.11.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "deprecation", marker = "python_full_version >= '3.12'" },
-    { name = "fastmcp", marker = "python_full_version >= '3.12'" },
-    { name = "filelock", marker = "python_full_version >= '3.12'" },
-    { name = "httpx", marker = "python_full_version >= '3.12'" },
-    { name = "litellm", marker = "python_full_version >= '3.12'" },
-    { name = "lmnr", marker = "python_full_version >= '3.12'" },
-    { name = "pydantic", marker = "python_full_version >= '3.12'" },
-    { name = "python-frontmatter", marker = "python_full_version >= '3.12'" },
-    { name = "python-json-logger", marker = "python_full_version >= '3.12'" },
-    { name = "tenacity", marker = "python_full_version >= '3.12'" },
-    { name = "websockets", marker = "python_full_version >= '3.12'" },
+    { name = "deprecation" },
+    { name = "fastmcp" },
+    { name = "filelock" },
+    { name = "httpx" },
+    { name = "litellm" },
+    { name = "lmnr" },
+    { name = "pydantic" },
+    { name = "python-frontmatter" },
+    { name = "python-json-logger" },
+    { name = "tenacity" },
+    { name = "websockets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3a/fc/cfb73768099be94c9f92b2e160f29d1f6d3a4dd84fea5e33a2b0984449cc/openhands_sdk-1.11.5.tar.gz", hash = "sha256:dd6225876b7b8dbb6c608559f2718c3d0bf44d0bb741e990b185c6cdc5150c5a", size = 295069, upload-time = "2026-02-20T22:16:47.102Z" }
 wheels = [
@@ -4145,6 +4145,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+app-launcher = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+]
 browser = [
     { name = "playwright" },
 ]
@@ -4415,6 +4418,7 @@ requires-dist = [
     { name = "python-multipart", marker = "extra == 'server'", specifier = ">=0.0.9" },
     { name = "python-telegram-bot", specifier = ">=22.6" },
     { name = "python-telegram-bot", marker = "extra == 'channel-telegram'", specifier = ">=21.0" },
+    { name = "pywin32", marker = "sys_platform == 'win32' and extra == 'app-launcher'", specifier = ">=306" },
     { name = "rank-bm25", marker = "extra == 'memory-bm25'", specifier = ">=0.2.2" },
     { name = "respx", marker = "extra == 'dev'", specifier = ">=0.22" },
     { name = "rich", specifier = ">=13" },
@@ -4443,7 +4447,7 @@ requires-dist = [
     { name = "zeus-ml", extras = ["apple"], marker = "extra == 'energy-apple'" },
     { name = "zulip", marker = "extra == 'channel-zulip'", specifier = ">=0.9" },
 ]
-provides-extras = ["browser", "channel-discord", "channel-gmail", "channel-line", "channel-mastodon", "channel-messenger", "channel-nostr", "channel-reddit", "channel-rocketchat", "channel-slack", "channel-telegram", "channel-twilio", "channel-twitch", "channel-twitter", "channel-viber", "channel-xmpp", "channel-zulip", "dashboard", "desktop", "dev", "docs", "energy-all", "energy-amd", "energy-apple", "eval-sheets", "eval-wandb", "framework-comparison", "gpu-metrics", "inference-cloud", "inference-gemma", "inference-google", "inference-litellm", "inference-mlx", "inference-vllm", "learning-dspy", "learning-gepa", "media", "memory-bm25", "memory-colbert", "memory-faiss", "memory-pdf", "mining-pearl-cpu", "mining-pearl-vllm", "openhands", "orchestrator-training", "pdf", "sandbox-docker", "sandbox-wasm", "scheduler", "security-signing", "server", "speech", "speech-deepgram", "tools-search"]
+provides-extras = ["app-launcher", "browser", "channel-discord", "channel-gmail", "channel-line", "channel-mastodon", "channel-messenger", "channel-nostr", "channel-reddit", "channel-rocketchat", "channel-slack", "channel-telegram", "channel-twilio", "channel-twitch", "channel-twitter", "channel-viber", "channel-xmpp", "channel-zulip", "dashboard", "desktop", "dev", "docs", "energy-all", "energy-amd", "energy-apple", "eval-sheets", "eval-wandb", "framework-comparison", "gpu-metrics", "inference-cloud", "inference-gemma", "inference-google", "inference-litellm", "inference-mlx", "inference-vllm", "learning-dspy", "learning-gepa", "media", "memory-bm25", "memory-colbert", "memory-faiss", "memory-pdf", "mining-pearl-cpu", "mining-pearl-vllm", "openhands", "orchestrator-training", "pdf", "sandbox-docker", "sandbox-wasm", "scheduler", "security-signing", "server", "speech", "speech-deepgram", "tools-search"]
 
 [package.metadata.requires-dev]
 desktop-native = [{ name = "openjarvis-rust", directory = "rust/crates/openjarvis-python" }]
@@ -4533,10 +4537,10 @@ name = "opentelemetry-instrumentation"
 version = "0.60b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-api", marker = "python_full_version >= '3.12'" },
-    { name = "opentelemetry-semantic-conventions", marker = "python_full_version >= '3.12'" },
-    { name = "packaging", marker = "python_full_version >= '3.12'" },
-    { name = "wrapt", marker = "python_full_version >= '3.12'" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "packaging" },
+    { name = "wrapt" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/41/0f/7e6b713ac117c1f5e4e3300748af699b9902a2e5e34c9cf443dde25a01fa/opentelemetry_instrumentation-0.60b1.tar.gz", hash = "sha256:57ddc7974c6eb35865af0426d1a17132b88b2ed8586897fee187fd5b8944bd6a", size = 31706, upload-time = "2025-12-11T13:36:42.515Z" }
 wheels = [
@@ -4548,9 +4552,9 @@ name = "opentelemetry-instrumentation-threading"
 version = "0.60b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-api", marker = "python_full_version >= '3.12'" },
-    { name = "opentelemetry-instrumentation", marker = "python_full_version >= '3.12'" },
-    { name = "wrapt", marker = "python_full_version >= '3.12'" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "wrapt" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9b/0a/e36123ec4c0910a3936b92982545a53e9bca5b26a28df06883751a783f84/opentelemetry_instrumentation_threading-0.60b1.tar.gz", hash = "sha256:20b18a68abe5801fa9474336b7c27487d4af3e00b66f6a8734e4fdd75c8b0b43", size = 8768, upload-time = "2025-12-11T13:37:16.29Z" }
 wheels = [
@@ -4756,10 +4760,10 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'linux'",
 ]
 dependencies = [
-    { name = "numpy", marker = "python_full_version < '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
-    { name = "pytz", marker = "python_full_version < '3.11'" },
-    { name = "tzdata", marker = "python_full_version < '3.11'" },
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "tzdata" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -4818,9 +4822,9 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", marker = "python_full_version >= '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
-    { name = "tzdata", marker = "(python_full_version >= '3.11' and sys_platform == 'emscripten') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/de/da/b1dc0481ab8d55d0f46e343cfe67d4551a0e14fcee52bd38ca1bd73258d8/pandas-3.0.0.tar.gz", hash = "sha256:0facf7e87d38f721f0af46fe70d97373a37701b1c09f7ed7aeeb292ade5c050f", size = 4633005, upload-time = "2026-01-21T15:52:04.726Z" }
 wheels = [
@@ -5298,8 +5302,8 @@ name = "py-key-value-aio"
 version = "0.4.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "beartype", marker = "python_full_version >= '3.12'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.12'" },
+    { name = "beartype" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/3c/0397c072a38d4bc580994b42e0c90c5f44f679303489e4376289534735e5/py_key_value_aio-0.4.4.tar.gz", hash = "sha256:e3012e6243ed7cc09bb05457bd4d03b1ba5c2b1ca8700096b3927db79ffbbe55", size = 92300, upload-time = "2026-02-16T21:21:43.245Z" }
 wheels = [
@@ -5308,14 +5312,14 @@ wheels = [
 
 [package.optional-dependencies]
 filetree = [
-    { name = "aiofile", marker = "python_full_version >= '3.12'" },
-    { name = "anyio", marker = "python_full_version >= '3.12'" },
+    { name = "aiofile" },
+    { name = "anyio" },
 ]
 keyring = [
-    { name = "keyring", marker = "python_full_version >= '3.12'" },
+    { name = "keyring" },
 ]
 memory = [
-    { name = "cachetools", marker = "python_full_version >= '3.12'" },
+    { name = "cachetools" },
 ]
 
 [[package]]
@@ -5975,7 +5979,7 @@ name = "python-frontmatter"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyyaml", marker = "python_full_version >= '3.12'" },
+    { name = "pyyaml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/de/910fa208120314a12f9a88ea63e03707261692af782c99283f1a2c8a5e6f/python-frontmatter-1.1.0.tar.gz", hash = "sha256:7118d2bd56af9149625745c58c9b51fb67e8d1294a0c76796dafdc72c36e5f6d", size = 16256, upload-time = "2024-01-16T18:50:04.052Z" }
 wheels = [
@@ -6388,8 +6392,8 @@ name = "rich-rst"
 version = "1.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "docutils", marker = "python_full_version >= '3.12'" },
-    { name = "rich", marker = "python_full_version >= '3.12'" },
+    { name = "docutils" },
+    { name = "rich" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/bc/6d/a506aaa4a9eaa945ed8ab2b7347859f53593864289853c5d6d62b77246e0/rich_rst-1.3.2.tar.gz", hash = "sha256:a1196fdddf1e364b02ec68a05e8ff8f6914fee10fbca2e6b6735f166bb0da8d4", size = 14936, upload-time = "2025-10-14T16:49:45.332Z" }
 wheels = [
@@ -6679,10 +6683,10 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'linux'",
 ]
 dependencies = [
-    { name = "joblib", marker = "python_full_version < '3.11'" },
-    { name = "numpy", marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "threadpoolctl", marker = "python_full_version < '3.11'" },
+    { name = "joblib" },
+    { name = "numpy" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "threadpoolctl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/98/c2/a7855e41c9d285dfe86dc50b250978105dce513d6e459ea66a6aeb0e1e0c/scikit_learn-1.7.2.tar.gz", hash = "sha256:20e9e49ecd130598f1ca38a1d85090e1a600147b9c02fa6f15d69cb53d968fda", size = 7193136, upload-time = "2025-09-09T08:21:29.075Z" }
 wheels = [
@@ -6732,10 +6736,10 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "joblib", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", marker = "python_full_version >= '3.11'" },
-    { name = "scipy", version = "1.17.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "threadpoolctl", marker = "python_full_version >= '3.11'" },
+    { name = "joblib" },
+    { name = "numpy" },
+    { name = "scipy", version = "1.17.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "threadpoolctl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/d4/40988bf3b8e34feec1d0e6a051446b1f66225f8529b9309becaeef62b6c4/scikit_learn-1.8.0.tar.gz", hash = "sha256:9bccbb3b40e3de10351f8f5068e105d0f4083b1a65fa07b6634fbc401a6287fd", size = 7335585, upload-time = "2025-12-10T07:08:53.618Z" }
 wheels = [
@@ -6774,7 +6778,7 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'linux'",
 ]
 dependencies = [
-    { name = "numpy", marker = "python_full_version < '3.11'" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -6844,7 +6848,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", marker = "python_full_version >= '3.11'" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/56/3e/9cca699f3486ce6bc12ff46dc2031f1ec8eb9ccc9a320fdaf925f1417426/scipy-1.17.0.tar.gz", hash = "sha256:2591060c8e648d8b96439e111ac41fd8342fdeff1876be2e19dea3fe8930454e", size = 30396830, upload-time = "2026-01-10T21:34:23.009Z" }
 wheels = [
@@ -6895,8 +6899,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "python_full_version >= '3.12' and sys_platform == 'linux'" },
-    { name = "jeepney", marker = "python_full_version >= '3.12' and sys_platform == 'linux'" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -7121,9 +7125,9 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'linux'",
 ]
 dependencies = [
-    { name = "aiodns", marker = "python_full_version < '3.11'" },
-    { name = "pyasn1", marker = "python_full_version < '3.11'" },
-    { name = "pyasn1-modules", marker = "python_full_version < '3.11'" },
+    { name = "aiodns" },
+    { name = "pyasn1" },
+    { name = "pyasn1-modules" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d9/03/925a18ce8aced370a5135b3e0ef870ec71a30da005f747891c83df98ca53/slixmpp-1.12.0.tar.gz", hash = "sha256:7469f6dcaf5742fd62e0e66ee447c5338a74520c1982a70784e7b790def2fdd5", size = 715300, upload-time = "2025-10-19T17:50:18.975Z" }
 wheels = [
@@ -7164,9 +7168,9 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "aiodns", marker = "python_full_version >= '3.11'" },
-    { name = "pyasn1", marker = "python_full_version >= '3.11'" },
-    { name = "pyasn1-modules", marker = "python_full_version >= '3.11'" },
+    { name = "aiodns" },
+    { name = "pyasn1" },
+    { name = "pyasn1-modules" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8b/1c/6ce021fb5524b41330d583956d1ff8e508c95d6c1bb0ed34790e754cc8d2/slixmpp-1.13.2.tar.gz", hash = "sha256:1b6f7c4c273ae5d34c4e54f6d66984a27467de225312f19f942f971f38b78da2", size = 757698, upload-time = "2026-02-08T19:05:21.165Z" }
 wheels = [
@@ -7721,9 +7725,9 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'linux'",
 ]
 dependencies = [
-    { name = "aiohttp", marker = "python_full_version < '3.11'" },
-    { name = "iso8601", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "aiohttp" },
+    { name = "iso8601" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/de/61/3f177d7e48af2816bd7bc639a7d5c4f2fa0ff3ae46faf36754b3c3676de9/twitchio-2.10.0.tar.gz", hash = "sha256:3ae5e17b3764eff24ad7d12decb473c9d34f18510b5d705e0bbe6fcf0b06fd75", size = 114393, upload-time = "2024-06-25T14:47:22.463Z" }
 wheels = [
@@ -7749,7 +7753,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "aiohttp", marker = "python_full_version >= '3.11'" },
+    { name = "aiohttp" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/16/55/d0b8f1c6552f23994d925301fa7d5743109568cc8f079fee9866c5a52499/twitchio-3.2.1.tar.gz", hash = "sha256:a1be858a4028625173978db91224326b910a0aaa4c7db879a8867003642a0115", size = 248627, upload-time = "2026-01-29T14:14:44.803Z" }
 wheels = [


### PR DESCRIPTION
## What does this PR do?

Adds a new `app_launcher` tool (`src/openjarvis/tools/app_launcher.py`,
`@ToolRegistry.register("app_launcher")`) that lets an agent open or close
already-installed desktop applications by free-text name — e.g. "abra o
Chrome", "abra a calculadora", "feche o Spotify" — reusing the existing
tool-routing system (it's just a tool call, not a new module/agent) and
mirroring `shell_exec.py`'s `code:execute` capability pattern.

**Discovery** (Windows): reads the `App Paths` registry key
(`HKLM`/`HKCU`) and resolves Start Menu `.lnk` shortcuts via the Windows
Shell COM API (`pywin32`, new optional `app-launcher` extra, Windows-only
marker) — never a hardcoded install path. A small nickname table
normalizes generic terms ("navegador" → default browser, "calculadora" →
"calc") before falling back to fuzzy matching (`difflib`) for typos.

**Matching behavior** (see `find_app`/`_match_precise`/`_match_fuzzy`):
raw query term tried first (exact → substring), then alias-expansion
terms only if that finds nothing, then fuzzy matching only against the
user's own raw term (never against aliases — an alias is already a
precise, curated name, and fuzzy-matching it produced false positives
like "calculadora" ~ "CapCut" during testing). Candidates sharing the
same display name but different paths (e.g. two "Discord" shortcuts)
collapse to one match; candidates with genuinely different names (e.g.
"Google Chrome" vs "Google Chrome Canary") correctly trigger
disambiguation, asking which one the user meant.

**Safety** (explicit requirements from the brief): never installs new
software (no such action exists), never runs a caller-supplied path (the
tool's only input is a free-text `app_name` — every launchable path comes
from OS-level discovery of already-installed programs), never requests
admin elevation (plain `os.startfile`/unelevated `Popen`), and never
silently claims success — a not-found app or a failed launch always
returns `success=False` with a clear message.

**Closing** apps uses `tasklist`/`taskkill` (graceful terminate, escalating
to a forced kill only if that doesn't work) — kept dependency-free
(no `psutil`) since Windows ships these tools already.

## How was this tested?

- 22 new unit tests (`tests/tools/test_app_launcher.py`) covering: opening
  a found app, the not-found warning, disambiguation with multiple close
  matches, alias resolution, missing/unknown-action error handling,
  closing a running process, and confirming the tool's parameters never
  expose a raw path (only `action`/`app_name`).
- Full `tests/tools/` regression suite: 687 passed, 0 failures.
- **Manually verified end-to-end against real installed software** on a
  Windows machine: discovered 125 real installed apps via the registry +
  Start Menu, correctly resolved "bloco de notas"/"paint"/"discord"/
  "opera"/"winrar" to their real executables, correctly reported
  "chrome"/"spotify" as not installed (honest, not fabricated) on that
  machine, and actually opened + closed Notepad through the tool
  (confirmed via `tasklist` before/after).
- `ruff check` / `ruff format --check` pass on all changed files.

## Checklist

- [x] Tests pass (`uv run pytest tests/tools/ -v`)
- [x] Linter passes (`uv run ruff check src/ tests/`)
- [x] Formatter passes (`uv run ruff format --check src/ tests/`)
- [x] New/changed public API has docstrings
- [x] Follows registry pattern (`@ToolRegistry.register`)
- [ ] Documentation updated (not yet — flagging for a follow-up if merged)