### PR TITLE
style: restore Ruff formatting after merge wave

### DIFF
--- a/src/openjarvis/memory/store.py
+++ b/src/openjarvis/memory/store.py
@@ -165,9 +165,7 @@ class LocalFactStore(FactStore):
     ) -> None:
         max_facts = int(max_facts)
         if max_facts <= 0:
-            raise ValueError(
-                f"max_facts must be a positive integer, got {max_facts}"
-            )
+            raise ValueError(f"max_facts must be a positive integer, got {max_facts}")
         self._path = (
             Path(path).expanduser() if path is not None else _default_fact_path()
         )

--- a/src/openjarvis/skills/dependency.py
+++ b/src/openjarvis/skills/dependency.py
@@ -110,8 +110,7 @@ def validate_dependencies(
     if len(order) != len(graph):
         cyclic = set(graph) - set(order)
         raise DependencyCycleError(
-            "Cycle detected in skill dependency graph. "
-            f"Skills involved: {cyclic}",
+            f"Cycle detected in skill dependency graph. Skills involved: {cyclic}",
             skills=cyclic,
         )
 

--- a/src/openjarvis/skills/loader.py
+++ b/src/openjarvis/skills/loader.py
@@ -308,9 +308,7 @@ def discover_skills(directory: str | Path) -> list[SkillManifest]:
                 try:
                     manifests.append(load_skill_directory(grandchild))
                 except Exception as exc:
-                    LOGGER.warning(
-                        "Failed to load skill from %s: %s", grandchild, exc
-                    )
+                    LOGGER.warning("Failed to load skill from %s: %s", grandchild, exc)
                     continue
 
     return manifests

--- a/tests/channels/test_telegram.py
+++ b/tests/channels/test_telegram.py
@@ -152,7 +152,7 @@ class TestSend:
         markdown_failure.status_code = 400
         markdown_failure.text = (
             '{"ok":false,"description":"Bad Request: can\'t parse entities: '
-            'Character \'_\' is reserved and must be escaped"}'
+            "Character '_' is reserved and must be escaped\"}"
         )
         plain_success = MagicMock()
         plain_success.status_code = 200


### PR DESCRIPTION
## Summary

- restore Ruff 0.15.1 formatting in the four files identified by the post-merge main CI run
- make no behavioral changes

## Validation

- Ruff check across src/ and tests/: passed
- Ruff format check across src/ and tests/: 1,318 files formatted
- focused memory, skill loader/dependency, and Telegram tests: 86 passed

Follow-up to main CI run 32331498074.