### PR TITLE
fix(ui): show configured agent schedules

### DIFF
--- a/frontend/src/components/Desktop/AgentsPanel.tsx
+++ b/frontend/src/components/Desktop/AgentsPanel.tsx
@@ -16,6 +16,7 @@ import {
   fetchAgentTraces,
 } from '../../lib/api';
 import type { ManagedAgent, AgentTask, AgentMessage, AgentTemplate, LearningLogEntry, AgentTrace } from '../../lib/api';
+import { getAgentSchedule } from '../../lib/agent-schedule';
 
 // ---------------------------------------------------------------------------
 // Colors — Catppuccin Mocha
@@ -85,6 +86,11 @@ function formatSchedule(type?: string, value?: string): string {
   if (type === 'cron') return value ? `Cron: ${value}` : 'Cron';
   if (type === 'interval') return value ? `Every ${value}` : 'Interval';
   return type;
+}
+
+function formatAgentSchedule(agent: ManagedAgent): string {
+  const { type, value } = getAgentSchedule(agent);
+  return formatSchedule(type, value);
 }
 
 function formatCost(cost?: number): string {
@@ -689,7 +695,7 @@ function OverviewTab({ agent, onRun, onPause, onResume, onRecover }: {
         </div>
         <div style={rowStyle}>
           <span style={labelStyle}>Schedule</span>
-          <span style={valueStyle}>{formatSchedule(agent.schedule_type, agent.schedule_value)}</span>
+          <span style={valueStyle}>{formatAgentSchedule(agent)}</span>
         </div>
         <div style={rowStyle}>
           <span style={labelStyle}>Last Run</span>
@@ -977,7 +983,7 @@ function DetailPanel({
           <h2 style={{ color: C.text, fontSize: 18, fontWeight: 700, margin: 0 }}>{agent.name}</h2>
         </div>
         <div style={{ color: C.overlay0, fontSize: 12 }}>
-          {agent.agent_type} · Schedule: {formatSchedule(agent.schedule_type, agent.schedule_value)} · Last run: {formatRelativeTime(agent.last_run_at)}
+          {agent.agent_type} · Schedule: {formatAgentSchedule(agent)} · Last run: {formatRelativeTime(agent.last_run_at)}
         </div>
       </div>
 
@@ -1160,7 +1166,7 @@ export function AgentsPanel({ apiUrl }: Props) {
                   </button>
                 </div>
                 <div style={{ color: C.overlay0, fontSize: 11, marginTop: 4 }}>
-                  {formatSchedule(a.schedule_type, a.schedule_value)}
+                  {formatAgentSchedule(a)}
                 </div>
                 <div style={{ color: C.overlay1, fontSize: 11, marginTop: 2 }}>
                   Last run: {formatRelativeTime(a.last_run_at)}

--- a/frontend/src/components/Desktop/lib/api.ts
+++ b/frontend/src/components/Desktop/lib/api.ts
@@ -5,11 +5,16 @@
 // Types
 // ---------------------------------------------------------------------------
 
+export interface ManagedAgentConfig extends Record<string, unknown> {
+  schedule_type?: string;
+  schedule_value?: string | number;
+}
+
 export interface ManagedAgent {
   id: string;
   name: string;
   agent_type: string;
-  config: Record<string, unknown>;
+  config: ManagedAgentConfig;
   status: 'idle' | 'running' | 'paused' | 'error' | 'archived' | 'needs_attention' | 'budget_exceeded' | 'stalled';
   summary_memory: string;
   created_at: number;
@@ -18,8 +23,6 @@ export interface ManagedAgent {
   total_cost?: number;
   total_tokens?: number;
   last_run_at?: number | null;
-  schedule_type?: string;
-  schedule_value?: string;
   budget?: number;
   learning_enabled?: boolean;
 }

--- a/frontend/src/lib/agent-schedule.test.ts
+++ b/frontend/src/lib/agent-schedule.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { getAgentSchedule } from './agent-schedule';
+
+describe('getAgentSchedule', () => {
+  it('reads schedule fields from the nested agent config', () => {
+    expect(
+      getAgentSchedule({
+        config: {
+          schedule_type: 'cron',
+          schedule_value: '0 9 * * *',
+        },
+      }),
+    ).toEqual({ type: 'cron', value: '0 9 * * *' });
+  });
+
+  it('normalizes numeric interval values for display', () => {
+    expect(
+      getAgentSchedule({
+        config: { schedule_type: 'interval', schedule_value: 300 },
+      }),
+    ).toEqual({ type: 'interval', value: '300' });
+  });
+
+  it('prefers nested config over legacy top-level fields', () => {
+    expect(
+      getAgentSchedule({
+        config: {
+          schedule_type: 'cron',
+          schedule_value: '0 9 * * *',
+        },
+        schedule_type: 'manual',
+        schedule_value: '',
+      }),
+    ).toEqual({ type: 'cron', value: '0 9 * * *' });
+  });
+
+  it('falls back to legacy top-level fields for older servers', () => {
+    expect(
+      getAgentSchedule({
+        config: {},
+        schedule_type: 'interval',
+        schedule_value: '60',
+      }),
+    ).toEqual({ type: 'interval', value: '60' });
+  });
+});

--- a/frontend/src/lib/agent-schedule.ts
+++ b/frontend/src/lib/agent-schedule.ts
@@ -1,0 +1,32 @@
+export interface AgentScheduleSource {
+  config?: Record<string, unknown> | null;
+  // Retained as fallbacks for compatibility with older API responses.
+  schedule_type?: unknown;
+  schedule_value?: unknown;
+}
+
+export interface AgentSchedule {
+  type?: string;
+  value?: string;
+}
+
+function scheduleValue(value: unknown): string | undefined {
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' && Number.isFinite(value)) return String(value);
+  return undefined;
+}
+
+/** Read schedule fields from the managed-agent API response. */
+export function getAgentSchedule(agent: AgentScheduleSource): AgentSchedule {
+  const nestedType = agent.config?.schedule_type;
+
+  return {
+    type:
+      typeof nestedType === 'string'
+        ? nestedType
+        : scheduleValue(agent.schedule_type),
+    value:
+      scheduleValue(agent.config?.schedule_value) ??
+      scheduleValue(agent.schedule_value),
+  };
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -382,11 +382,16 @@ export async function fetchSpeechHealth(): Promise<SpeechHealth> {
 // Agent Manager
 // ---------------------------------------------------------------------------
 
+export interface ManagedAgentConfig extends Record<string, unknown> {
+  schedule_type?: string;
+  schedule_value?: string | number;
+}
+
 export interface ManagedAgent {
   id: string;
   name: string;
   agent_type: string;
-  config: Record<string, unknown>;
+  config: ManagedAgentConfig;
   status: 'idle' | 'running' | 'paused' | 'error' | 'archived' | 'needs_attention' | 'budget_exceeded' | 'stalled';
   summary_memory: string;
   created_at: number;
@@ -398,9 +403,6 @@ export interface ManagedAgent {
   input_tokens?: number;
   output_tokens?: number;
   last_run_at?: number | null;
-  // Schedule
-  schedule_type?: string;
-  schedule_value?: string;
   // Budget
   budget?: number;
   // Learning

--- a/frontend/src/pages/AgentsPage.tsx
+++ b/frontend/src/pages/AgentsPage.tsx
@@ -67,6 +67,7 @@ import type { ConnectRequest } from '../types/connectors';
 import { listConnectors, connectSource } from '../lib/connectors-api';
 import type { ToolCallInfo } from '../types';
 import { ToolCallCard } from '../components/Chat/ToolCallCard';
+import { getAgentSchedule } from '../lib/agent-schedule';
 
 // ---------------------------------------------------------------------------
 // Status helpers
@@ -179,6 +180,11 @@ function formatSchedule(type?: string, value?: string): string {
     return `Every ${value}`;
   }
   return type || 'Manual';
+}
+
+function formatAgentSchedule(agent: ManagedAgent): string {
+  const { type, value } = getAgentSchedule(agent);
+  return formatSchedule(type, value);
 }
 
 // ---------------------------------------------------------------------------
@@ -1225,7 +1231,7 @@ function AgentCard({
 
       {/* Row 2: Schedule + last run */}
       <div className="text-xs mb-2 flex items-center gap-3" style={{ color: 'var(--color-text-tertiary)' }}>
-        <span>{formatSchedule(agent.schedule_type, agent.schedule_value)}</span>
+        <span>{formatAgentSchedule(agent)}</span>
         <span>·</span>
         <span>Last run: {formatRelativeTime(agent.last_run_at)}</span>
       </div>
@@ -1520,7 +1526,7 @@ function AgentConfigGrid({ agent, onAgentUpdated }: { agent: ManagedAgent; onAge
       </span>
     )],
     ['Agent Type', <span key="at">{agent.agent_type}</span>],
-    ['Schedule', <span key="sc">{formatSchedule(agent.schedule_type, agent.schedule_value)}</span>],
+    ['Schedule', <span key="sc">{formatAgentSchedule(agent)}</span>],
     ['Last Run', <span key="lr">{formatRelativeTime(agent.last_run_at)}</span>],
     ['Budget', <span key="bg">{agent.budget ? formatCost(agent.budget) : 'Unlimited'}</span>],
     ['Learning', <span key="le">{agent.learning_enabled ? 'Enabled' : 'Disabled'}</span>],


### PR DESCRIPTION
## What does this PR do?

Fixes #864.

- reads managed-agent schedule fields from `agent.config` in both the web and desktop agent views
- centralizes schedule extraction, including numeric interval normalization and compatibility with older top-level responses
- aligns the frontend managed-agent types with the backend response shape
- adds regression coverage for nested, numeric, precedence, and legacy schedule values

## How was this tested?

- `cd frontend && npm test` — 52 tests passed
- `cd frontend && ./node_modules/.bin/tsc --noEmit --project tsconfig.json --pretty false`
- production Vite build to a temporary output directory
- `git diff --check`

## Checklist

- [x] Tests pass
- [x] TypeScript check passes
- [x] Production frontend build passes
- [x] New public helper has documentation
- [x] Documentation update is not applicable
