### PR TITLE
fix(server): guard WebSocket subprotocol credential comparison against non-ASCII input

### DIFF
--- a/src/openjarvis/server/auth_middleware.py
+++ b/src/openjarvis/server/auth_middleware.py
@@ -148,8 +148,8 @@ def _offered_websocket_auth(websocket) -> tuple[str, str | None]:  # noqa: ANN00
 
 
 def authenticate_websocket(
-    websocket,
-    expected_key: str,  # noqa: ANN001
+    websocket,  # noqa: ANN001
+    expected_key: str,
 ) -> tuple[bool, str | None]:
     """Authenticate a WebSocket and return its negotiated auth subprotocol.
 
@@ -174,7 +174,7 @@ def authenticate_websocket(
 
     expected_protocol = _websocket_key_protocol(expected_key)
     protocol_valid = bool(credential_protocol and expected_protocol) and (
-        secrets.compare_digest(credential_protocol, expected_protocol)
+        _api_keys_match(credential_protocol, expected_protocol)
     )
     return header_valid or protocol_valid, selected_protocol
 


### PR DESCRIPTION
## Summary
- `authenticate_websocket()` in `auth_middleware.py` compared the offered `Sec-WebSocket-Protocol` credential against the expected one with a raw `secrets.compare_digest()` call, which raises `TypeError` on non-ASCII input instead of returning `False`
- The sibling header-auth path already had this exact problem solved via the `_api_keys_match()` helper (catches `UnicodeEncodeError`, compares as bytes); the `protocol_valid` branch just wasn't using it
- Switched `protocol_valid` to go through `_api_keys_match()` too, so a malformed/non-ASCII subprotocol credential fails auth cleanly (403) instead of crashing the handshake (500)
- Also fixes a misplaced `# noqa: ANN001` (was on `expected_key`, belongs on the untyped `websocket` param)

Found while reviewing the commit range that landed #747: a maintainer follow-up commit added `authenticate_websocket()` with this gap, but #747 was squash-merged about an hour before that follow-up commit could be included.

## Test plan
- [x] `uv run pytest tests/server/test_websocket_auth.py tests/server/test_auth_middleware.py -q` — 38/38 pass
- [x] Manual repro: calling `authenticate_websocket()` with a non-ASCII `Sec-WebSocket-Protocol` value no longer raises `TypeError`, returns `(False, None)`
- [x] `ruff check` / `ruff format --check` clean on the changed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)