### PR TITLE
fix: make credential storage recoverable

### DIFF
--- a/src/openjarvis/core/credentials.py
+++ b/src/openjarvis/core/credentials.py
@@ -6,18 +6,25 @@ Thread-safe writes via lock. Sets os.environ on save for immediate effect.
 
 from __future__ import annotations
 
+import logging
 import os
 import threading
+import time
 from pathlib import Path
 
+import tomlkit
+
 from openjarvis.core.paths import get_config_dir
+from openjarvis.security.file_utils import secure_write_text
 
 try:
     import tomllib
 except ModuleNotFoundError:
     import tomli as tomllib  # type: ignore[no-redef]
 
-_LOCK = threading.Lock()
+logger = logging.getLogger(__name__)
+
+_LOCK = threading.RLock()
 
 
 def _default_path() -> Path:
@@ -59,12 +66,30 @@ TOOL_CREDENTIALS: dict[str, list[str]] = {
 
 
 def load_credentials(path: Path | None = None) -> dict[str, dict[str, str]]:
-    """Load credentials from TOML file."""
+    """Load credentials, preserving malformed input as a recoverable backup."""
     p = Path(path) if path else _default_path()
-    if not p.exists():
-        return {}
-    with open(p, "rb") as f:
-        return tomllib.load(f)
+    with _LOCK:
+        if not p.exists():
+            return {}
+        try:
+            with open(p, "rb") as f:
+                return tomllib.load(f)
+        except tomllib.TOMLDecodeError:
+            backup = p.with_name(f"{p.name}.corrupt-{time.time_ns()}")
+            try:
+                os.replace(p, backup)
+                os.chmod(backup, 0o600)
+            except OSError:
+                logger.exception(
+                    "Could not preserve malformed credential file %s",
+                    p,
+                )
+                raise
+            logger.warning(
+                "Malformed credential file moved to %s; starting with an empty store",
+                backup,
+            )
+            return {}
 
 
 def _validate_credential_key(tool_name: str, key: str) -> None:
@@ -74,15 +99,13 @@ def _validate_credential_key(tool_name: str, key: str) -> None:
 
 
 def _write_credentials(creds: dict[str, dict[str, str]], path: Path) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    lines: list[str] = []
+    document = tomlkit.document()
     for section, kvs in creds.items():
-        lines.append(f"[{section}]")
-        for k, v in kvs.items():
-            lines.append(f'{k} = "{v}"')
-        lines.append("")
-    path.write_text("\n".join(lines))
-    os.chmod(path, 0o600)
+        table = tomlkit.table()
+        for key, value in kvs.items():
+            table.add(key, value)
+        document.add(section, table)
+    secure_write_text(path, tomlkit.dumps(document), mode=0o600, encoding="utf-8")
 
 
 def save_credential(

--- a/tests/core/test_credentials.py
+++ b/tests/core/test_credentials.py
@@ -64,6 +64,45 @@ def test_save_and_load(cred_path):
     assert creds["web_search"]["TAVILY_API_KEY"] == "tvly-123"
 
 
+def test_credential_special_characters_round_trip(cred_path):
+    value = 'quote" backslash\\ internal\nnewline and unicode: café 🔐'
+
+    save_credential("email", "EMAIL_PASSWORD", value, path=cred_path)
+
+    assert load_credentials(path=cred_path)["email"]["EMAIL_PASSWORD"] == value
+    assert cred_path.read_text(encoding="utf-8")
+
+
+def test_malformed_file_is_backed_up_and_store_recovers(cred_path):
+    malformed = '[email]\nEMAIL_PASSWORD = "unterminated\n'
+    cred_path.write_text(malformed, encoding="utf-8")
+
+    assert load_credentials(path=cred_path) == {}
+    assert not cred_path.exists()
+    backups = list(cred_path.parent.glob("credentials.toml.corrupt-*"))
+    assert len(backups) == 1
+    assert backups[0].read_text(encoding="utf-8") == malformed
+
+    save_credential("web_search", "TAVILY_API_KEY", "recovered", path=cred_path)
+    assert load_credentials(path=cred_path) == {
+        "web_search": {"TAVILY_API_KEY": "recovered"}
+    }
+
+
+def test_atomic_write_failure_preserves_existing_credentials(cred_path, monkeypatch):
+    save_credential("web_search", "TAVILY_API_KEY", "original", path=cred_path)
+    original = cred_path.read_bytes()
+
+    def fail_replace(source, destination):
+        raise OSError("replace blocked")
+
+    monkeypatch.setattr("openjarvis.security.file_utils.os.replace", fail_replace)
+    with pytest.raises(OSError, match="replace blocked"):
+        save_credential("web_search", "TAVILY_API_KEY", "new", path=cred_path)
+
+    assert cred_path.read_bytes() == original
+
+
 def test_restore_environ_preserves_legitimate_ambient_key(cred_path):
     """Regression for #788 must not erase a real key from the parent process."""
     baseline = {"TAVILY_API_KEY": "tvly-legitimate-ambient"}


### PR DESCRIPTION
## Summary
- serialize credential values with tomlkit so quotes, backslashes, newlines, and Unicode round-trip safely
- atomically write explicit UTF-8 credential files with owner-only permissions
- preserve malformed files as timestamped backups and recover with an empty writable store
- serialize reads/recovery/writes with a reentrant process lock

## Validation
- credentials + secure-file tests — 16 passed
- broader core suite — 271 passed; three failures require the unavailable local Rust extension and are unrelated to this diff
- Ruff check and format checks passed

Fixes #763