### PR TITLE
fix: keep PowerShell open on installer failure

### DIFF
--- a/deploy/windows/install.ps1
+++ b/deploy/windows/install.ps1
@@ -73,7 +73,10 @@ function Write-Ok    ($msg) { Write-Host "[ok]    $msg" -ForegroundColor Green }
 function Write-Warn2 ($msg) { Write-Host "[warn]  $msg" -ForegroundColor Yellow }
 function Write-Fail  ($msg) {
     Write-Host "[fail]  $msg" -ForegroundColor Red
-    exit 1
+    # A terminating error aborts this installer while returning control to an
+    # existing interactive PowerShell. `exit` would close the entire host when
+    # the documented `irm ... | iex` command is run in a terminal (#868).
+    throw [System.InvalidOperationException]::new([string] $msg)
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/deployment/test_packaging.py
+++ b/tests/deployment/test_packaging.py
@@ -63,6 +63,17 @@ def test_windows_installer_syncs_the_native_group() -> None:
     )
 
 
+def test_windows_installer_failure_does_not_exit_interactive_host() -> None:
+    installer = WINDOWS_INSTALL_PS1.read_text(encoding="utf-8")
+    write_fail = installer.split("function Write-Fail", maxsplit=1)[1].split(
+        "# ---------------------------------------------------------------------------",
+        maxsplit=1,
+    )[0]
+
+    assert "throw [System.InvalidOperationException]" in write_fail
+    assert "exit 1" not in write_fail
+
+
 def test_quickstart_installs_web_search_dependencies() -> None:
     quickstart = QUICKSTART_SH.read_text()
     assert "--extra tools-search" in quickstart


### PR DESCRIPTION
## Summary

- replace the Windows installer helper’s process-wide `exit 1` with a terminating PowerShell exception
- keep the caller’s PowerShell host open when the installer is invoked through `irm ... | iex`
- add a packaging regression that prevents `Write-Fail` from reintroducing a host-closing exit

## Validation

- `pytest tests/deployment/test_packaging.py -q` (8 passed)
- `ruff check` and `ruff format --check` on the changed test

Fixes #868