### PR TITLE
feat: support named Google account profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,26 +90,24 @@ jarvis connect --account personal-main google
 jarvis connect --account work google
 jarvis connect --account subscriptions google
 
+# Authorize and immediately index every Google primitive for one profile.
+jarvis connect --account work --sync google
+
 # Sync or inspect one account at a time through the API server.
 jarvis serve --port 8000
 curl -X POST 'http://127.0.0.1:8000/v1/connectors/gmail/sync?account=personal-main'
 curl 'http://127.0.0.1:8000/v1/connectors/gmail/sync?account=personal-main'
 
-# Scope research to a single account by using source:account filters.
-jarvis ask --research \
-  "Search only gmail:personal-main for the renewal notice. Do not use other accounts."
-jarvis ask --research \
-  "Search only gmail:work for the quarterly planning thread. Do not use other accounts."
+# Scope research with a hard account boundary.
+jarvis ask --account personal-main "Find the renewal notice"
+jarvis ask --account work "Find the quarterly planning thread"
 ```
 
 Account-scoped filters are available as `gmail:<account>`, `gdrive:<account>`,
 `gcalendar:<account>`, and `google_tasks:<account>` wherever connector sources
 are supported. The search layer treats zero matches inside an account as zero
 matches; it will not synthesize a recent unrelated email as a fallback result.
-Incremental syncs also re-fetch a small lookback window, configurable with
-`OPENJARVIS_SYNC_LOOKBACK_SECONDS`, so messages that arrive slightly before the
-last polling timestamp are not skipped. See
-[Google Account Profiles](https://open-jarvis.github.io/OpenJarvis/user-guide/google-account-profiles/).
+See [Google Account Profiles](https://open-jarvis.github.io/OpenJarvis/user-guide/google-account-profiles/).
 
 Per-preset deep dives: [morning digest](https://open-jarvis.github.io/OpenJarvis/user-guide/morning-digest/) · [deep research](https://open-jarvis.github.io/OpenJarvis/user-guide/deep-research/) · [code assistant](https://open-jarvis.github.io/OpenJarvis/user-guide/code-assistant/) · [scheduled monitor](https://open-jarvis.github.io/OpenJarvis/user-guide/scheduled-monitor/) · [chat simple](https://open-jarvis.github.io/OpenJarvis/user-guide/chat-simple/) · or the full [quickstart guide](https://open-jarvis.github.io/OpenJarvis/getting-started/quickstart/).
 

--- a/README.md
+++ b/README.md
@@ -74,8 +74,15 @@ Example:
 ```bash
 jarvis init --preset morning-digest-mac
 jarvis connect gdrive          # one OAuth covers Gmail / Calendar / Tasks
+jarvis connect google --account work      # optional named Google profile
 jarvis digest --fresh          # generate and play your first briefing
 ```
+
+Named Google profiles let you connect accounts such as `personal`, `work`, or
+`subscriptions` side by side. Analysis can then stay scoped with prompts like
+`jarvis ask "Summarize only work Gmail about renewals"` or direct filters such
+as `source="gmail:work"`. See
+[Google Account Profiles](https://open-jarvis.github.io/OpenJarvis/user-guide/google-account-profiles/).
 
 Per-preset deep dives: [morning digest](https://open-jarvis.github.io/OpenJarvis/user-guide/morning-digest/) · [deep research](https://open-jarvis.github.io/OpenJarvis/user-guide/deep-research/) · [code assistant](https://open-jarvis.github.io/OpenJarvis/user-guide/code-assistant/) · [scheduled monitor](https://open-jarvis.github.io/OpenJarvis/user-guide/scheduled-monitor/) · [chat simple](https://open-jarvis.github.io/OpenJarvis/user-guide/chat-simple/) · or the full [quickstart guide](https://open-jarvis.github.io/OpenJarvis/getting-started/quickstart/).
 

--- a/README.md
+++ b/README.md
@@ -79,9 +79,36 @@ jarvis digest --fresh          # generate and play your first briefing
 ```
 
 Named Google profiles let you connect accounts such as `personal`, `work`, or
-`subscriptions` side by side. Analysis can then stay scoped with prompts like
-`jarvis ask "Summarize only work Gmail about renewals"` or direct filters such
-as `source="gmail:work"`. See
+`subscriptions` side by side. Each profile gets its own OAuth token file, source
+IDs, provenance metadata, and sync checkpoint, so Gmail/Drive/Calendar/Tasks data
+from one account does not overwrite or resume from another account's state.
+
+```bash
+# Connect multiple Google identities side by side. The account alias comes
+# before the provider name.
+jarvis connect --account personal-main google
+jarvis connect --account work google
+jarvis connect --account subscriptions google
+
+# Sync or inspect one account at a time through the API server.
+jarvis serve --port 8000
+curl -X POST 'http://127.0.0.1:8000/v1/connectors/gmail/sync?account=personal-main'
+curl 'http://127.0.0.1:8000/v1/connectors/gmail/sync?account=personal-main'
+
+# Scope research to a single account by using source:account filters.
+jarvis ask --research \
+  "Search only gmail:personal-main for the renewal notice. Do not use other accounts."
+jarvis ask --research \
+  "Search only gmail:work for the quarterly planning thread. Do not use other accounts."
+```
+
+Account-scoped filters are available as `gmail:<account>`, `gdrive:<account>`,
+`gcalendar:<account>`, and `google_tasks:<account>` wherever connector sources
+are supported. The search layer treats zero matches inside an account as zero
+matches; it will not synthesize a recent unrelated email as a fallback result.
+Incremental syncs also re-fetch a small lookback window, configurable with
+`OPENJARVIS_SYNC_LOOKBACK_SECONDS`, so messages that arrive slightly before the
+last polling timestamp are not skipped. See
 [Google Account Profiles](https://open-jarvis.github.io/OpenJarvis/user-guide/google-account-profiles/).
 
 Per-preset deep dives: [morning digest](https://open-jarvis.github.io/OpenJarvis/user-guide/morning-digest/) · [deep research](https://open-jarvis.github.io/OpenJarvis/user-guide/deep-research/) · [code assistant](https://open-jarvis.github.io/OpenJarvis/user-guide/code-assistant/) · [scheduled monitor](https://open-jarvis.github.io/OpenJarvis/user-guide/scheduled-monitor/) · [chat simple](https://open-jarvis.github.io/OpenJarvis/user-guide/chat-simple/) · or the full [quickstart guide](https://open-jarvis.github.io/OpenJarvis/getting-started/quickstart/).

--- a/docs/development/google-account-profiles-analysis-layer.md
+++ b/docs/development/google-account-profiles-analysis-layer.md
@@ -113,8 +113,8 @@ preserve the same profile scope.
 The connector sync API accepts an optional account query parameter:
 
 ```text
-POST /api/connectors/{connector_id}/sync?account=work
-GET  /api/connectors/{connector_id}/sync-status?account=work
+POST /v1/connectors/gmail/sync?account=work
+GET  /v1/connectors/gmail/sync?account=work
 ```
 
 Sync state is keyed by connector/profile pair. A long-running `gmail:work` sync

--- a/docs/development/google-account-profiles-analysis-layer.md
+++ b/docs/development/google-account-profiles-analysis-layer.md
@@ -1,0 +1,176 @@
+# Google Account Profiles: Analysis Layer Plan
+
+This note extends the Google connector profile work from the connect/auth layer
+into analysis, retrieval, citations, and test coverage.
+
+## Goal
+
+Named Google profiles should not stop at token storage. Once users connect
+accounts such as `personal`, `work`, `research`, `subscriptions`, or `banqer`,
+OpenJarvis should preserve that account boundary through indexing and analysis
+so a query can intentionally search one persona, several personas, or all
+indexed Google data.
+
+## Data Model
+
+Connector documents now carry profile metadata:
+
+```python
+metadata = {
+    "account": "work",
+    "source_profile": "work",
+    "connector": "gmail",
+}
+```
+
+Google document IDs are also account-aware where applicable, for example:
+
+```text
+gmail:work:<message-id>
+gdrive:research:<file-id>
+gcalendar:family:<event-id>
+```
+
+The knowledge store exposes both plain connector IDs and account-scoped IDs in
+`distinct_sources()`:
+
+```text
+gmail
+gmail:work
+gdrive:research
+gcalendar:family
+```
+
+## Retrieval Semantics
+
+Analysis supports two equivalent scoping styles:
+
+```python
+store.retrieve("renewals", source="gmail:work")
+hybrid.search("renewals", sources=["gmail"], accounts=["work"])
+```
+
+The first form is useful for direct retrieval and config-style source lists.
+The second form is useful for planners because account aliases can be combined
+with multiple connectors:
+
+```python
+hybrid.search(
+    "calendar conflicts",
+    sources=["gcalendar"],
+    accounts=["personal", "work"],
+)
+```
+
+`HybridSearch` applies account filters with
+`json_extract(metadata, '$.account')`, so source and account filters intersect
+instead of overwriting each other. For example, `sources=["gdrive"]` plus
+`accounts=["work"]` returns work Drive chunks, not work Gmail or personal Drive.
+
+## Planner Behavior
+
+The research loop exposes a structured `accounts` search parameter:
+
+```python
+search(query, person=None, time_range=None, sources=None, accounts=None, limit=20)
+```
+
+Planner rules now tell the model:
+
+- Use `sources=[...]` when the user names a connector such as Gmail, Drive, or
+  Calendar.
+- Use account-scoped source IDs such as `gmail:work` only when they appear in
+  the connected-sources list.
+- Use `accounts=[...]` when the user names a persona/profile/account such as
+  "work account", "personal Drive", or "research calendar".
+- Combine both filters when the user names both a connector and an account, for
+  example `sources=["gmail"], accounts=["work"]`.
+
+Example user requests:
+
+```text
+Summarize only my work email and calendar.
+Search my research Drive, not personal Drive.
+What overlaps between my personal calendar and project calendar?
+Find docs related to x0bni across my project account and personal notes.
+```
+
+## Citation And UI Metadata
+
+Search hits now include:
+
+```python
+SearchHit.account
+SearchHit.source_profile
+```
+
+`build_sources_for_client()` passes both fields through to the citation payload
+so the UI can render provenance such as `Gmail / work` and follow-up queries can
+preserve the same profile scope.
+
+## Sync API
+
+The connector sync API accepts an optional account query parameter:
+
+```text
+POST /api/connectors/{connector_id}/sync?account=work
+GET  /api/connectors/{connector_id}/sync-status?account=work
+```
+
+Sync state is keyed by connector/profile pair. A long-running `gmail:work` sync
+does not hide or overwrite `gmail:personal` status.
+
+## Migration
+
+For a clean install that already has one legacy Google profile:
+
+```bash
+jarvis connect google --account work
+```
+
+This creates a fresh token at:
+
+```text
+~/.openjarvis/connectors/google/accounts/work.json
+```
+
+If reauthenticating is not desirable, copy the legacy token:
+
+```bash
+mkdir -p ~/.openjarvis/connectors/google/accounts
+cp ~/.openjarvis/connectors/google.json \
+  ~/.openjarvis/connectors/google/accounts/work.json
+```
+
+Then run a profile sync so newly indexed chunks receive account metadata.
+
+## Test Plan
+
+Connector/auth/profile tests:
+
+```bash
+uv run --extra dev pytest \
+  tests/connectors/test_oauth_flow.py \
+  tests/connectors/test_gmail.py \
+  tests/connectors/test_store.py \
+  tests/cli/test_connect.py
+```
+
+Analysis-layer tests:
+
+```bash
+uv run --extra dev pytest \
+  tests/agents/test_research_loop.py \
+  tests/connectors/test_hybrid_search.py
+```
+
+Lint:
+
+```bash
+uv run --extra dev ruff check \
+  src/openjarvis/agents/research_loop.py \
+  src/openjarvis/connectors/hybrid_search.py \
+  src/openjarvis/server/connectors_router.py \
+  tests/agents/test_research_loop.py \
+  tests/connectors/test_hybrid_search.py
+```

--- a/docs/development/google-account-profiles-analysis-layer.md
+++ b/docs/development/google-account-profiles-analysis-layer.md
@@ -125,7 +125,7 @@ does not hide or overwrite `gmail:personal` status.
 For a clean install that already has one legacy Google profile:
 
 ```bash
-jarvis connect google --account work
+jarvis connect google --account work --migrate-legacy-google --sync
 ```
 
 This creates a fresh token at:
@@ -142,7 +142,12 @@ cp ~/.openjarvis/connectors/google.json \
   ~/.openjarvis/connectors/google/accounts/work.json
 ```
 
-Then run a profile sync so newly indexed chunks receive account metadata.
+Then run the same explicit migration command so legacy unscoped rows and
+checkpoints are removed before the named profile is reindexed:
+
+```bash
+jarvis connect google --account work --migrate-legacy-google --sync
+```
 
 ## Test Plan
 

--- a/docs/user-guide/channels-and-connectors.md
+++ b/docs/user-guide/channels-and-connectors.md
@@ -186,6 +186,25 @@ The fastest way is to use the App Manifest — paste this JSON to configure ever
    - Your browser will open Google's consent page → grant read-only access
    - You'll see "Authorization successful!" → Drive data starts syncing
 
+### Named Google profiles
+
+Use a profile alias when you want multiple Google accounts on the same
+OpenJarvis install:
+
+```bash
+jarvis connect google --account work
+jarvis connect google --account personal
+jarvis connect gdrive --account research
+```
+
+Tokens are stored separately under
+`~/.openjarvis/connectors/google/accounts/<alias>.json`, and indexed chunks are
+tagged with that alias. Research queries can then scope analysis to one profile,
+for example `gmail:work` or `sources=["gdrive"], accounts=["research"]`.
+
+See [Google Account Profiles](google-account-profiles.md) for migration steps
+from the legacy single-profile token file and analysis examples.
+
 ### Troubleshooting
 
 | Issue | Solution |

--- a/docs/user-guide/deep-research.md
+++ b/docs/user-guide/deep-research.md
@@ -100,6 +100,9 @@ default_backend = "sqlite"
 # Summarize across multiple documents
 jarvis ask "Summarize all emails about the Q3 budget review"
 
+# Restrict a Google query to a named account profile
+jarvis ask "Summarize only my work Gmail about subscription renewals"
+
 # Cross-reference sources
 jarvis ask "What do papers A and B agree on regarding attention mechanisms?"
 
@@ -112,6 +115,35 @@ jarvis ask "List all action items from the meeting notes in ~/Documents/meetings
 # Research with web fallback
 jarvis ask "Compare our internal benchmarks with the latest published results"
 ```
+
+## Google Account-Scoped Research
+
+If you connect multiple Google profiles, the research agent can keep analysis
+scoped to one persona or compare across personas. Connect profiles with an
+alias:
+
+```bash
+jarvis connect google --account work
+jarvis connect google --account personal
+jarvis connect gdrive --account research
+```
+
+After sync, OpenJarvis exposes both connector-level sources and scoped sources:
+
+```text
+gmail
+gmail:work
+gdrive:research
+gcalendar:personal
+```
+
+The planner uses those aliases as structured filters. For example, "only work
+Gmail" becomes `sources=["gmail"], accounts=["work"]`, while "research Drive"
+becomes `sources=["gdrive"], accounts=["research"]`. Citations include the
+profile alias so the UI can show which account produced each source.
+
+For setup, migration, and test commands, see
+[Google Account Profiles](google-account-profiles.md).
 
 ## Indexing Different Data Sources
 

--- a/docs/user-guide/google-account-profiles.md
+++ b/docs/user-guide/google-account-profiles.md
@@ -129,11 +129,12 @@ hybrid.search("Q3 plan", sources=["gdrive"], accounts=["research"])
 
 ## UI And API Sync
 
-The connector sync API accepts an optional `account` query parameter:
+The connector sync API accepts an optional `account` query parameter. Use the
+real connector routes, not a synthetic `/v1/connectors/google/...` endpoint:
 
 ```text
-POST /api/connectors/google/sync?account=work
-GET  /api/connectors/google/sync-status?account=work
+POST /v1/connectors/gmail/sync?account=work
+GET  /v1/connectors/gmail/sync?account=work
 ```
 
 Sync status is tracked per connector/profile pair, so a long sync for

--- a/docs/user-guide/google-account-profiles.md
+++ b/docs/user-guide/google-account-profiles.md
@@ -1,0 +1,171 @@
+# Google Account Profiles
+
+OpenJarvis supports named Google profile aliases so multiple Google accounts can
+be connected, synced, and searched without overwriting each other's OAuth
+tokens. Use aliases such as `personal`, `work`, `subscriptions`,
+`kanakia-org-home`, or `banqer` to keep indexed data persona-scoped.
+
+## Connect Profiles
+
+Use `jarvis connect google` when you want one OAuth grant to cover Gmail, Drive,
+Calendar, Contacts, and Tasks.
+
+```bash
+# Default Google profile
+jarvis connect google
+
+# Named profiles
+jarvis connect google --account work
+jarvis connect google --account personal
+jarvis connect google --account subscriptions
+```
+
+The connector-specific commands use the same profile store and can also take an
+account alias:
+
+```bash
+jarvis connect gmail --account work
+jarvis connect gdrive --account research
+jarvis connect gcalendar --account family
+```
+
+`--profile` is accepted as an alias for `--account`.
+
+## Alias Names
+
+Aliases should be short, readable, and stable. They are normalized into safe
+directory names, so names such as `aquantive-nirav`, `kanakia.org-home`, and
+`banqer` work. Prefer lowercase words separated by `-`, `_`, or `.`.
+
+Avoid putting secrets in alias names. Aliases are used in local file paths,
+document IDs, metadata, and source filters.
+
+## Token Storage
+
+Named profiles are stored under:
+
+```text
+~/.openjarvis/connectors/google/accounts/<alias>.json
+```
+
+Examples:
+
+```text
+~/.openjarvis/connectors/google/accounts/work.json
+~/.openjarvis/connectors/google/accounts/personal.json
+~/.openjarvis/connectors/google/accounts/banqer.json
+```
+
+The legacy single-profile token path is still read for compatibility:
+
+```text
+~/.openjarvis/connectors/google.json
+```
+
+## Migrating A Clean Install With One Existing Profile
+
+If a machine already has one Google connection from before profile aliases,
+choose the alias you want that account to become and reconnect:
+
+```bash
+jarvis connect google --account work
+```
+
+That is the safest path because it creates a fresh profile token in the new
+segmented location. Existing indexed data can remain in the knowledge store;
+new syncs will write account metadata for the chosen alias.
+
+If you need to preserve the existing token without reauthenticating, copy the
+legacy token into the new account directory:
+
+```bash
+mkdir -p ~/.openjarvis/connectors/google/accounts
+cp ~/.openjarvis/connectors/google.json \
+  ~/.openjarvis/connectors/google/accounts/work.json
+```
+
+After copying, run a sync for that account so newly indexed chunks receive the
+account metadata:
+
+```bash
+jarvis connect google --account work
+```
+
+## Analysis And Queries
+
+Once profiles have synced, analysis works through the normal research and memory
+tools. Each indexed chunk carries account metadata, and source lists expose both
+plain connector IDs and scoped connector IDs:
+
+```text
+gmail
+gmail:work
+gdrive:research
+gcalendar:family
+```
+
+Natural-language examples:
+
+```bash
+jarvis ask "Summarize only my work Gmail about subscription renewals"
+jarvis ask "Find Drive files from research about the Q3 plan"
+jarvis ask "Compare personal calendar and work calendar conflicts this week"
+```
+
+The research planner maps these requests to structured filters:
+
+```python
+search("subscription renewals", sources=["gmail"], accounts=["work"])
+search("Q3 plan", sources=["gdrive"], accounts=["research"])
+search("calendar conflicts", sources=["gcalendar"], accounts=["personal", "work"])
+```
+
+Direct retrieval can use either scoped source IDs or an account filter:
+
+```python
+store.retrieve("subscription renewals", source="gmail:work")
+hybrid.search("Q3 plan", sources=["gdrive"], accounts=["research"])
+```
+
+## UI And API Sync
+
+The connector sync API accepts an optional `account` query parameter:
+
+```text
+POST /api/connectors/google/sync?account=work
+GET  /api/connectors/google/sync-status?account=work
+```
+
+Sync status is tracked per connector/profile pair, so a long sync for
+`gmail:work` does not mask the state of `gmail:personal`.
+
+## How To Test
+
+For CLI and connector profile behavior:
+
+```bash
+uv run --extra dev pytest \
+  tests/connectors/test_oauth_flow.py \
+  tests/connectors/test_gmail.py \
+  tests/connectors/test_store.py \
+  tests/cli/test_connect.py
+```
+
+For analysis-layer account filters:
+
+```bash
+uv run --extra dev pytest \
+  tests/agents/test_research_loop.py \
+  tests/connectors/test_hybrid_search.py
+```
+
+For linting touched code:
+
+```bash
+uv run --extra dev ruff check \
+  src/openjarvis/agents/research_loop.py \
+  src/openjarvis/connectors/hybrid_search.py \
+  src/openjarvis/server/connectors_router.py \
+  tests/agents/test_research_loop.py \
+  tests/connectors/test_hybrid_search.py
+```

--- a/docs/user-guide/google-account-profiles.md
+++ b/docs/user-guide/google-account-profiles.md
@@ -75,9 +75,12 @@ jarvis connect google --account work --migrate-legacy-google --sync
 
 The migration flag is intentionally explicit because it deletes only legacy
 Google rows whose metadata has no account alias. It preserves every already
-named profile. Reindexing then writes collision-safe IDs and account metadata,
-preventing duplicates and ensuring a later named disconnect removes all data
-owned by that profile.
+named profile. Historical Gmail OAuth and Gmail IMAP rows both used
+`source = "gmail"`; ambiguous unmarked Gmail rows are therefore preserved
+instead of risking unrelated IMAP mail, while Gmail rows carrying positive
+Google-connector provenance are migrated. Reindexing writes collision-safe IDs
+and account metadata so future disconnects can remove exactly the selected
+profile.
 
 If you need to preserve the existing token without reauthenticating, copy the
 legacy token into the new account directory:
@@ -163,9 +166,12 @@ when available. The email is provenance for display and citation only; it is
 not independently signature-validated and never controls authorization. The
 local alias remains the retrieval boundary.
 
-Setting a declared profile to `enabled = false` prevents CLI/server use and
-removes it from configured default research and digest account lists. Unlisted
-ad-hoc aliases remain enabled for backwards compatibility.
+Setting a declared profile to `enabled = false` prevents new CLI/server use and
+removes it from configured default research and digest account lists. Cleanup
+remains available with `jarvis connect --account ALIAS --disconnect google` or
+the provider-wide disconnect API, so disabling a profile never traps its
+credentials or index. Unlisted ad-hoc aliases remain enabled for backwards
+compatibility.
 
 ## UI And API Sync
 

--- a/docs/user-guide/google-account-profiles.md
+++ b/docs/user-guide/google-account-profiles.md
@@ -33,9 +33,10 @@ jarvis connect gcalendar --account family
 
 ## Alias Names
 
-Aliases should be short, readable, and stable. They are normalized into safe
-directory names, so names such as `aquantive-nirav`, `kanakia.org-home`, and
-`banqer` work. Prefer lowercase words separated by `-`, `_`, or `.`.
+Aliases should be short, readable, and stable. They are normalized to lowercase
+safe filenames, so names such as `aquantive-nirav`, `kanakia.org-home`, and
+`banqer` work. Windows-reserved names and trailing dots are rejected. Prefer
+lowercase words separated by `-`, `_`, or `.`.
 
 Avoid putting secrets in alias names. Aliases are used in local file paths,
 document IDs, metadata, and source filters.
@@ -107,10 +108,14 @@ gcalendar:family
 Natural-language examples:
 
 ```bash
-jarvis ask "Summarize only my work Gmail about subscription renewals"
-jarvis ask "Find Drive files from research about the Q3 plan"
-jarvis ask "Compare personal calendar and work calendar conflicts this week"
+jarvis ask --account work "Summarize Gmail subscription renewals"
+jarvis ask --account research "Find Drive files about the Q3 plan"
+jarvis ask --accounts personal,work "Compare calendar conflicts this week"
 ```
+
+`--account` is repeatable and `--accounts` accepts a comma-separated list. An
+account filter implies `--research`, because the boundary applies to indexed
+knowledge retrieval rather than direct model inference.
 
 The research planner maps these requests to structured filters:
 
@@ -127,6 +132,32 @@ store.retrieve("subscription renewals", source="gmail:work")
 hybrid.search("Q3 plan", sources=["gdrive"], accounts=["research"])
 ```
 
+Set a default research boundary and expand morning-digest Google sources across
+selected profiles in `config.toml`:
+
+```toml
+[connectors.google.accounts.personal]
+enabled = true
+
+[connectors.google.accounts.work]
+enabled = true
+
+[agent]
+default_accounts = ["personal"]
+
+[digest]
+accounts = ["personal", "work"]
+
+[digest.messages]
+sources = ["gmail", "google_tasks"]
+```
+
+An explicitly scoped source such as `gmail:research` is left unchanged. Without
+`digest.accounts`, section sources keep their legacy default-profile behavior.
+Google sync documents include the local alias, connector, and the verified
+`source_email` claim returned by Google, when available. The email is
+provenance for display and citation; the alias remains the retrieval boundary.
+
 ## UI And API Sync
 
 The connector sync API accepts an optional `account` query parameter. Use the
@@ -139,6 +170,18 @@ GET  /v1/connectors/gmail/sync?account=work
 
 Sync status is tracked per connector/profile pair, so a long sync for
 `gmail:work` does not mask the state of `gmail:personal`.
+
+One named Google profile uses a shared OAuth grant for all five Google
+connectors. Disconnecting any one of those connector routes for a named account
+therefore disconnects the whole named Google profile and removes that account's
+Gmail, Drive, Calendar, Contacts, and Tasks index rows together:
+
+```text
+POST /v1/connectors/gdrive/disconnect?account=work
+```
+
+This provider-wide behavior prevents half-disconnected profiles with stale
+indexed data. Other named accounts are not affected.
 
 ## How To Test
 

--- a/docs/user-guide/google-account-profiles.md
+++ b/docs/user-guide/google-account-profiles.md
@@ -66,15 +66,18 @@ The legacy single-profile token path is still read for compatibility:
 ## Migrating A Clean Install With One Existing Profile
 
 If a machine already has one Google connection from before profile aliases,
-choose the alias you want that account to become and reconnect:
+choose the alias you want that account to become, explicitly remove the
+unscoped legacy index rows/checkpoints, and reindex:
 
 ```bash
-jarvis connect google --account work
+jarvis connect google --account work --migrate-legacy-google --sync
 ```
 
-That is the safest path because it creates a fresh profile token in the new
-segmented location. Existing indexed data can remain in the knowledge store;
-new syncs will write account metadata for the chosen alias.
+The migration flag is intentionally explicit because it deletes only legacy
+Google rows whose metadata has no account alias. It preserves every already
+named profile. Reindexing then writes collision-safe IDs and account metadata,
+preventing duplicates and ensuring a later named disconnect removes all data
+owned by that profile.
 
 If you need to preserve the existing token without reauthenticating, copy the
 legacy token into the new account directory:
@@ -85,11 +88,11 @@ cp ~/.openjarvis/connectors/google.json \
   ~/.openjarvis/connectors/google/accounts/work.json
 ```
 
-After copying, run a sync for that account so newly indexed chunks receive the
-account metadata:
+After copying, run the same explicit migration and sync so indexed chunks
+receive the account metadata:
 
 ```bash
-jarvis connect google --account work
+jarvis connect google --account work --migrate-legacy-google --sync
 ```
 
 ## Analysis And Queries
@@ -154,9 +157,15 @@ sources = ["gmail", "google_tasks"]
 
 An explicitly scoped source such as `gmail:research` is left unchanged. Without
 `digest.accounts`, section sources keep their legacy default-profile behavior.
-Google sync documents include the local alias, connector, and the verified
-`source_email` claim returned by Google, when available. The email is
-provenance for display and citation; the alias remains the retrieval boundary.
+Google sync documents include the local alias, connector, and the
+provider-asserted `source_email` claim delivered by Google's TLS token endpoint,
+when available. The email is provenance for display and citation only; it is
+not independently signature-validated and never controls authorization. The
+local alias remains the retrieval boundary.
+
+Setting a declared profile to `enabled = false` prevents CLI/server use and
+removes it from configured default research and digest account lists. Unlisted
+ad-hoc aliases remain enabled for backwards compatibility.
 
 ## UI And API Sync
 

--- a/frontend/src/components/GoogleAccountField.test.tsx
+++ b/frontend/src/components/GoogleAccountField.test.tsx
@@ -1,0 +1,37 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+
+import { GoogleAccountField, supportsGoogleAccounts } from './GoogleAccountField';
+
+describe('Google account profile field', () => {
+  it('renders known aliases and verified source-email provenance', () => {
+    const html = renderToStaticMarkup(
+      <GoogleAccountField
+        connectorId="gdrive"
+        account="work"
+        accounts={[
+          {
+            account: 'work',
+            connected: true,
+            source_email: 'person@company.example',
+          },
+          { account: 'personal', connected: false },
+        ]}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(html).toContain('Google account profile');
+    expect(html).toContain('value="work"');
+    expect(html).toContain('value="personal"');
+    expect(html).toContain('person@company.example');
+    expect(html).toContain('Actions apply only to');
+  });
+
+  it('only enables named profiles for Google provider connectors', () => {
+    expect(supportsGoogleAccounts('gmail')).toBe(true);
+    expect(supportsGoogleAccounts('google_tasks')).toBe(true);
+    expect(supportsGoogleAccounts('spotify')).toBe(false);
+    expect(supportsGoogleAccounts('gmail_imap')).toBe(false);
+  });
+});

--- a/frontend/src/components/GoogleAccountField.test.tsx
+++ b/frontend/src/components/GoogleAccountField.test.tsx
@@ -1,10 +1,14 @@
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it, vi } from 'vitest';
 
-import { GoogleAccountField, supportsGoogleAccounts } from './GoogleAccountField';
+import {
+  GoogleAccountField,
+  normalizeGoogleAccount,
+  supportsGoogleAccounts,
+} from './GoogleAccountField';
 
 describe('Google account profile field', () => {
-  it('renders known aliases and verified source-email provenance', () => {
+  it('renders known aliases and provider-asserted source-email provenance', () => {
     const html = renderToStaticMarkup(
       <GoogleAccountField
         connectorId="gdrive"
@@ -33,6 +37,10 @@ describe('Google account profile field', () => {
     expect(supportsGoogleAccounts('google_tasks')).toBe(true);
     expect(supportsGoogleAccounts('spotify')).toBe(false);
     expect(supportsGoogleAccounts('gmail_imap')).toBe(false);
+  });
+
+  it('normalizes aliases before they reach connector lifecycle state', () => {
+    expect(normalizeGoogleAccount(' Work ')).toBe('work');
   });
 
   it('marks configured disabled profiles as unavailable', () => {

--- a/frontend/src/components/GoogleAccountField.test.tsx
+++ b/frontend/src/components/GoogleAccountField.test.tsx
@@ -2,6 +2,7 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  canSelectGoogleAccountProfile,
   GoogleAccountField,
   normalizeGoogleAccount,
   supportsGoogleAccounts,
@@ -43,18 +44,26 @@ describe('Google account profile field', () => {
     expect(normalizeGoogleAccount(' Work ')).toBe('work');
   });
 
-  it('marks configured disabled profiles as unavailable', () => {
+  it('keeps disabled connected profiles selectable only for cleanup', () => {
+    const accounts = [
+      { account: 'work', connected: true, enabled: true },
+      { account: 'personal', connected: true, enabled: false },
+      { account: 'archived', connected: false, enabled: false },
+    ];
+    expect(canSelectGoogleAccountProfile(accounts, 'personal')).toBe(true);
+    expect(canSelectGoogleAccountProfile(accounts, 'archived')).toBe(false);
+
     const html = renderToStaticMarkup(
       <GoogleAccountField
         connectorId="gmail"
         account="work"
-        accounts={[{ account: 'work', connected: true, enabled: false }]}
+        accounts={accounts}
         onChange={vi.fn()}
       />,
     );
 
-    expect(html).toContain('disabled in config.toml');
-    expect(html).toMatch(/<option[^>]*disabled/);
-    expect(html).toContain('work — disabled');
+    expect(html).toMatch(/<option value="personal">/);
+    expect(html).toMatch(/<option value="archived" disabled/);
+    expect(html).toContain('personal — disabled');
   });
 });

--- a/frontend/src/components/GoogleAccountField.test.tsx
+++ b/frontend/src/components/GoogleAccountField.test.tsx
@@ -34,4 +34,19 @@ describe('Google account profile field', () => {
     expect(supportsGoogleAccounts('spotify')).toBe(false);
     expect(supportsGoogleAccounts('gmail_imap')).toBe(false);
   });
+
+  it('marks configured disabled profiles as unavailable', () => {
+    const html = renderToStaticMarkup(
+      <GoogleAccountField
+        connectorId="gmail"
+        account="work"
+        accounts={[{ account: 'work', connected: true, enabled: false }]}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(html).toContain('disabled in config.toml');
+    expect(html).toMatch(/<option[^>]*disabled/);
+    expect(html).toContain('work — disabled');
+  });
 });

--- a/frontend/src/components/GoogleAccountField.tsx
+++ b/frontend/src/components/GoogleAccountField.tsx
@@ -17,6 +17,19 @@ export function normalizeGoogleAccount(account: string): string {
   return account.trim().toLowerCase();
 }
 
+export function canSelectGoogleAccountProfile(
+  accounts: NonNullable<ConnectorInfo['accounts']>,
+  account: string,
+): boolean {
+  const normalized = normalizeGoogleAccount(account);
+  const profile = accounts.find(
+    (candidate) => normalizeGoogleAccount(candidate.account) === normalized,
+  );
+  // A disabled profile cannot be connected or synced, but an existing
+  // connection must remain selectable so the user can disconnect/clean it.
+  return !profile || profile.enabled !== false || profile.connected;
+}
+
 export function GoogleAccountField({
   connectorId,
   account,
@@ -41,8 +54,11 @@ export function GoogleAccountField({
       profile.account.toLowerCase() === normalizedDraft && profile.enabled === false,
   );
   const commit = () => {
-    if (!disabledProfile) onChange(normalizedDraft);
+    if (canSelectGoogleAccountProfile(accounts, normalizedDraft)) {
+      onChange(normalizedDraft);
+    }
   };
+  const profileBlocked = !canSelectGoogleAccountProfile(accounts, normalizedDraft);
 
   return (
     <div style={{ marginBottom: 10 }}>
@@ -89,7 +105,7 @@ export function GoogleAccountField({
           <option
             key={profile.account}
             value={profile.account}
-            disabled={profile.enabled === false}
+            disabled={profile.enabled === false && !profile.connected}
           >
             {profile.source_email || (profile.connected ? 'Connected' : 'Not connected')}
           </option>
@@ -99,7 +115,7 @@ export function GoogleAccountField({
         <button
           type="button"
           onClick={commit}
-          disabled={disabled || Boolean(disabledProfile)}
+          disabled={disabled || profileBlocked}
           style={{
             marginTop: 5,
             padding: '4px 8px',
@@ -108,7 +124,7 @@ export function GoogleAccountField({
             borderRadius: 4,
             color: 'var(--color-on-accent)',
             fontSize: 10.5,
-            cursor: disabled || disabledProfile ? 'default' : 'pointer',
+            cursor: disabled || profileBlocked ? 'default' : 'pointer',
           }}
         >
           Use profile

--- a/frontend/src/components/GoogleAccountField.tsx
+++ b/frontend/src/components/GoogleAccountField.tsx
@@ -13,6 +13,10 @@ export function supportsGoogleAccounts(connectorId: string): boolean {
   return GOOGLE_CONNECTORS.has(connectorId);
 }
 
+export function normalizeGoogleAccount(account: string): string {
+  return account.trim().toLowerCase();
+}
+
 export function GoogleAccountField({
   connectorId,
   account,
@@ -31,13 +35,13 @@ export function GoogleAccountField({
 
   useEffect(() => setDraft(account), [account]);
 
-  const normalizedDraft = draft.trim().toLowerCase();
+  const normalizedDraft = normalizeGoogleAccount(draft);
   const disabledProfile = accounts.find(
     (profile) =>
       profile.account.toLowerCase() === normalizedDraft && profile.enabled === false,
   );
   const commit = () => {
-    if (!disabledProfile) onChange(draft.trim());
+    if (!disabledProfile) onChange(normalizedDraft);
   };
 
   return (

--- a/frontend/src/components/GoogleAccountField.tsx
+++ b/frontend/src/components/GoogleAccountField.tsx
@@ -1,0 +1,134 @@
+import { useEffect, useState } from 'react';
+import type { ConnectorInfo } from '../types/connectors';
+
+const GOOGLE_CONNECTORS = new Set([
+  'gmail',
+  'gdrive',
+  'gcalendar',
+  'gcontacts',
+  'google_tasks',
+]);
+
+export function supportsGoogleAccounts(connectorId: string): boolean {
+  return GOOGLE_CONNECTORS.has(connectorId);
+}
+
+export function GoogleAccountField({
+  connectorId,
+  account,
+  accounts = [],
+  disabled = false,
+  onChange,
+}: {
+  connectorId: string;
+  account: string;
+  accounts?: NonNullable<ConnectorInfo['accounts']>;
+  disabled?: boolean;
+  onChange: (account: string) => void;
+}) {
+  const listId = `google-account-${connectorId.replace(/[^a-z0-9_-]/gi, '-')}`;
+  const [draft, setDraft] = useState(account);
+
+  useEffect(() => setDraft(account), [account]);
+
+  const commit = () => onChange(draft.trim());
+
+  return (
+    <div style={{ marginBottom: 10 }}>
+      <label
+        htmlFor={listId}
+        style={{
+          display: 'block',
+          fontSize: 11,
+          fontWeight: 600,
+          color: 'var(--color-text-secondary)',
+          marginBottom: 4,
+        }}
+      >
+        Google account profile
+      </label>
+      <input
+        id={listId}
+        list={`${listId}-options`}
+        value={draft}
+        onChange={(event) => setDraft(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter') {
+            event.preventDefault();
+            commit();
+          }
+        }}
+        disabled={disabled}
+        placeholder="Profile name (for example, work)"
+        autoComplete="off"
+        style={{
+          width: '100%',
+          padding: '7px 10px',
+          background: 'var(--color-bg)',
+          border: '1px solid var(--color-border)',
+          borderRadius: 4,
+          color: 'var(--color-text)',
+          fontSize: 12,
+          boxSizing: 'border-box',
+          opacity: disabled ? 0.6 : 1,
+        }}
+      />
+      <datalist id={`${listId}-options`}>
+        {accounts.map((profile) => (
+          <option key={profile.account} value={profile.account}>
+            {profile.source_email || (profile.connected ? 'Connected' : 'Not connected')}
+          </option>
+        ))}
+      </datalist>
+      {draft.trim() !== account && (
+        <button
+          type="button"
+          onClick={commit}
+          disabled={disabled}
+          style={{
+            marginTop: 5,
+            padding: '4px 8px',
+            background: 'var(--color-accent-purple)',
+            border: 'none',
+            borderRadius: 4,
+            color: 'var(--color-on-accent)',
+            fontSize: 10.5,
+            cursor: disabled ? 'default' : 'pointer',
+          }}
+        >
+          Use profile
+        </button>
+      )}
+      <div
+        style={{
+          marginTop: 4,
+          fontSize: 10.5,
+          color: 'var(--color-text-tertiary)',
+        }}
+      >
+        {account
+          ? `Actions apply only to “${account}”.`
+          : 'Leave blank to use the legacy default Google connection.'}
+      </div>
+      {accounts.length > 0 && (
+        <div
+          data-testid="known-google-accounts"
+          style={{
+            marginTop: 4,
+            fontSize: 10.5,
+            color: 'var(--color-text-tertiary)',
+          }}
+        >
+          Known profiles:{' '}
+          {accounts
+            .map((profile) =>
+              profile.source_email
+                ? `${profile.account} (${profile.source_email})`
+                : profile.account,
+            )
+            .join(', ')}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/GoogleAccountField.tsx
+++ b/frontend/src/components/GoogleAccountField.tsx
@@ -31,7 +31,14 @@ export function GoogleAccountField({
 
   useEffect(() => setDraft(account), [account]);
 
-  const commit = () => onChange(draft.trim());
+  const normalizedDraft = draft.trim().toLowerCase();
+  const disabledProfile = accounts.find(
+    (profile) =>
+      profile.account.toLowerCase() === normalizedDraft && profile.enabled === false,
+  );
+  const commit = () => {
+    if (!disabledProfile) onChange(draft.trim());
+  };
 
   return (
     <div style={{ marginBottom: 10 }}>
@@ -75,7 +82,11 @@ export function GoogleAccountField({
       />
       <datalist id={`${listId}-options`}>
         {accounts.map((profile) => (
-          <option key={profile.account} value={profile.account}>
+          <option
+            key={profile.account}
+            value={profile.account}
+            disabled={profile.enabled === false}
+          >
             {profile.source_email || (profile.connected ? 'Connected' : 'Not connected')}
           </option>
         ))}
@@ -84,7 +95,7 @@ export function GoogleAccountField({
         <button
           type="button"
           onClick={commit}
-          disabled={disabled}
+          disabled={disabled || Boolean(disabledProfile)}
           style={{
             marginTop: 5,
             padding: '4px 8px',
@@ -93,7 +104,7 @@ export function GoogleAccountField({
             borderRadius: 4,
             color: 'var(--color-on-accent)',
             fontSize: 10.5,
-            cursor: disabled ? 'default' : 'pointer',
+            cursor: disabled || disabledProfile ? 'default' : 'pointer',
           }}
         >
           Use profile
@@ -110,6 +121,11 @@ export function GoogleAccountField({
           ? `Actions apply only to “${account}”.`
           : 'Leave blank to use the legacy default Google connection.'}
       </div>
+      {disabledProfile && (
+        <div role="alert" style={{ marginTop: 4, fontSize: 10.5, color: '#f59e0b' }}>
+          This profile is disabled in config.toml.
+        </div>
+      )}
       {accounts.length > 0 && (
         <div
           data-testid="known-google-accounts"
@@ -123,8 +139,10 @@ export function GoogleAccountField({
           {accounts
             .map((profile) =>
               profile.source_email
-                ? `${profile.account} (${profile.source_email})`
-                : profile.account,
+                ? `${profile.account} (${profile.source_email})${
+                    profile.enabled === false ? ' — disabled' : ''
+                  }`
+                : `${profile.account}${profile.enabled === false ? ' — disabled' : ''}`,
             )
             .join(', ')}
         </div>

--- a/frontend/src/components/setup/SourceConnectFlow.test.tsx
+++ b/frontend/src/components/setup/SourceConnectFlow.test.tsx
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { shouldStartServerOAuth } from './SourceConnectFlow';
+import type { ConnectResponse } from '../../types/connectors';
+
+function response(
+  patch: Partial<ConnectResponse> = {},
+): ConnectResponse {
+  return {
+    connector_id: 'gdrive',
+    connected: false,
+    status: 'pending',
+    ...patch,
+  };
+}
+
+describe('setup connector OAuth decisions', () => {
+  it('starts consent for an OAuth response that is still pending', () => {
+    expect(shouldStartServerOAuth('oauth', response())).toBe(true);
+  });
+
+  it('starts consent whenever an OAuth response is not connected', () => {
+    expect(
+      shouldStartServerOAuth(
+        'oauth',
+        response({ status: 'disconnected', connected: false }),
+      ),
+    ).toBe(true);
+  });
+
+  it('does not replace a completed OAuth or non-OAuth connection with consent', () => {
+    expect(
+      shouldStartServerOAuth(
+        'oauth',
+        response({ status: 'connected', connected: true }),
+      ),
+    ).toBe(false);
+    expect(shouldStartServerOAuth('token', response())).toBe(false);
+  });
+
+  it('honors an explicit oauth_required directive', () => {
+    expect(
+      shouldStartServerOAuth(
+        'token',
+        response({ status: 'oauth_required', oauth_start: '/oauth/start' }),
+      ),
+    ).toBe(true);
+  });
+});

--- a/frontend/src/components/setup/SourceConnectFlow.tsx
+++ b/frontend/src/components/setup/SourceConnectFlow.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   CheckCircle2,
   Circle,
@@ -10,10 +10,17 @@ import {
 import { SOURCE_CATALOG } from '../../types/connectors';
 import {
   connectSource,
+  listConnectors,
   openServerOAuthPopup,
   startServerOAuth,
 } from '../../lib/connectors-api';
-import type { ConnectRequest, ConnectorMeta } from '../../types/connectors';
+import { GoogleAccountField, supportsGoogleAccounts } from '../GoogleAccountField';
+import type {
+  ConnectRequest,
+  ConnectorInfo,
+  ConnectorMeta,
+  ConnectResponse,
+} from '../../types/connectors';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -24,7 +31,18 @@ type SourceState = 'pending' | 'connecting' | 'connected' | 'skipped' | 'error';
 interface SourceEntry {
   id: string;
   state: SourceState;
+  account?: string;
   error?: string;
+}
+
+export function shouldStartServerOAuth(
+  authType: ConnectorMeta['auth_type'] | undefined,
+  response: ConnectResponse,
+): boolean {
+  return (
+    response.status === 'oauth_required' ||
+    (authType === 'oauth' && !response.connected)
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -461,6 +479,30 @@ export function SourceConnectFlow({
     selectedIds.map((id) => ({ id, state: 'pending' as SourceState })),
   );
   const [activeIndex, setActiveIndex] = useState(0);
+  const [googleAccounts, setGoogleAccounts] = useState<
+    Record<string, NonNullable<ConnectorInfo['accounts']>>
+  >({});
+
+  useEffect(() => {
+    let cancelled = false;
+    listConnectors()
+      .then((connectors) => {
+        if (cancelled) return;
+        setGoogleAccounts(
+          Object.fromEntries(
+            connectors
+              .filter((connector) =>
+                supportsGoogleAccounts(connector.connector_id),
+              )
+              .map((connector) => [connector.connector_id, connector.accounts ?? []]),
+          ),
+        );
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const updateEntry = (id: string, patch: Partial<SourceEntry>) => {
     setEntries((prev) => prev.map((e) => (e.id === id ? { ...e, ...patch } : e)));
@@ -477,13 +519,17 @@ export function SourceConnectFlow({
 
   const handleConnect = async (id: string, req: ConnectRequest) => {
     const card = SOURCE_CATALOG.find((item) => item.connector_id === id);
+    const account = entries.find((entry) => entry.id === id)?.account?.trim() ?? '';
     const oauthPopup =
       card?.auth_type === 'oauth' ? openServerOAuthPopup() : null;
     updateEntry(id, { state: 'connecting', error: undefined });
     try {
-      const response = await connectSource(id, req);
-      if (response.status === 'oauth_required') {
-        await startServerOAuth(id, response.oauth_start, oauthPopup);
+      const response = await connectSource(
+        id,
+        account ? { ...req, account } : req,
+      );
+      if (shouldStartServerOAuth(card?.auth_type, response)) {
+        await startServerOAuth(id, response.oauth_start, oauthPopup, account);
       } else {
         oauthPopup?.close();
       }
@@ -555,6 +601,16 @@ export function SourceConnectFlow({
                 </div>
               )}
             </div>
+
+            {supportsGoogleAccounts(activeEntry.id) && (
+              <GoogleAccountField
+                connectorId={activeEntry.id}
+                account={activeEntry.account ?? ''}
+                accounts={googleAccounts[activeEntry.id] ?? []}
+                disabled={activeEntry.state === 'connecting'}
+                onChange={(account) => updateEntry(activeEntry.id, { account })}
+              />
+            )}
 
             {activeEntry.state === 'connected' ? (
               <div className="flex items-center gap-2 text-sm"

--- a/frontend/src/components/setup/SourceConnectFlow.tsx
+++ b/frontend/src/components/setup/SourceConnectFlow.tsx
@@ -8,8 +8,11 @@ import {
   Loader2,
 } from 'lucide-react';
 import { SOURCE_CATALOG } from '../../types/connectors';
-import { connectSource, getConnector } from '../../lib/connectors-api';
-import { getBase } from '../../lib/api';
+import {
+  connectSource,
+  openServerOAuthPopup,
+  startServerOAuth,
+} from '../../lib/connectors-api';
 import type { ConnectRequest, ConnectorMeta } from '../../types/connectors';
 
 // ---------------------------------------------------------------------------
@@ -138,56 +141,25 @@ function FilesystemPanel({
 
 function OAuthPanel({
   displayName,
-  authUrl,
-  connectorId,
   onConnect,
   onSkip,
   isConnecting,
 }: {
   displayName: string;
-  authUrl?: string;
-  connectorId: string;
   onConnect: (req: ConnectRequest) => void;
   onSkip: () => void;
   isConnecting: boolean;
 }) {
-  const [waiting, setWaiting] = useState(false);
-
-  const startOAuth = () => {
-    // Open the server's OAuth start endpoint which redirects to the provider
-    const oauthUrl = `${getBase()}/v1/connectors/${encodeURIComponent(connectorId)}/oauth/start`;
-    window.open(oauthUrl, '_blank', 'width=600,height=700');
-    setWaiting(true);
-
-    // Poll for connection status
-    const interval = setInterval(async () => {
-      try {
-        const info = await getConnector(connectorId);
-        if (info.connected) {
-          clearInterval(interval);
-          setWaiting(false);
-          onConnect({});
-        }
-      } catch {
-        // ignore polling errors
-      }
-    }, 2000);
-
-    // Stop polling after 3 minutes
-    setTimeout(() => {
-      clearInterval(interval);
-      setWaiting(false);
-    }, 180000);
-  };
+  const startOAuth = () => onConnect({});
 
   return (
     <div className="flex flex-col gap-4">
       <p className="text-sm" style={{ color: 'var(--color-text-secondary)' }}>
-        {waiting
+        {isConnecting
           ? `Waiting for ${displayName} authorization... Complete it in the browser window.`
           : `Connect your ${displayName} account with one click.`}
       </p>
-      {waiting ? (
+      {isConnecting ? (
         <div className="flex items-center gap-2 text-sm" style={{ color: 'var(--color-accent)' }}>
           <Loader2 size={16} className="animate-spin" />
           Waiting for authorization...
@@ -504,11 +476,20 @@ export function SourceConnectFlow({
   };
 
   const handleConnect = async (id: string, req: ConnectRequest) => {
+    const card = SOURCE_CATALOG.find((item) => item.connector_id === id);
+    const oauthPopup =
+      card?.auth_type === 'oauth' ? openServerOAuthPopup() : null;
     updateEntry(id, { state: 'connecting', error: undefined });
     try {
-      await connectSource(id, req);
+      const response = await connectSource(id, req);
+      if (response.status === 'oauth_required') {
+        await startServerOAuth(id, response.oauth_start, oauthPopup);
+      } else {
+        oauthPopup?.close();
+      }
       updateEntry(id, { state: 'connected' });
     } catch (err: unknown) {
+      oauthPopup?.close();
       const msg = err instanceof Error ? err.message : String(err);
       updateEntry(id, { state: 'error', error: msg });
       return;
@@ -606,8 +587,6 @@ export function SourceConnectFlow({
             ) : (
               <OAuthPanel
                 displayName={activeCard.display_name}
-                authUrl={undefined}
-                connectorId={activeEntry.id}
                 onConnect={(req) => handleConnect(activeEntry.id, req)}
                 onSkip={() => handleSkip(activeEntry.id)}
                 isConnecting={activeEntry.state === 'connecting'}

--- a/frontend/src/lib/connectors-api.auth.test.ts
+++ b/frontend/src/lib/connectors-api.auth.test.ts
@@ -203,16 +203,67 @@ describe('connectors-api sends the Bearer auth header', () => {
 
   it('scopes connector detail and sync calls to an account alias', async () => {
     fetchMock.mockImplementation(async () => okJson({}));
-    const { getConnector, getSyncStatus, triggerSync } = await freshConnectorsApi();
+    const {
+      connectSource,
+      disconnectSource,
+      getConnector,
+      getSyncStatus,
+      triggerSync,
+    } = await freshConnectorsApi();
 
+    await connectSource('gmail', { account: 'work', code: 'credential' });
     await getConnector('gmail', 'work');
     await getSyncStatus('gmail', 'work');
     await triggerSync('gmail', 'work');
+    await disconnectSource('gmail', undefined, 'work');
 
     expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+      '/v1/connectors/gmail/connect',
       '/v1/connectors/gmail?account=work',
       '/v1/connectors/gmail/sync?account=work',
       '/v1/connectors/gmail/sync?account=work',
+      '/v1/connectors/gmail/disconnect?account=work',
     ]);
+    expect(fetchMock.mock.calls[0]?.[1]?.body).toBe(
+      JSON.stringify({ account: 'work', code: 'credential' }),
+    );
+  });
+
+  it('carries a requested account through OAuth start and connection polling', async () => {
+    vi.useFakeTimers();
+    const popup = {
+      location: { href: 'about:blank' },
+      close: vi.fn(),
+    };
+    vi.stubGlobal('window', {
+      open: vi.fn(() => popup),
+      location: { origin: 'http://localhost:1313' },
+    });
+    try {
+      fetchMock
+        .mockResolvedValueOnce(
+          okJson({ authorization_url: 'https://accounts.example/authorize' }),
+        )
+        .mockResolvedValueOnce(okJson({ connected: true }));
+      const { startServerOAuth } = await freshConnectorsApi();
+
+      const flow = startServerOAuth(
+        'gdrive',
+        undefined,
+        popup as unknown as Window,
+        'work-team',
+      );
+      await vi.advanceTimersByTimeAsync(2000);
+      await flow;
+
+      expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+        '/v1/connectors/gdrive/oauth/start?account=work-team&response_mode=json',
+        '/v1/connectors/gdrive?account=work-team',
+      ]);
+      expect(popup.location.href).toBe('https://accounts.example/authorize');
+    } finally {
+      vi.useRealTimers();
+      vi.unstubAllGlobals();
+    }
   });
 });

--- a/frontend/src/lib/connectors-api.auth.test.ts
+++ b/frontend/src/lib/connectors-api.auth.test.ts
@@ -156,10 +156,20 @@ describe('connectors-api sends the Bearer auth header', () => {
 
   it('OAuth polling waits for a real connected state before resolving', async () => {
     vi.useFakeTimers();
-    const open = vi.fn();
-    vi.stubGlobal('window', { open });
+    const popup = {
+      location: { href: 'about:blank' },
+      close: vi.fn(),
+    };
+    const open = vi.fn(() => popup);
+    vi.stubGlobal('window', {
+      open,
+      location: { origin: 'http://localhost:1313' },
+    });
     try {
       fetchMock
+        .mockResolvedValueOnce(
+          okJson({ authorization_url: 'https://provider.example/authorize' }),
+        )
         .mockResolvedValueOnce(okJson({ connected: false }))
         .mockResolvedValueOnce(okJson({ connected: true }));
       const { startServerOAuth } = await freshConnectorsApi();
@@ -168,17 +178,41 @@ describe('connectors-api sends the Bearer auth header', () => {
       const flow = startServerOAuth('spotify').then(() => {
         resolved = true;
       });
+      expect(open).toHaveBeenCalledWith(
+        'about:blank',
+        '_blank',
+        'width=600,height=700',
+      );
+      expect(open.mock.invocationCallOrder[0]).toBeLessThan(
+        fetchMock.mock.invocationCallOrder[0],
+      );
       await vi.advanceTimersByTimeAsync(2000);
       expect(resolved).toBe(false);
       await vi.advanceTimersByTimeAsync(2000);
       await flow;
 
       expect(resolved).toBe(true);
-      expect(fetchMock).toHaveBeenCalledTimes(2);
-      expect(open).toHaveBeenCalledOnce();
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+      expect(fetchMock.mock.calls[0]?.[0]).toContain('response_mode=json');
+      expect(popup.location.href).toBe('https://provider.example/authorize');
     } finally {
       vi.useRealTimers();
       vi.unstubAllGlobals();
     }
+  });
+
+  it('scopes connector detail and sync calls to an account alias', async () => {
+    fetchMock.mockImplementation(async () => okJson({}));
+    const { getConnector, getSyncStatus, triggerSync } = await freshConnectorsApi();
+
+    await getConnector('gmail', 'work');
+    await getSyncStatus('gmail', 'work');
+    await triggerSync('gmail', 'work');
+
+    expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+      '/v1/connectors/gmail?account=work',
+      '/v1/connectors/gmail/sync?account=work',
+      '/v1/connectors/gmail/sync?account=work',
+    ]);
   });
 });

--- a/frontend/src/lib/connectors-api.ts
+++ b/frontend/src/lib/connectors-api.ts
@@ -18,8 +18,9 @@ export async function listConnectors(): Promise<ConnectorInfo[]> {
   return data.connectors || [];
 }
 
-export async function getConnector(id: string): Promise<ConnectorInfo> {
-  const res = await apiFetch(`/v1/connectors/${encodeURIComponent(id)}`);
+export async function getConnector(id: string, account = ''): Promise<ConnectorInfo> {
+  const query = account ? `?account=${encodeURIComponent(account)}` : '';
+  const res = await apiFetch(`/v1/connectors/${encodeURIComponent(id)}${query}`);
   if (!res.ok) throw new Error(`Failed to get connector ${id}: ${res.status}`);
   return res.json();
 }
@@ -39,16 +40,51 @@ export async function connectSource(id: string, req: ConnectRequest): Promise<Co
   return res.json();
 }
 
+const OAUTH_POPUP_FEATURES = 'width=600,height=700';
+
+/** Open a placeholder while the caller still owns a trusted click gesture.
+ * Browsers may block a popup created only after an awaited API request. */
+export function openServerOAuthPopup(): Window | null {
+  return window.open('about:blank', '_blank', OAUTH_POPUP_FEATURES);
+}
+
 /** Open the server-side OAuth consent flow in a popup and resolve once the
  *  connector reports connected (or reject on timeout). Reused for any OAuth
  *  connector whose /connect returned `oauth_required` (issue #512). */
-export function startServerOAuth(id: string, oauthStartPath?: string): Promise<void> {
+export async function startServerOAuth(
+  id: string,
+  oauthStartPath?: string,
+  existingPopup?: Window | null,
+): Promise<void> {
+  const popup = existingPopup ?? openServerOAuthPopup();
+  if (!popup) {
+    throw new Error('Authorization popup was blocked — allow popups and retry.');
+  }
   const path = oauthStartPath || `/v1/connectors/${encodeURIComponent(id)}/oauth/start`;
-  window.open(`${getBase()}${path}`, '_blank', 'width=600,height=700');
+  const startUrl = new URL(`${getBase()}${path}`, window.location.origin);
+  const account = startUrl.searchParams.get('account') || '';
+  startUrl.searchParams.set('response_mode', 'json');
+
+  try {
+    const startResponse = await apiFetch(`${startUrl.pathname}${startUrl.search}`);
+    if (!startResponse.ok) {
+      const err = await startResponse.json().catch(() => ({ detail: startResponse.statusText }));
+      throw new Error(err.detail || `Failed to start OAuth: ${startResponse.status}`);
+    }
+    const payload = (await startResponse.json()) as { authorization_url?: string };
+    if (!payload.authorization_url) {
+      throw new Error('OAuth start returned no authorization URL');
+    }
+    popup.location.href = payload.authorization_url;
+  } catch (error) {
+    popup.close();
+    throw error;
+  }
+
   return new Promise((resolve, reject) => {
     const interval = setInterval(async () => {
       try {
-        const info = await getConnector(id);
+        const info = await getConnector(id, account);
         if (info.connected) {
           clearInterval(interval);
           clearTimeout(timer);
@@ -60,6 +96,7 @@ export function startServerOAuth(id: string, oauthStartPath?: string): Promise<v
     }, 2000);
     const timer = setTimeout(() => {
       clearInterval(interval);
+      popup.close();
       reject(new Error('Authorization timed out — please try again.'));
     }, 180000);
   });
@@ -78,8 +115,10 @@ export class ConnectorApiError extends Error {
 export async function disconnectSource(
   id: string,
   signal?: AbortSignal,
+  account = '',
 ): Promise<void> {
-  const res = await apiFetch(`/v1/connectors/${encodeURIComponent(id)}/disconnect`, {
+  const query = account ? `?account=${encodeURIComponent(account)}` : '';
+  const res = await apiFetch(`/v1/connectors/${encodeURIComponent(id)}/disconnect${query}`, {
     method: 'POST',
     signal,
   });
@@ -96,6 +135,7 @@ export interface DisconnectUntilCompleteOptions {
   signal?: AbortSignal;
   retryDelayMs?: number;
   onPending?: (message: string) => void;
+  account?: string;
 }
 
 function waitForDisconnectRetry(delayMs: number, signal?: AbortSignal): Promise<void> {
@@ -128,11 +168,12 @@ export async function disconnectSourceUntilComplete(
     signal,
     retryDelayMs = 1500,
     onPending,
+    account = '',
   }: DisconnectUntilCompleteOptions = {},
 ): Promise<void> {
   while (true) {
     try {
-      await disconnectSource(id, signal);
+      await disconnectSource(id, signal, account);
       return;
     } catch (err) {
       if (!(err instanceof ConnectorApiError) || err.status !== 409) {
@@ -144,14 +185,16 @@ export async function disconnectSourceUntilComplete(
   }
 }
 
-export async function getSyncStatus(id: string): Promise<SyncStatus> {
-  const res = await apiFetch(`/v1/connectors/${encodeURIComponent(id)}/sync`);
+export async function getSyncStatus(id: string, account = ''): Promise<SyncStatus> {
+  const query = account ? `?account=${encodeURIComponent(account)}` : '';
+  const res = await apiFetch(`/v1/connectors/${encodeURIComponent(id)}/sync${query}`);
   if (!res.ok) throw new Error(`Failed to get sync status for ${id}: ${res.status}`);
   return res.json();
 }
 
-export async function triggerSync(id: string): Promise<{ connector_id: string; chunks_indexed: number; status: string }> {
-  const res = await apiFetch(`/v1/connectors/${encodeURIComponent(id)}/sync`, {
+export async function triggerSync(id: string, account = ''): Promise<{ connector_id: string; chunks_indexed: number; status: string }> {
+  const query = account ? `?account=${encodeURIComponent(account)}` : '';
+  const res = await apiFetch(`/v1/connectors/${encodeURIComponent(id)}/sync${query}`, {
     method: 'POST',
   });
   if (!res.ok) {

--- a/frontend/src/lib/connectors-api.ts
+++ b/frontend/src/lib/connectors-api.ts
@@ -55,6 +55,7 @@ export async function startServerOAuth(
   id: string,
   oauthStartPath?: string,
   existingPopup?: Window | null,
+  requestedAccount = '',
 ): Promise<void> {
   const popup = existingPopup ?? openServerOAuthPopup();
   if (!popup) {
@@ -62,6 +63,9 @@ export async function startServerOAuth(
   }
   const path = oauthStartPath || `/v1/connectors/${encodeURIComponent(id)}/oauth/start`;
   const startUrl = new URL(`${getBase()}${path}`, window.location.origin);
+  if (requestedAccount && !startUrl.searchParams.has('account')) {
+    startUrl.searchParams.set('account', requestedAccount);
+  }
   const account = startUrl.searchParams.get('account') || '';
   startUrl.searchParams.set('response_mode', 'json');
 

--- a/frontend/src/lib/rehype-citations.ts
+++ b/frontend/src/lib/rehype-citations.ts
@@ -38,6 +38,8 @@ function buildTooltip(src: ResearchSource): string {
   if (src.title) parts.push(src.title);
   const meta: string[] = [];
   if (src.sender) meta.push(src.sender);
+  if (src.source_email) meta.push(src.source_email);
+  else if (src.account) meta.push(src.account);
   const date = formatTooltipDate(src.date);
   if (date) meta.push(date);
   if (meta.length > 0) parts.push(meta.join(' · '));

--- a/frontend/src/lib/store.ts
+++ b/frontend/src/lib/store.ts
@@ -14,6 +14,7 @@ import type {
   ToolCallInfo,
   TokenUsage,
 } from '../types';
+import type { ConnectorInfo } from '../types/connectors';
 import type { ManagedAgent } from './api';
 import { isEmbedOnlyModel } from './model-capabilities';
 import { serializeToolCallArguments } from './tool-call';
@@ -24,6 +25,7 @@ export interface CachedConnector {
   connected: boolean;
   chunks: number;
   auth_type: string;
+  accounts?: ConnectorInfo['accounts'];
 }
 
 export interface AgentEvent {

--- a/frontend/src/pages/DataSourcesPage.lifecycle.test.tsx
+++ b/frontend/src/pages/DataSourcesPage.lifecycle.test.tsx
@@ -62,7 +62,7 @@ describe('connector lifecycle status', () => {
     };
 
     expect(resolveConnectorAccount(connector, undefined)).toBe('work');
-    expect(resolveConnectorAccount(connector, 'personal')).toBe('personal');
+    expect(resolveConnectorAccount(connector, ' Personal ')).toBe('personal');
     expect(connectorInstanceKey('gdrive', 'work')).toBe('gdrive:work');
     expect(connectorInstanceKey('gdrive')).toBe('gdrive');
   });

--- a/frontend/src/pages/DataSourcesPage.lifecycle.test.tsx
+++ b/frontend/src/pages/DataSourcesPage.lifecycle.test.tsx
@@ -65,5 +65,10 @@ describe('connector lifecycle status', () => {
     expect(resolveConnectorAccount(connector, ' Personal ')).toBe('personal');
     expect(connectorInstanceKey('gdrive', 'work')).toBe('gdrive:work');
     expect(connectorInstanceKey('gdrive')).toBe('gdrive');
+
+    connector.accounts = [
+      { account: 'disabled-work', connected: true, enabled: false },
+    ];
+    expect(resolveConnectorAccount(connector, undefined)).toBe('disabled-work');
   });
 });

--- a/frontend/src/pages/DataSourcesPage.lifecycle.test.tsx
+++ b/frontend/src/pages/DataSourcesPage.lifecycle.test.tsx
@@ -56,6 +56,7 @@ describe('connector lifecycle status', () => {
       chunks: 0,
       auth_type: 'oauth',
       accounts: [
+        { account: 'disabled', connected: true, enabled: false },
         { account: 'work', connected: true, source_email: 'me@example.com' },
       ],
     };

--- a/frontend/src/pages/DataSourcesPage.lifecycle.test.tsx
+++ b/frontend/src/pages/DataSourcesPage.lifecycle.test.tsx
@@ -3,8 +3,13 @@ import { describe, expect, it, vi } from 'vitest';
 
 vi.mock('../lib/store', () => ({ useAppStore: vi.fn() }));
 
-import { SyncStatusDisplay } from './DataSourcesPage';
+import {
+  connectorInstanceKey,
+  resolveConnectorAccount,
+  SyncStatusDisplay,
+} from './DataSourcesPage';
 import type { SyncStatus } from '../types/connectors';
+import type { CachedConnector } from '../lib/store';
 
 const baseStatus: SyncStatus = {
   state: 'idle',
@@ -41,5 +46,23 @@ describe('connector lifecycle status', () => {
 
     expect(html).toContain('Sync Now');
     expect(html).toMatch(/<button[^>]*disabled/);
+  });
+
+  it('selects and keys a named connected account without conflating defaults', () => {
+    const connector: CachedConnector = {
+      connector_id: 'gdrive',
+      display_name: 'Google Drive',
+      connected: false,
+      chunks: 0,
+      auth_type: 'oauth',
+      accounts: [
+        { account: 'work', connected: true, source_email: 'me@example.com' },
+      ],
+    };
+
+    expect(resolveConnectorAccount(connector, undefined)).toBe('work');
+    expect(resolveConnectorAccount(connector, 'personal')).toBe('personal');
+    expect(connectorInstanceKey('gdrive', 'work')).toBe('gdrive:work');
+    expect(connectorInstanceKey('gdrive')).toBe('gdrive');
   });
 });

--- a/frontend/src/pages/DataSourcesPage.tsx
+++ b/frontend/src/pages/DataSourcesPage.tsx
@@ -694,7 +694,9 @@ export function resolveConnectorAccount(
   return (
     connector.accounts?.find(
       (profile) => profile.enabled !== false && profile.connected,
-    )?.account ?? ''
+    )?.account ??
+    connector.accounts?.find((profile) => profile.connected)?.account ??
+    ''
   );
 }
 
@@ -707,7 +709,6 @@ function isSelectedAccountConnected(
     connector.accounts?.find(
       (profile) =>
         normalizeGoogleAccount(profile.account) === normalizeGoogleAccount(account) &&
-        profile.enabled !== false &&
         profile.connected,
     ),
   );
@@ -1211,11 +1212,13 @@ function DataSourcesSection() {
             const account = accountFor(c);
             const instanceKey = connectorInstanceKey(c.connector_id, account);
             const sync = syncStatuses[instanceKey];
-            const sourceEmail = c.accounts?.find(
+            const selectedProfile = c.accounts?.find(
               (profile) =>
                 normalizeGoogleAccount(profile.account) ===
                 normalizeGoogleAccount(account),
-            )?.source_email;
+            );
+            const sourceEmail = selectedProfile?.source_email;
+            const accountDisabled = selectedProfile?.enabled === false;
             const hasError = !!sync?.error;
             return (
               <div
@@ -1240,7 +1243,7 @@ function DataSourcesSection() {
                         connectorId={c.connector_id}
                         account={account}
                         accounts={c.accounts ?? []}
-                        disabled={connectorActionsBusy}
+                        disabled={connectorActionsBusy || accountDisabled}
                         onChange={(nextAccount) =>
                           selectAccount(
                             c.connector_id,
@@ -1257,13 +1260,18 @@ function DataSourcesSection() {
                         Signed in as {sourceEmail}
                       </div>
                     )}
+                    {accountDisabled && (
+                      <div style={{ fontSize: 10.5, color: '#f59e0b', marginBottom: 4 }}>
+                        Disabled in config.toml · disconnect remains available
+                      </div>
+                    )}
                     <SyncStatusDisplay
                       chunks={c.chunks}
                       sync={sync}
                       unitLabel={unit}
                       connectorId={c.connector_id}
                       account={account}
-                      disabled={connectorActionsBusy}
+                      disabled={connectorActionsBusy || accountDisabled}
                       onSyncTriggered={loadConnectors}
                     />
                     {disconnectError?.id === instanceKey && (

--- a/frontend/src/pages/DataSourcesPage.tsx
+++ b/frontend/src/pages/DataSourcesPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useCallback, useRef } from 'react';
 import { motion } from 'motion/react';
 import { useAppStore } from '../lib/store';
+import type { CachedConnector } from '../lib/store';
 import {
   fetchManagedAgents,
   fetchAgentChannels,
@@ -23,8 +24,24 @@ import {
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import { SOURCE_CATALOG } from '../types/connectors';
-import type { ConnectRequest, ConnectorMeta, SyncStatus, OAuthSetupInfo } from '../types/connectors';
-import { listConnectors, connectSource, disconnectSourceUntilComplete, getConnector, getSyncStatus, triggerSync, openServerOAuthPopup, startServerOAuth } from '../lib/connectors-api';
+import type {
+  ConnectRequest,
+  ConnectorInfo,
+  ConnectorMeta,
+  SyncStatus,
+  OAuthSetupInfo,
+} from '../types/connectors';
+import {
+  listConnectors,
+  connectSource,
+  disconnectSourceUntilComplete,
+  getConnector,
+  getSyncStatus,
+  triggerSync,
+  openServerOAuthPopup,
+  startServerOAuth,
+} from '../lib/connectors-api';
+import { GoogleAccountField, supportsGoogleAccounts } from '../components/GoogleAccountField';
 
 // ---------------------------------------------------------------------------
 // Inline connect form (reused from AgentsPage pattern)
@@ -145,6 +162,7 @@ function InlineConnectForm({
 
 function GenericConnectPanel({
   connectorId,
+  account,
   displayName,
   authType,
   loading,
@@ -153,6 +171,7 @@ function GenericConnectPanel({
   onOAuthStart,
 }: {
   connectorId: string;
+  account?: string;
   displayName: string;
   authType: string;
   loading: boolean;
@@ -166,7 +185,7 @@ function GenericConnectPanel({
   useEffect(() => {
     if (authType !== 'oauth') return;
     let cancelled = false;
-    getConnector(connectorId)
+    getConnector(connectorId, account)
       .then((info) => {
         if (!cancelled) setOauthSetup(info.oauth_setup ?? null);
       })
@@ -174,7 +193,7 @@ function GenericConnectPanel({
     return () => {
       cancelled = true;
     };
-  }, [connectorId, authType]);
+  }, [connectorId, account, authType]);
 
   if (authType === 'local') {
     if (connectorId === 'news_rss') {
@@ -542,10 +561,16 @@ function metaFor(connectorId: string) {
 function GmailOAuthAdvanced({
   loading,
   disabled = false,
+  account,
+  accounts,
+  onAccountChange,
   onConnect,
 }: {
   loading: boolean;
   disabled?: boolean;
+  account: string;
+  accounts: NonNullable<ConnectorInfo['accounts']>;
+  onAccountChange: (account: string) => void;
   onConnect: (req: ConnectRequest) => void;
 }) {
   const [open, setOpen] = useState(false);
@@ -591,6 +616,13 @@ function GmailOAuthAdvanced({
             </a>{' '}
             then paste the Client ID and Client Secret below.
           </div>
+          <GoogleAccountField
+            connectorId="gmail"
+            account={account}
+            accounts={accounts}
+            disabled={disabled || loading}
+            onChange={onAccountChange}
+          />
           <InlineConnectForm
             fields={[
               { name: 'email', placeholder: 'Client ID', type: 'text' },
@@ -645,11 +677,37 @@ function formatBacklogRange(iso: string | null | undefined): string | null {
   return `past ${years} year${years === 1 ? '' : 's'}`;
 }
 
+export function connectorInstanceKey(connectorId: string, account = ''): string {
+  return account ? `${connectorId}:${account}` : connectorId;
+}
+
+export function resolveConnectorAccount(
+  connector: CachedConnector,
+  selectedAccount: string | undefined,
+): string {
+  if (selectedAccount !== undefined) return selectedAccount.trim();
+  if (connector.connected) return '';
+  return connector.accounts?.find((profile) => profile.connected)?.account ?? '';
+}
+
+function isSelectedAccountConnected(
+  connector: CachedConnector,
+  account: string,
+): boolean {
+  if (!account) return connector.connected;
+  return Boolean(
+    connector.accounts?.find(
+      (profile) => profile.account === account && profile.connected,
+    ),
+  );
+}
+
 export function SyncStatusDisplay({
   chunks,
   sync,
   unitLabel,
   connectorId,
+  account = '',
   disabled = false,
   onSyncTriggered,
 }: {
@@ -657,6 +715,7 @@ export function SyncStatusDisplay({
   sync: SyncStatus | undefined;
   unitLabel: string;
   connectorId: string;
+  account?: string;
   disabled?: boolean;
   onSyncTriggered: () => void;
 }) {
@@ -668,7 +727,7 @@ export function SyncStatusDisplay({
     setSyncing(true);
     setSyncError('');
     try {
-      await triggerSync(connectorId);
+      await triggerSync(connectorId, account);
       onSyncTriggered();
     } catch (err: any) {
       setSyncError(err.message || 'Sync failed');
@@ -841,6 +900,7 @@ function DataSourcesSection() {
   const isFirstLoad = cachedConnectors === null;
   const [syncStatuses, setSyncStatuses] = useState<Record<string, SyncStatus>>({});
   const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [selectedAccounts, setSelectedAccounts] = useState<Record<string, string>>({});
   const [loading, setLoading] = useState(false);
   const [disconnectingId, setDisconnectingId] = useState<string | null>(null);
   const [disconnectError, setDisconnectError] = useState<{ id: string; message: string } | null>(null);
@@ -856,6 +916,7 @@ function DataSourcesSection() {
           connected: c.connected,
           chunks: (c as any).chunks || 0,
           auth_type: c.auth_type,
+          accounts: c.accounts,
         })),
       );
     } catch {
@@ -865,19 +926,41 @@ function DataSourcesSection() {
 
   const setConnectors = setCachedConnectors;
 
+  const accountFor = useCallback(
+    (connector: CachedConnector) =>
+      resolveConnectorAccount(
+        connector,
+        selectedAccounts[connector.connector_id],
+      ),
+    [selectedAccounts],
+  );
+
+  const selectAccount = useCallback((
+    connectorId: string,
+    account: string,
+    expandedConnectorId = connectorId,
+  ) => {
+    setSelectedAccounts((previous) => ({ ...previous, [connectorId]: account }));
+    setExpandedId(expandedConnectorId);
+  }, []);
+
   // Poll sync status for connected sources
   const loadSyncStatuses = useCallback(async () => {
-    const connected = connectors.filter((c) => c.connected);
+    const connected = connectors.filter((c) =>
+      isSelectedAccountConnected(c, accountFor(c)),
+    );
     const statuses: Record<string, SyncStatus> = {};
     await Promise.all(
       connected.map(async (c) => {
+        const account = accountFor(c);
         try {
-          statuses[c.connector_id] = await getSyncStatus(c.connector_id);
+          statuses[connectorInstanceKey(c.connector_id, account)] =
+            await getSyncStatus(c.connector_id, account);
         } catch { /* */ }
       }),
     );
     setSyncStatuses((prev) => ({ ...prev, ...statuses }));
-  }, [connectors]);
+  }, [accountFor, connectors]);
 
   useEffect(() => {
     void loadConnectors();
@@ -886,12 +969,12 @@ function DataSourcesSection() {
   }, [loadConnectors]);
 
   useEffect(() => {
-    if (connectors.some((c) => c.connected)) {
+    if (connectors.some((c) => isSelectedAccountConnected(c, accountFor(c)))) {
       loadSyncStatuses();
       const interval = setInterval(loadSyncStatuses, 5000);
       return () => clearInterval(interval);
     }
-  }, [connectors, loadSyncStatuses]);
+  }, [accountFor, connectors, loadSyncStatuses]);
 
   const [connectingId, setConnectingId] = useState<string | null>(null);
   const [connectStage, setConnectStage] = useState<string>('');
@@ -899,21 +982,23 @@ function DataSourcesSection() {
 
   useEffect(() => () => disconnectAbortRef.current?.abort(), []);
 
-  const handleDisconnect = async (id: string) => {
+  const handleDisconnect = async (id: string, account = '') => {
     if (disconnectAbortRef.current || loading) return;
+    const instanceKey = connectorInstanceKey(id, account);
     const controller = new AbortController();
     disconnectAbortRef.current = controller;
-    setDisconnectingId(id);
+    setDisconnectingId(instanceKey);
     setDisconnectError(null);
     try {
       await disconnectSourceUntilComplete(id, {
         signal: controller.signal,
+        account,
         onPending: () => {
           setSyncStatuses((prev) => {
-            const current = prev[id];
+            const current = prev[instanceKey];
             return {
               ...prev,
-              [id]: {
+              [instanceKey]: {
                 state: 'stopping',
                 items_synced: current?.items_synced ?? 0,
                 items_total: current?.items_total ?? 0,
@@ -928,14 +1013,14 @@ function DataSourcesSection() {
       });
       setSyncStatuses((prev) => {
         const next = { ...prev };
-        delete next[id];
+        delete next[instanceKey];
         return next;
       });
       await loadConnectors();
     } catch (err) {
       if (!(err instanceof DOMException && err.name === 'AbortError')) {
         setDisconnectError({
-          id,
+          id: instanceKey,
           message: err instanceof Error ? err.message : 'Disconnect failed',
         });
       }
@@ -947,9 +1032,16 @@ function DataSourcesSection() {
     }
   };
 
-  const handleConnect = async (id: string, req: ConnectRequest | null) => {
+  const handleConnect = async (
+    id: string,
+    req: ConnectRequest | null,
+    requestedAccount?: string,
+  ) => {
     if (loading || disconnectAbortRef.current) return;
     const connector = connectors.find((item) => item.connector_id === id);
+    const account = (
+      requestedAccount ?? (connector ? accountFor(connector) : '')
+    ).trim();
     const oauthPopup =
       req === null || connector?.auth_type === 'oauth'
         ? openServerOAuthPopup()
@@ -959,7 +1051,9 @@ function DataSourcesSection() {
     setConnectStage('Connecting...');
     setConnectError('');
     try {
-      const resp = req === null ? null : await connectSource(id, req);
+      const resp = req === null
+        ? null
+        : await connectSource(id, account ? { ...req, account } : req);
 
       // OAuth connectors (Google Drive/Calendar/Contacts/Gmail/Tasks): pasting
       // a Client ID / Secret only registers the app credentials. The backend
@@ -969,7 +1063,7 @@ function DataSourcesSection() {
       // this the connector would stay "pending" forever — the exact #512 bug.
       if (req === null || resp?.status === 'oauth_required') {
         setConnectStage('Opening provider sign-in...');
-        await startServerOAuth(id, resp?.oauth_start, oauthPopup);
+        await startServerOAuth(id, resp?.oauth_start, oauthPopup, account);
       } else {
         oauthPopup?.close();
       }
@@ -979,15 +1073,16 @@ function DataSourcesSection() {
       // Wait for connector to show as connected
       for (let i = 0; i < 20; i++) {
         await new Promise((r) => setTimeout(r, 2000));
-        const updated = await listConnectors();
-        const target = updated.find((c) => c.connector_id === id);
-        if (target?.connected) {
+        const target = await getConnector(id, account);
+        if (target.connected) {
+          const updated = await listConnectors();
           setConnectors(updated.map((c) => ({
             connector_id: c.connector_id,
             display_name: c.display_name,
             connected: c.connected,
             chunks: (c as any).chunks || 0,
             auth_type: c.auth_type,
+            accounts: c.accounts,
           })));
           break;
         }
@@ -997,7 +1092,7 @@ function DataSourcesSection() {
       // Trigger sync
       setConnectStage('Syncing data...');
       try {
-        await triggerSync(id);
+        await triggerSync(id, account);
       } catch { /* sync may already be running */ }
 
       // Close form after a brief moment
@@ -1030,13 +1125,14 @@ function DataSourcesSection() {
     const gmail = connectors.find((c) => c.connector_id === 'gmail');
     const gmailImap = connectors.find((c) => c.connector_id === 'gmail_imap');
     if (!gmail || !gmailImap) return connectors;
-    if (gmail.connected && !gmailImap.connected) {
+    const gmailConnected = isSelectedAccountConnected(gmail, accountFor(gmail));
+    if (gmailConnected && !gmailImap.connected) {
       return connectors.filter((c) => c.connector_id !== 'gmail_imap');
     }
-    if (gmailImap.connected && !gmail.connected) {
+    if (gmailImap.connected && !gmailConnected) {
       return connectors.filter((c) => c.connector_id !== 'gmail');
     }
-    if (gmail.connected && gmailImap.connected) {
+    if (gmailConnected && gmailImap.connected) {
       const dropId = gmail.chunks >= gmailImap.chunks ? 'gmail_imap' : 'gmail';
       return connectors.filter((c) => c.connector_id !== dropId);
     }
@@ -1044,10 +1140,20 @@ function DataSourcesSection() {
     return connectors.filter((c) => c.connector_id !== 'gmail');
   })();
 
-  const connected = unifiedConnectors.filter((c) => c.connected);
-  const notConnectedBase = unifiedConnectors.filter((c) => !c.connected);
+  const connected = unifiedConnectors.filter((c) =>
+    isSelectedAccountConnected(c, accountFor(c)),
+  );
+  const notConnectedBase = unifiedConnectors.filter(
+    (c) => !isSelectedAccountConnected(c, accountFor(c)),
+  );
   // Always show the upload card in the not-connected list (it has no backend connector)
-  const uploadEntry = { connector_id: 'upload', display_name: 'Upload / Paste', connected: false, chunks: 0, auth_type: 'local' };
+  const uploadEntry: CachedConnector = {
+    connector_id: 'upload',
+    display_name: 'Upload / Paste',
+    connected: false,
+    chunks: 0,
+    auth_type: 'local',
+  };
   const notConnected = notConnectedBase.some((c) => c.connector_id === 'upload')
     ? notConnectedBase
     : [...notConnectedBase, uploadEntry];
@@ -1091,7 +1197,12 @@ function DataSourcesSection() {
           {connected.map((c) => {
             const meta = metaFor(c.connector_id);
             const unit = meta?.unitLabel || 'items';
-            const sync = syncStatuses[c.connector_id];
+            const account = accountFor(c);
+            const instanceKey = connectorInstanceKey(c.connector_id, account);
+            const sync = syncStatuses[instanceKey];
+            const sourceEmail = c.accounts?.find(
+              (profile) => profile.account === account,
+            )?.source_email;
             const hasError = !!sync?.error;
             return (
               <div
@@ -1111,22 +1222,45 @@ function DataSourcesSection() {
                     <div className="font-semibold" style={{ fontSize: 14, fontWeight: 600, color: 'var(--color-text)' }}>
                       {meta?.display_name ?? c.display_name}
                     </div>
+                    {supportsGoogleAccounts(c.connector_id) && (
+                      <GoogleAccountField
+                        connectorId={c.connector_id}
+                        account={account}
+                        accounts={c.accounts ?? []}
+                        disabled={connectorActionsBusy}
+                        onChange={(nextAccount) =>
+                          selectAccount(
+                            c.connector_id,
+                            nextAccount,
+                            c.connector_id === 'gmail'
+                              ? 'gmail_imap'
+                              : c.connector_id,
+                          )
+                        }
+                      />
+                    )}
+                    {sourceEmail && (
+                      <div style={{ fontSize: 10.5, color: 'var(--color-text-tertiary)', marginBottom: 4 }}>
+                        Signed in as {sourceEmail}
+                      </div>
+                    )}
                     <SyncStatusDisplay
                       chunks={c.chunks}
                       sync={sync}
                       unitLabel={unit}
                       connectorId={c.connector_id}
+                      account={account}
                       disabled={connectorActionsBusy}
                       onSyncTriggered={loadConnectors}
                     />
-                    {disconnectError?.id === c.connector_id && (
+                    {disconnectError?.id === instanceKey && (
                       <div style={{ fontSize: 11, color: 'var(--color-error)', marginTop: 4 }}>
                         Disconnect failed: {disconnectError.message}
                       </div>
                     )}
                   </div>
                   <button
-                    onClick={() => handleDisconnect(c.connector_id)}
+                    onClick={() => handleDisconnect(c.connector_id, account)}
                     disabled={connectorActionsBusy}
                     className="hud-label"
                     style={{
@@ -1140,7 +1274,7 @@ function DataSourcesSection() {
                       opacity: connectorActionsBusy ? 0.5 : 1,
                     }}
                   >
-                    {disconnectingId === c.connector_id
+                    {disconnectingId === instanceKey
                       ? sync?.state === 'stopping' ? 'Cleaning up…' : 'Disconnecting…'
                       : sync?.state === 'stopping' ? 'Finish disconnect' : 'Disconnect'}
                   </button>
@@ -1163,6 +1297,13 @@ function DataSourcesSection() {
           {notConnected.map((c) => {
             const meta = metaFor(c.connector_id);
             const isExpanded = expandedId === c.connector_id;
+            const account = accountFor(c);
+            const gmailOAuthConnector = connectors.find(
+              (connector) => connector.connector_id === 'gmail',
+            );
+            const gmailOAuthAccount = gmailOAuthConnector
+              ? accountFor(gmailOAuthConnector)
+              : '';
 
             return (
               <div
@@ -1206,6 +1347,17 @@ function DataSourcesSection() {
 
                 {isExpanded && c.connector_id !== 'upload' && meta?.steps && (
                   <div style={{ borderTop: '1px solid var(--color-border)', padding: 12 }}>
+                    {supportsGoogleAccounts(c.connector_id) && (
+                      <GoogleAccountField
+                        connectorId={c.connector_id}
+                        account={account}
+                        accounts={c.accounts ?? []}
+                        disabled={connectorActionsBusy}
+                        onChange={(nextAccount) =>
+                          selectAccount(c.connector_id, nextAccount)
+                        }
+                      />
+                    )}
                     {meta.steps.map((step, i) => (
                       <div
                         key={i}
@@ -1237,14 +1389,23 @@ function DataSourcesSection() {
                         fields={meta.inputFields}
                         loading={loading && connectingId === c.connector_id}
                         disabled={connectorActionsBusy}
-                        onSubmit={(req) => handleConnect(c.connector_id, req)}
+                        onSubmit={(req) =>
+                          handleConnect(c.connector_id, req, account)
+                        }
                       />
                     )}
                     {c.connector_id === 'gmail_imap' && (
                       <GmailOAuthAdvanced
                         loading={loading && connectingId === 'gmail'}
                         disabled={connectorActionsBusy}
-                        onConnect={(req) => handleConnect('gmail', req)}
+                        account={gmailOAuthAccount}
+                        accounts={gmailOAuthConnector?.accounts ?? []}
+                        onAccountChange={(nextAccount) =>
+                          selectAccount('gmail', nextAccount, 'gmail_imap')
+                        }
+                        onConnect={(req) =>
+                          handleConnect('gmail', req, gmailOAuthAccount)
+                        }
                       />
                     )}
                     {meta?.troubleshooting && (
@@ -1299,14 +1460,30 @@ function DataSourcesSection() {
 
                 {isExpanded && c.connector_id !== 'upload' && !meta?.steps && (
                   <div style={{ borderTop: '1px solid var(--color-border)', padding: 12 }}>
+                    {supportsGoogleAccounts(c.connector_id) && (
+                      <GoogleAccountField
+                        connectorId={c.connector_id}
+                        account={account}
+                        accounts={c.accounts ?? []}
+                        disabled={connectorActionsBusy}
+                        onChange={(nextAccount) =>
+                          selectAccount(c.connector_id, nextAccount)
+                        }
+                      />
+                    )}
                     <GenericConnectPanel
                       connectorId={c.connector_id}
+                      account={account}
                       displayName={meta?.display_name ?? c.display_name}
                       authType={c.auth_type || 'oauth'}
                       loading={loading && connectingId === c.connector_id}
                       disabled={connectorActionsBusy}
-                      onConnect={(req) => handleConnect(c.connector_id, req)}
-                      onOAuthStart={() => handleConnect(c.connector_id, null)}
+                      onConnect={(req) =>
+                        handleConnect(c.connector_id, req, account)
+                      }
+                      onOAuthStart={() =>
+                        handleConnect(c.connector_id, null, account)
+                      }
                     />
                     {connectingId === c.connector_id && connectStage && (
                       <div style={{ marginTop: 8, fontSize: 12, color: 'var(--color-warning)' }}>

--- a/frontend/src/pages/DataSourcesPage.tsx
+++ b/frontend/src/pages/DataSourcesPage.tsx
@@ -41,7 +41,11 @@ import {
   openServerOAuthPopup,
   startServerOAuth,
 } from '../lib/connectors-api';
-import { GoogleAccountField, supportsGoogleAccounts } from '../components/GoogleAccountField';
+import {
+  GoogleAccountField,
+  normalizeGoogleAccount,
+  supportsGoogleAccounts,
+} from '../components/GoogleAccountField';
 
 // ---------------------------------------------------------------------------
 // Inline connect form (reused from AgentsPage pattern)
@@ -685,7 +689,7 @@ export function resolveConnectorAccount(
   connector: CachedConnector,
   selectedAccount: string | undefined,
 ): string {
-  if (selectedAccount !== undefined) return selectedAccount.trim();
+  if (selectedAccount !== undefined) return normalizeGoogleAccount(selectedAccount);
   if (connector.connected) return '';
   return (
     connector.accounts?.find(
@@ -702,7 +706,7 @@ function isSelectedAccountConnected(
   return Boolean(
     connector.accounts?.find(
       (profile) =>
-        profile.account === account &&
+        normalizeGoogleAccount(profile.account) === normalizeGoogleAccount(account) &&
         profile.enabled !== false &&
         profile.connected,
     ),
@@ -1208,7 +1212,9 @@ function DataSourcesSection() {
             const instanceKey = connectorInstanceKey(c.connector_id, account);
             const sync = syncStatuses[instanceKey];
             const sourceEmail = c.accounts?.find(
-              (profile) => profile.account === account,
+              (profile) =>
+                normalizeGoogleAccount(profile.account) ===
+                normalizeGoogleAccount(account),
             )?.source_email;
             const hasError = !!sync?.error;
             return (

--- a/frontend/src/pages/DataSourcesPage.tsx
+++ b/frontend/src/pages/DataSourcesPage.tsx
@@ -687,7 +687,11 @@ export function resolveConnectorAccount(
 ): string {
   if (selectedAccount !== undefined) return selectedAccount.trim();
   if (connector.connected) return '';
-  return connector.accounts?.find((profile) => profile.connected)?.account ?? '';
+  return (
+    connector.accounts?.find(
+      (profile) => profile.enabled !== false && profile.connected,
+    )?.account ?? ''
+  );
 }
 
 function isSelectedAccountConnected(
@@ -697,7 +701,10 @@ function isSelectedAccountConnected(
   if (!account) return connector.connected;
   return Boolean(
     connector.accounts?.find(
-      (profile) => profile.account === account && profile.connected,
+      (profile) =>
+        profile.account === account &&
+        profile.enabled !== false &&
+        profile.connected,
     ),
   );
 }

--- a/frontend/src/pages/DataSourcesPage.tsx
+++ b/frontend/src/pages/DataSourcesPage.tsx
@@ -24,7 +24,7 @@ import {
 import type { LucideIcon } from 'lucide-react';
 import { SOURCE_CATALOG } from '../types/connectors';
 import type { ConnectRequest, ConnectorMeta, SyncStatus, OAuthSetupInfo } from '../types/connectors';
-import { listConnectors, connectSource, disconnectSourceUntilComplete, getConnector, getSyncStatus, triggerSync, startServerOAuth } from '../lib/connectors-api';
+import { listConnectors, connectSource, disconnectSourceUntilComplete, getConnector, getSyncStatus, triggerSync, openServerOAuthPopup, startServerOAuth } from '../lib/connectors-api';
 
 // ---------------------------------------------------------------------------
 // Inline connect form (reused from AgentsPage pattern)
@@ -949,6 +949,11 @@ function DataSourcesSection() {
 
   const handleConnect = async (id: string, req: ConnectRequest | null) => {
     if (loading || disconnectAbortRef.current) return;
+    const connector = connectors.find((item) => item.connector_id === id);
+    const oauthPopup =
+      req === null || connector?.auth_type === 'oauth'
+        ? openServerOAuthPopup()
+        : null;
     setLoading(true);
     setConnectingId(id);
     setConnectStage('Connecting...');
@@ -964,7 +969,9 @@ function DataSourcesSection() {
       // this the connector would stay "pending" forever — the exact #512 bug.
       if (req === null || resp?.status === 'oauth_required') {
         setConnectStage('Opening provider sign-in...');
-        await startServerOAuth(id, resp?.oauth_start);
+        await startServerOAuth(id, resp?.oauth_start, oauthPopup);
+      } else {
+        oauthPopup?.close();
       }
 
       setConnectStage('Connected! Starting sync...');
@@ -999,6 +1006,7 @@ function DataSourcesSection() {
       loadConnectors();
       loadSyncStatuses();
     } catch (err: any) {
+      oauthPopup?.close();
       let errorMsg = err.message || 'Connection failed';
       if (id === 'gmail_imap' && (errorMsg.includes('auth') || errorMsg.includes('credentials') || errorMsg.includes('LOGIN'))) {
         errorMsg = 'Invalid credentials — make sure you\'re using an App Password (16 characters), not your regular Gmail password.';

--- a/frontend/src/types/connectors.ts
+++ b/frontend/src/types/connectors.ts
@@ -44,6 +44,7 @@ export interface ConnectorInfo {
   account?: string | null;
   accounts?: Array<{
     account: string;
+    enabled?: boolean;
     connected: boolean;
     source_email?: string;
   }>;

--- a/frontend/src/types/connectors.ts
+++ b/frontend/src/types/connectors.ts
@@ -41,6 +41,12 @@ export interface ConnectorInfo {
   mcp_tools?: string[];
   chunks?: number;
   oauth_setup?: OAuthSetupInfo | null;
+  account?: string | null;
+  accounts?: Array<{
+    account: string;
+    connected: boolean;
+    source_email?: string;
+  }>;
 }
 
 export interface SyncStatus {
@@ -56,9 +62,12 @@ export interface SyncStatus {
   oldest_item_date?: string | null;
   last_sync: string | null;
   error: string | null;
+  account?: string | null;
 }
 
 export interface ConnectRequest {
+  account?: string;
+  profile?: string;
   path?: string;
   token?: string;
   code?: string;
@@ -82,6 +91,7 @@ export interface ConnectResponse {
   status: "connected" | "pending" | "oauth_required" | "disconnected";
   oauth_start?: string;
   sync_status?: string | null;
+  account?: string | null;
 }
 
 export type WizardStep = "pick" | "connect" | "ingest" | "ready";

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -72,6 +72,9 @@ export interface ResearchSource {
   sender?: string;
   date?: string;
   url?: string;
+  account?: string;
+  source_profile?: string;
+  source_email?: string;
 }
 
 export interface ResearchSearchTrace {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -189,6 +189,7 @@ nav:
       - Simple Chat: user-guide/chat-simple.md
       - Agents: user-guide/agents.md
       - Channels & Connectors: user-guide/channels-and-connectors.md
+      - Google Account Profiles: user-guide/google-account-profiles.md
       - Tools: user-guide/tools.md
       - Memory: user-guide/memory.md
       - External MCP Servers: user-guide/mcp-external-servers.md
@@ -203,5 +204,6 @@ nav:
   - Leaderboard: leaderboard.md
   - Roadmap: development/roadmap.md
   - Development:
+      - Google Account Profiles Analysis Layer: development/google-account-profiles-analysis-layer.md
       - Mining: development/mining.md
       - Pearl Model Enablement: development/pearl-model-enablement.md

--- a/src/openjarvis/agents/morning_digest.py
+++ b/src/openjarvis/agents/morning_digest.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import json
 from datetime import datetime
 from pathlib import Path
-from typing import Any, List, Optional
+from typing import Any, Callable, List, Optional
 
 from openjarvis.agents._stubs import AgentContext, AgentResult, ToolUsingAgent
 from openjarvis.agents.digest_store import DigestArtifact, DigestStore
@@ -26,16 +26,34 @@ _GOOGLE_PROFILE_SOURCES = {
 }
 
 
-def expand_account_sources(sources: List[str], accounts: List[str]) -> List[str]:
-    """Expand unscoped Google digest sources across configured profiles."""
-    if not accounts:
-        return list(sources)
+def expand_account_sources(
+    sources: List[str],
+    accounts: Optional[List[str]],
+    *,
+    is_account_enabled: Optional[Callable[[str], bool]] = None,
+) -> List[str]:
+    """Expand and enforce Google profile scope for digest sources.
+
+    ``None`` means no account scope was configured, while an empty list means
+    a scope was configured but every requested profile was disabled. Keeping
+    those states distinct prevents an all-disabled config from widening back
+    to every Google account.
+    """
     from openjarvis.connectors.oauth import normalize_account_alias
 
-    aliases = [normalize_account_alias(account) for account in accounts]
+    aliases = (
+        None
+        if accounts is None
+        else [normalize_account_alias(account) for account in accounts]
+    )
     expanded: List[str] = []
     for source in sources:
-        if ":" in source or source not in _GOOGLE_PROFILE_SOURCES:
+        connector_id, separator, raw_account = source.partition(":")
+        if separator and connector_id in _GOOGLE_PROFILE_SOURCES:
+            alias = normalize_account_alias(raw_account)
+            if is_account_enabled is None or is_account_enabled(alias):
+                expanded.append(f"{connector_id}:{alias}")
+        elif source not in _GOOGLE_PROFILE_SOURCES or aliases is None:
             expanded.append(source)
         else:
             expanded.extend(f"{source}:{account}" for account in aliases)

--- a/src/openjarvis/agents/morning_digest.py
+++ b/src/openjarvis/agents/morning_digest.py
@@ -17,6 +17,31 @@ from openjarvis.core.paths import get_config_dir
 from openjarvis.core.registry import AgentRegistry
 from openjarvis.core.types import Message, Role, ToolCall
 
+_GOOGLE_PROFILE_SOURCES = {
+    "gcalendar",
+    "gcontacts",
+    "gdrive",
+    "gmail",
+    "google_tasks",
+}
+
+
+def expand_account_sources(sources: List[str], accounts: List[str]) -> List[str]:
+    """Expand unscoped Google digest sources across configured profiles."""
+    if not accounts:
+        return list(sources)
+    from openjarvis.connectors.oauth import normalize_account_alias
+
+    aliases = [normalize_account_alias(account) for account in accounts]
+    expanded: List[str] = []
+    for source in sources:
+        if ":" in source or source not in _GOOGLE_PROFILE_SOURCES:
+            expanded.append(source)
+        else:
+            expanded.extend(f"{source}:{account}" for account in aliases)
+    return expanded
+
+
 _SECTION_PROMPTS = {
     "messages": "MESSAGES — Prioritize provided messages or tasks needing action.",
     "calendar": "CALENDAR — Cover only provided upcoming events.",

--- a/src/openjarvis/agents/proactive_agent.py
+++ b/src/openjarvis/agents/proactive_agent.py
@@ -83,11 +83,12 @@ Each action object must have these fields:
         ids like ``"gmail:wells_fargo"`` or ``"msg_1"`` — the executor
         will fail.  If a digest line has no ``id=...`` segment, do not
         propose an action for that line.
-      - For email actions: message_id MUST be the part of doc_id after
-        the ``gmail:`` prefix (e.g. ``"18f9abc"``).
+      - For email actions: copy ``message_id=...`` and ``account=...`` from
+        the digest line. The message_id is the provider-native ID, not the
+        account-prefixed doc_id. Omit account only for the default profile.
       - For sms actions: contact (phone/email), body (the message text)
-      - For calendar actions: event_id (the part after ``gcalendar:`` in
-        the digest's ``id=...``) and calendar_id (default "primary")
+      - For calendar actions: copy ``event_id=...`` and ``account=...`` from
+        the digest line; calendar_id defaults to "primary".
   - permission_key: pattern string like "email_delete:domain:noreply.github.com"
   - tier: one of trivial | low | medium | high
   - reasoning: one sentence why

--- a/src/openjarvis/agents/research_loop.py
+++ b/src/openjarvis/agents/research_loop.py
@@ -558,6 +558,25 @@ class ResearchAgent:
     def _execute_search(self, args: Dict[str, Any]) -> ToolInvocation:
         query = str(args.get("query", "") or "")
         person = args.get("person") or None
+
+        def _norm_markerish(value: str) -> str:
+            return "".join(ch.lower() for ch in value if ch.isalnum())
+
+        if person:
+            person = str(person).strip() or None
+            # Small/local planners often misclassify exact marker strings,
+            # ticket IDs, and other search literals as a `person` filter. That
+            # turns a good lexical search into an impossible AND over
+            # participants/author. If the supposed person is just the query
+            # rewritten/normalized, treat it as a search term only.
+            if query and person:
+                norm_query = _norm_markerish(query)
+                norm_person = _norm_markerish(person)
+                marker_like_query = any(ch in query for ch in "_-0123456789")
+                if norm_person == norm_query or (
+                    marker_like_query and norm_person and norm_person in norm_query
+                ):
+                    person = None
         time_range = self._parse_time_range(args.get("time_range"))
         sources = args.get("sources") or None
         if sources and not isinstance(sources, list):
@@ -565,6 +584,22 @@ class ResearchAgent:
         accounts = args.get("accounts") or args.get("account") or None
         if accounts and not isinstance(accounts, list):
             accounts = [str(accounts)]
+        if person:
+            # The planner can also mistake an account alias from a scoped
+            # source like gmail:personal-main for a person filter (e.g.
+            # person="Personal Main" or person="work-credain"). Account
+            # scoping already happens through sources/accounts; adding the
+            # alias as a participant/author filter makes exact marker tests
+            # impossible to find. Strip person when it is just the named
+            # account/profile scope.
+            scoped_accounts: list[str] = []
+            for source in sources or []:
+                source_s = str(source)
+                if ":" in source_s:
+                    scoped_accounts.append(source_s.split(":", 1)[1])
+            scoped_accounts.extend(str(account) for account in (accounts or []))
+            if any(_norm_markerish(person) == _norm_markerish(account) for account in scoped_accounts):
+                person = None
         limit = int(args.get("limit", 20) or 20)
         limit = max(1, min(limit, 20))
 

--- a/src/openjarvis/agents/research_loop.py
+++ b/src/openjarvis/agents/research_loop.py
@@ -215,6 +215,9 @@ def shape_results_for_model(
             "sender": sender,
             "timestamp": h.timestamp,
             "source": h.source,
+            "account": h.account,
+            "source_profile": h.source_profile,
+            "source_email": h.source_email,
             "score": round(h.score, 4),
         }
         if i < detailed_top:
@@ -415,6 +418,7 @@ def build_sources_for_client(
                 "source": h.source,
                 "account": h.account,
                 "source_profile": h.source_profile,
+                "source_email": h.source_email,
                 "source_id": _bare_doc_id(h.source, h.document_id),
                 "url": url,
             }
@@ -574,12 +578,54 @@ class ResearchAgent:
         sources = args.get("sources") or None
         if sources and not isinstance(sources, list):
             sources = [str(sources)]
+        from openjarvis.connectors.oauth import normalize_account_alias
+
+        normalized_sources: List[str] = []
+        for source in sources or []:
+            source_text = str(source).strip()
+            if not source_text:
+                continue
+            if ":" not in source_text:
+                normalized_sources.append(source_text)
+                continue
+            connector_id, raw_account = source_text.split(":", 1)
+            try:
+                scoped_account = normalize_account_alias(raw_account)
+            except ValueError:
+                scoped_account = "__openjarvis_no_matching_account__"
+            normalized_sources.append(f"{connector_id}:{scoped_account}")
+        sources = normalized_sources or None
         accounts = args.get("accounts") or args.get("account") or None
         if accounts and not isinstance(accounts, list):
             accounts = [str(accounts)]
-        has_scoped_source = any(":" in str(source) for source in (sources or []))
-        if not accounts and not has_scoped_source and self._default_accounts:
-            accounts = list(self._default_accounts)
+        if accounts:
+            normalized_accounts: List[str] = []
+            for account in accounts:
+                try:
+                    normalized_accounts.append(normalize_account_alias(str(account)))
+                except ValueError:
+                    normalized_accounts.append("__openjarvis_no_matching_account__")
+            accounts = normalized_accounts
+        if self._default_accounts:
+            # User/configured account scope is an authorization-style
+            # boundary, not a planner hint.  A model-generated scoped source
+            # (for example ``gmail:personal``) must never bypass an explicit
+            # ``--account work`` restriction.  Planner-provided account
+            # filters may narrow a multi-account boundary, but never widen it.
+            if accounts:
+                requested = set(accounts)
+                accounts = [
+                    account
+                    for account in self._default_accounts
+                    if account in requested
+                ]
+                if not accounts:
+                    # HybridSearch treats an empty list as no filter.  Use an
+                    # impossible stored alias so a disjoint planner request
+                    # deterministically returns zero rows instead.
+                    accounts = ["__openjarvis_no_matching_account__"]
+            else:
+                accounts = list(self._default_accounts)
         if person:
             # The planner can also mistake an account alias from a scoped
             # source like gmail:personal-main for a person filter (e.g.

--- a/src/openjarvis/agents/research_loop.py
+++ b/src/openjarvis/agents/research_loop.py
@@ -72,8 +72,9 @@ SEARCH_TOOL_SPEC: Dict[str, Any] = {
             "notes, calendar events, attachments). Combines BM25 lexical match "
             "with dense embedding similarity, ranked by reciprocal rank fusion. "
             "Use structured filters (person, time_range, sources) whenever the "
-            "user names a specific person or time window. Each call returns up "
-            "to 'limit' results with content snippets and thread context."
+            "user names a specific person, time window, connector, or account "
+            "alias. Each call returns up to 'limit' results with content "
+            "snippets and thread context."
         ),
         "parameters": {
             "type": "object",
@@ -111,7 +112,19 @@ SEARCH_TOOL_SPEC: Dict[str, Any] = {
                         "→ ['slack', 'gmail']). Valid IDs include: gmail, slack, "
                         "granola, notion, obsidian, gcalendar, gdrive, gmail_imap, "
                         "outlook, imessage, whatsapp, apple_notes, apple_contacts, "
-                        "gcontacts, google_tasks, github_notifications."
+                        "gcontacts, google_tasks, github_notifications. Named account "
+                        "sources use "
+                        "connector:account syntax, e.g. ['gmail:work'] or "
+                        "['gdrive:research']."
+                    ),
+                    "items": {"type": "string"},
+                },
+                "accounts": {
+                    "type": "array",
+                    "description": (
+                        "Restrict the search to one or more named account aliases "
+                        "across all matching connectors, e.g. ['work'] or "
+                        "['personal', 'research']."
                     ),
                     "items": {"type": "string"},
                 },
@@ -134,19 +147,20 @@ The user's corpus contains data from these sources only:
 
 You answer questions by calling two tools:
 
-    search(query, person=None, time_range=None, sources=None, limit=20)
+    search(query, person=None, time_range=None, sources=None, accounts=None, limit=20)
     clarify(question)
 
 Strategy:
   1. If the user names a person, ALWAYS pass `person=` rather than relying on lexical match. Hybrid search will fuzzy-match name or address fragments.
   2. When the user mentions ANY time window — "this past week", "recently", "last month", "past few days", "yesterday" — you MUST translate it to a `time_range` parameter. Today is {today}.
   3. The `time_range` argument is a JSON object: `{{"start": "<ISO 8601>", "end": "<ISO 8601>"}}`. Either bound may be omitted, but pass at least one whenever the user gave you a temporal cue.
-  4. When the user names a specific data source — "my Granola notes", "in Slack", "from my email" — you MUST pass `sources=[...]` with the matching connector ID. Only use IDs that appear in the connected-sources list above; do NOT invent or assume sources that are not connected. Common synonyms: "meeting notes"/"meetings"/"transcripts" → granola; "email"/"inbox" → gmail; "DMs"/"channels" → slack. Without this filter the search returns mail/messages ABOUT a tool instead of records FROM that tool.
+  4. When the user names a specific data source — "my Granola notes", "in Slack", "from my email" — you MUST pass `sources=[...]` with the matching connector ID. Account-scoped source IDs such as `gmail:work`, `gdrive:research`, and `gcalendar:family` are valid when they appear in the connected-sources list. Only use IDs that appear in the connected-sources list above; do NOT invent or assume sources that are not connected. Common synonyms: "meeting notes"/"meetings"/"transcripts" → granola; "email"/"inbox" → gmail; "DMs"/"channels" → slack. Without this filter the search returns mail/messages ABOUT a tool instead of records FROM that tool.
   4a. Never apologize about sources that aren't in the connected-sources list — if the user asks about "Notion" but Notion isn't connected, just say "Notion isn't connected, but here's what I found in {available_sources}" and answer from what is available.
+  4b. When the user names an account/profile/persona — "work account", "personal Drive", "research calendar", "only banqer" — pass `accounts=[...]` with the matching alias if that alias appears in connected sources. Use `sources=[...]` as well when the user also names a connector, e.g. sources=["gmail"], accounts=["work"] for work email only.
   5. When the user asks for "next", "upcoming", "future", or "soon" calendar events/meetings/appointments, use `sources=["gcalendar"]` if gcalendar is connected, set `time_range={{"start": "{today}"}}`, and use `query=""` unless the user gave a specific topic such as "dentist" or "music lesson". This returns the nearest upcoming calendar items across calendars instead of keyword-matching only birthdays or event titles.
   6. If the first structured search returns nothing useful, broaden with a semantic query and drop filters one at a time.
   7. You have a clarify tool. Only use it AFTER at least one search attempt. Use it when: you found multiple ambiguous matches (e.g. 3 different people named John), search returned zero results and the query might need reframing, or the scope is too broad to synthesize meaningfully. Never use clarify before searching — always try first.
-  8. After receiving a clarify response, use the information to construct a precise search with the correct person, time_range, sources, and query parameters. Only use an empty query when structured filters carry the request; never send a search with no concrete parameters. Extract every concrete signal from the user's reply (names, dates, topics, sources) and put it on the call.
+  8. After receiving a clarify response, use the information to construct a precise search with the correct person, time_range, sources, accounts, and query parameters. Only use an empty query when structured filters carry the request; never send a search with no concrete parameters. Extract every concrete signal from the user's reply (names, dates, topics, sources, accounts) and put it on the call.
   9. Tool calls — search AND clarify — share a budget of 5 total. Spend wisely.
 
 Synthesis rules:
@@ -399,6 +413,8 @@ def build_sources_for_client(
                 "sender": sender,
                 "date": _hit_date(h.timestamp),
                 "source": h.source,
+                "account": h.account,
+                "source_profile": h.source_profile,
                 "source_id": _bare_doc_id(h.source, h.document_id),
                 "url": url,
             }
@@ -546,6 +562,9 @@ class ResearchAgent:
         sources = args.get("sources") or None
         if sources and not isinstance(sources, list):
             sources = [str(sources)]
+        accounts = args.get("accounts") or args.get("account") or None
+        if accounts and not isinstance(accounts, list):
+            accounts = [str(accounts)]
         limit = int(args.get("limit", 20) or 20)
         limit = max(1, min(limit, 20))
 
@@ -554,6 +573,7 @@ class ResearchAgent:
             person=person,
             time_range=time_range,
             sources=sources,
+            accounts=accounts,
             limit=limit,
         )
         titles = [h.title or (h.content_snippet[:60] + "…") for h in hits[:5]]
@@ -575,6 +595,7 @@ class ResearchAgent:
                     else None
                 ),
                 "sources": sources,
+                "accounts": accounts,
                 "limit": limit,
             },
             num_results=len(hits),

--- a/src/openjarvis/agents/research_loop.py
+++ b/src/openjarvis/agents/research_loop.py
@@ -744,7 +744,7 @@ class ResearchAgent:
         if store is None:
             return []
         try:
-            return list(store.distinct_sources())
+            return list(store.distinct_sources(accounts=self._default_accounts))
         except Exception as exc:  # noqa: BLE001
             logger.debug("distinct_sources() failed: %s", exc)
             return []

--- a/src/openjarvis/agents/research_loop.py
+++ b/src/openjarvis/agents/research_loop.py
@@ -23,6 +23,7 @@ import sys
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional, Tuple
+from urllib.parse import quote
 
 from openjarvis.connectors.hybrid_search import HybridSearch, SearchHit
 from openjarvis.core.types import Message, Role, ToolCall
@@ -264,6 +265,15 @@ def _bare_doc_id(source: str, document_id: str) -> str:
     return document_id
 
 
+def _native_doc_id(source: str, document_id: str, account: str = "") -> str:
+    """Strip connector and named-profile prefixes from a stored document ID."""
+    bare = _bare_doc_id(source, document_id)
+    account_prefix = f"{account}:" if account else ""
+    if account_prefix and bare.startswith(account_prefix):
+        return bare[len(account_prefix) :]
+    return bare
+
+
 def _hit_url(source: str, document_id: str) -> str:
     """Reconstruct a clickable URL from a hit's ``doc_id`` alone.
 
@@ -408,7 +418,22 @@ def build_sources_for_client(
         # link for sources whose web URL doesn't derive from the doc_id.
         # Fall back to the doc_id-based reconstruction for sources where
         # that still works (Slack, Gmail).
-        url = h.url or _hit_url(h.source, h.document_id)
+        source_id = _native_doc_id(h.source, h.document_id, h.account)
+        if h.url:
+            url = h.url
+        elif h.source == "gmail" and h.account:
+            # A named Gmail citation must never fall back to browser slot
+            # /u/0, which can open a different signed-in identity.  Rebuild
+            # only when provider-asserted email provenance is available;
+            # otherwise omit the ambiguous link.
+            url = (
+                "https://mail.google.com/mail/?authuser="
+                f"{quote(h.source_email.strip(), safe='')}#all/{source_id}"
+                if h.source_email and source_id
+                else ""
+            )
+        else:
+            url = _hit_url(h.source, h.document_id)
         out.append(
             {
                 "ref": i + 1 + ref_offset,
@@ -419,7 +444,7 @@ def build_sources_for_client(
                 "account": h.account,
                 "source_profile": h.source_profile,
                 "source_email": h.source_email,
-                "source_id": _bare_doc_id(h.source, h.document_id),
+                "source_id": source_id,
                 "url": url,
             }
         )
@@ -525,9 +550,11 @@ class ResearchAgent:
         self._on_event = on_event
         from openjarvis.connectors.oauth import normalize_account_alias
 
-        self._default_accounts = [
-            normalize_account_alias(account) for account in (default_accounts or [])
-        ]
+        self._default_accounts = (
+            None
+            if default_accounts is None
+            else [normalize_account_alias(account) for account in default_accounts]
+        )
         # Explicit list wins; otherwise we'll discover sources from the
         # KnowledgeStore on each run() call so the prompt stays accurate
         # even as the user connects new connectors mid-session.
@@ -606,13 +633,15 @@ class ResearchAgent:
                 except ValueError:
                     normalized_accounts.append("__openjarvis_no_matching_account__")
             accounts = normalized_accounts
-        if self._default_accounts:
+        if self._default_accounts is not None:
             # User/configured account scope is an authorization-style
             # boundary, not a planner hint.  A model-generated scoped source
             # (for example ``gmail:personal``) must never bypass an explicit
             # ``--account work`` restriction.  Planner-provided account
             # filters may narrow a multi-account boundary, but never widen it.
-            if accounts:
+            if not self._default_accounts:
+                accounts = ["__openjarvis_no_matching_account__"]
+            elif accounts:
                 requested = set(accounts)
                 accounts = [
                     account

--- a/src/openjarvis/agents/research_loop.py
+++ b/src/openjarvis/agents/research_loop.py
@@ -508,6 +508,7 @@ class ResearchAgent:
         clarify_handler: Optional[Callable[[str], str]] = None,
         on_event: Optional[Callable[[Dict[str, Any]], None]] = None,
         available_sources: Optional[List[str]] = None,
+        default_accounts: Optional[List[str]] = None,
     ) -> None:
         self._engine = engine
         self._search = search
@@ -518,6 +519,11 @@ class ResearchAgent:
         self._num_ctx = int(num_ctx)
         self._clarify_handler = clarify_handler or _default_clarify_handler
         self._on_event = on_event
+        from openjarvis.connectors.oauth import normalize_account_alias
+
+        self._default_accounts = [
+            normalize_account_alias(account) for account in (default_accounts or [])
+        ]
         # Explicit list wins; otherwise we'll discover sources from the
         # KnowledgeStore on each run() call so the prompt stays accurate
         # even as the user connects new connectors mid-session.
@@ -564,19 +570,6 @@ class ResearchAgent:
 
         if person:
             person = str(person).strip() or None
-            # Small/local planners often misclassify exact marker strings,
-            # ticket IDs, and other search literals as a `person` filter. That
-            # turns a good lexical search into an impossible AND over
-            # participants/author. If the supposed person is just the query
-            # rewritten/normalized, treat it as a search term only.
-            if query and person:
-                norm_query = _norm_markerish(query)
-                norm_person = _norm_markerish(person)
-                marker_like_query = any(ch in query for ch in "_-0123456789")
-                if norm_person == norm_query or (
-                    marker_like_query and norm_person and norm_person in norm_query
-                ):
-                    person = None
         time_range = self._parse_time_range(args.get("time_range"))
         sources = args.get("sources") or None
         if sources and not isinstance(sources, list):
@@ -584,6 +577,9 @@ class ResearchAgent:
         accounts = args.get("accounts") or args.get("account") or None
         if accounts and not isinstance(accounts, list):
             accounts = [str(accounts)]
+        has_scoped_source = any(":" in str(source) for source in (sources or []))
+        if not accounts and not has_scoped_source and self._default_accounts:
+            accounts = list(self._default_accounts)
         if person:
             # The planner can also mistake an account alias from a scoped
             # source like gmail:personal-main for a person filter (e.g.
@@ -598,7 +594,10 @@ class ResearchAgent:
                 if ":" in source_s:
                     scoped_accounts.append(source_s.split(":", 1)[1])
             scoped_accounts.extend(str(account) for account in (accounts or []))
-            if any(_norm_markerish(person) == _norm_markerish(account) for account in scoped_accounts):
+            if any(
+                _norm_markerish(person) == _norm_markerish(account)
+                for account in scoped_accounts
+            ):
                 person = None
         limit = int(args.get("limit", 20) or 20)
         limit = max(1, min(limit, 20))

--- a/src/openjarvis/agents/tool_resolver.py
+++ b/src/openjarvis/agents/tool_resolver.py
@@ -284,13 +284,25 @@ def build_deep_research_tools(
 
     store = KnowledgeStore(str(path))
     try:
+        from openjarvis.core.config import load_config
+
+        config = load_config()
+        account_scope = config.connectors.google.account_scope(
+            config.agent.default_accounts
+        )
         retriever = TwoStageRetriever(store)
-        return [
+        tools = [
             KnowledgeSearchTool(retriever=retriever),
-            KnowledgeSQLTool(store=store),
-            ScanChunksTool(store=store, engine=engine, model=model),
+            KnowledgeSQLTool(store=store, accounts=account_scope),
+            ScanChunksTool(
+                store=store,
+                engine=engine,
+                model=model,
+                accounts=account_scope,
+            ),
             ThinkTool(),
         ]
+        return tools
     except Exception:
         store.close()
         raise

--- a/src/openjarvis/agents/tool_resolver.py
+++ b/src/openjarvis/agents/tool_resolver.py
@@ -259,6 +259,37 @@ def instantiate_registered_tool(
     return tool_cls()
 
 
+def build_deep_research_tools_from_store(
+    engine: Any,
+    model: str,
+    store: Any,
+) -> list[Any]:
+    """Construct one consistently account-scoped deep-research tool set."""
+    from openjarvis.connectors.retriever import TwoStageRetriever
+    from openjarvis.core.config import load_config
+    from openjarvis.tools.knowledge_search import KnowledgeSearchTool
+    from openjarvis.tools.knowledge_sql import KnowledgeSQLTool
+    from openjarvis.tools.scan_chunks import ScanChunksTool
+    from openjarvis.tools.think import ThinkTool
+
+    config = load_config()
+    account_scope = config.connectors.google.account_scope(
+        config.agent.default_accounts
+    )
+    retriever = TwoStageRetriever(store)
+    return [
+        KnowledgeSearchTool(retriever=retriever),
+        KnowledgeSQLTool(store=store, accounts=account_scope),
+        ScanChunksTool(
+            store=store,
+            engine=engine,
+            model=model,
+            accounts=account_scope,
+        ),
+        ThinkTool(),
+    ]
+
+
 def build_deep_research_tools(
     engine: Any,
     model: str,
@@ -275,34 +306,11 @@ def build_deep_research_tools(
     if not path.exists():
         return []
 
-    from openjarvis.connectors.retriever import TwoStageRetriever
     from openjarvis.connectors.store import KnowledgeStore
-    from openjarvis.tools.knowledge_search import KnowledgeSearchTool
-    from openjarvis.tools.knowledge_sql import KnowledgeSQLTool
-    from openjarvis.tools.scan_chunks import ScanChunksTool
-    from openjarvis.tools.think import ThinkTool
 
     store = KnowledgeStore(str(path))
     try:
-        from openjarvis.core.config import load_config
-
-        config = load_config()
-        account_scope = config.connectors.google.account_scope(
-            config.agent.default_accounts
-        )
-        retriever = TwoStageRetriever(store)
-        tools = [
-            KnowledgeSearchTool(retriever=retriever),
-            KnowledgeSQLTool(store=store, accounts=account_scope),
-            ScanChunksTool(
-                store=store,
-                engine=engine,
-                model=model,
-                accounts=account_scope,
-            ),
-            ThinkTool(),
-        ]
-        return tools
+        return build_deep_research_tools_from_store(engine, model, store)
     except Exception:
         store.close()
         raise
@@ -507,6 +515,7 @@ __all__ = [
     "BROWSER_SUB_TOOLS",
     "ResolvedAgentTools",
     "build_deep_research_tools",
+    "build_deep_research_tools_from_store",
     "ensure_registries_populated",
     "instantiate_registered_tool",
     "resolve_agent_tools",

--- a/src/openjarvis/cli/ask.py
+++ b/src/openjarvis/cli/ask.py
@@ -157,18 +157,15 @@ def _run_research(
             trace.print(f"  [dim]↳ Clarifying:[/dim] [dim italic]{q}[/dim italic]")
         # final_answer and clarify_response are handled outside the loop.
 
+    config = load_config()
+    configured_defaults = config.agent.default_accounts
+    default_account_scope = config.connectors.google.account_scope(configured_defaults)
     agent = ResearchAgent(
         engine=engine,
         search=HybridSearch(store, embedder),
         model=planner_model,
         on_event=on_event,
-        default_accounts=(
-            accounts
-            if accounts is not None
-            else load_config().connectors.google.enabled_aliases(
-                load_config().agent.default_accounts
-            )
-        ),
+        default_accounts=(accounts if accounts is not None else default_account_scope),
     )
 
     started = time.monotonic()

--- a/src/openjarvis/cli/ask.py
+++ b/src/openjarvis/cli/ask.py
@@ -43,6 +43,7 @@ def _run_research(
     knowledge_db: str | None,
     output_json: bool,
     console: Console,
+    accounts: list[str] | None = None,
 ) -> None:
     """Run the hybrid-search research loop and print the result to the console.
 
@@ -66,14 +67,13 @@ def _run_research(
     store = KnowledgeStore(**store_kwargs)
 
     # Research mode is wired specifically to Ollama: the planner prompt
-    # and the function-call schema for search/clarify both assume Ollama's
-    # /api/chat tool semantics. Using the engine returned by get_engine() here
-    # is a foot-gun — discovery can pick any OpenAI-compatible engine registered
-    # on the same port as our own API server. Honor configured/remote Ollama
-    # host though; otherwise LAN setups fall back to localhost during research.
-    cfg = load_config()
-    ollama_host = cfg.engine.ollama.host or None
-    engine = OllamaEngine(host=ollama_host)
+    # (gemma4:31b) and the function-call schema for search/clarify both
+    # assume Ollama's /api/chat tool semantics. Using the engine returned
+    # by get_engine() here is a foot-gun — discovery can pick any
+    # OpenAI-compatible engine registered on the same port as our own
+    # API server. research_router.py hardcodes OllamaEngine() for the
+    # same reason; mirror that here so CLI and HTTP behave identically.
+    engine = OllamaEngine()
 
     chunk_count = store._conn.execute(
         "SELECT COUNT(*) FROM knowledge_chunks"
@@ -86,7 +86,7 @@ def _run_research(
         chunk_count,
     )
 
-    embedder = OllamaEmbedder(host=ollama_host or "http://localhost:11434")
+    embedder = OllamaEmbedder()
     embedder_available = embedder.is_available()
     logger.debug("research: embedder available=%s", embedder_available)
     if not embedder_available:
@@ -96,9 +96,7 @@ def _run_research(
         )
         embedder = None
 
-    planner_model = (
-        model_name or cfg.intelligence.default_model or DEFAULT_PLANNER_MODEL
-    )
+    planner_model = model_name or DEFAULT_PLANNER_MODEL
     logger.debug("research: planner_model=%s", planner_model)
 
     # ---- Output styling --------------------------------------------------
@@ -164,6 +162,9 @@ def _run_research(
         search=HybridSearch(store, embedder),
         model=planner_model,
         on_event=on_event,
+        default_accounts=(
+            accounts if accounts is not None else load_config().agent.default_accounts
+        ),
     )
 
     started = time.monotonic()
@@ -219,6 +220,24 @@ def _run_research(
             f"[dim]Deep Research · {elapsed:.1f}s · "
             f"{len(cited)} {src_word} cited · {planner_model} · {engine_label}[/dim]"
         )
+
+
+def _normalise_account_filters(
+    account_names: tuple[str, ...],
+    accounts_csv: str,
+) -> list[str]:
+    """Validate and de-duplicate CLI account filters in stable order."""
+    from openjarvis.connectors.oauth import normalize_account_alias
+
+    raw_accounts = [*account_names, *accounts_csv.split(",")]
+    accounts: list[str] = []
+    for raw_account in raw_accounts:
+        if not raw_account.strip():
+            continue
+        account = normalize_account_alias(raw_account)
+        if account not in accounts:
+            accounts.append(account)
+    return accounts
 
 
 def _get_memory_backend(config):
@@ -637,6 +656,21 @@ def _print_profile(
     ),
 )
 @click.option(
+    "--account",
+    "account_names",
+    multiple=True,
+    help=(
+        "Limit knowledge retrieval to a named connector account. "
+        "Repeat for multiple accounts; implies --research."
+    ),
+)
+@click.option(
+    "--accounts",
+    "accounts_csv",
+    default="",
+    help="Comma-separated named connector accounts; implies --research.",
+)
+@click.option(
     "-i",
     "--image",
     "image_paths",
@@ -676,6 +710,8 @@ def ask(
     enable_profile: bool,
     research_mode: bool,
     knowledge_db: str | None,
+    account_names: tuple[str, ...],
+    accounts_csv: str,
     persona_name: str | None,
     image_paths: tuple[str, ...] = (),
     capture_screen: bool = False,
@@ -711,6 +747,13 @@ def ask(
 
     # Load config
     config = load_config()
+
+    try:
+        requested_accounts = _normalise_account_filters(account_names, accounts_csv)
+    except ValueError as exc:
+        raise click.UsageError(str(exc)) from exc
+    if requested_accounts:
+        research_mode = True
 
     # Resolve effective MemoryFilesConfig with --persona override
     import dataclasses as _dc
@@ -818,6 +861,7 @@ def ask(
             knowledge_db=knowledge_db,
             output_json=output_json,
             console=console,
+            accounts=requested_accounts or None,
         )
         return
 

--- a/src/openjarvis/cli/ask.py
+++ b/src/openjarvis/cli/ask.py
@@ -66,13 +66,14 @@ def _run_research(
     store = KnowledgeStore(**store_kwargs)
 
     # Research mode is wired specifically to Ollama: the planner prompt
-    # (gemma4:31b) and the function-call schema for search/clarify both
-    # assume Ollama's /api/chat tool semantics. Using the engine returned
-    # by get_engine() here is a foot-gun — discovery can pick any
-    # OpenAI-compatible engine registered on the same port as our own
-    # API server. research_router.py hardcodes OllamaEngine() for the
-    # same reason; mirror that here so CLI and HTTP behave identically.
-    engine = OllamaEngine()
+    # and the function-call schema for search/clarify both assume Ollama's
+    # /api/chat tool semantics. Using the engine returned by get_engine() here
+    # is a foot-gun — discovery can pick any OpenAI-compatible engine registered
+    # on the same port as our own API server. Honor configured/remote Ollama
+    # host though; otherwise LAN setups fall back to localhost during research.
+    cfg = load_config()
+    ollama_host = cfg.engine.ollama.host or None
+    engine = OllamaEngine(host=ollama_host)
 
     chunk_count = store._conn.execute(
         "SELECT COUNT(*) FROM knowledge_chunks"
@@ -85,7 +86,7 @@ def _run_research(
         chunk_count,
     )
 
-    embedder = OllamaEmbedder()
+    embedder = OllamaEmbedder(host=ollama_host or "http://localhost:11434")
     embedder_available = embedder.is_available()
     logger.debug("research: embedder available=%s", embedder_available)
     if not embedder_available:
@@ -95,7 +96,9 @@ def _run_research(
         )
         embedder = None
 
-    planner_model = model_name or DEFAULT_PLANNER_MODEL
+    planner_model = (
+        model_name or cfg.intelligence.default_model or DEFAULT_PLANNER_MODEL
+    )
     logger.debug("research: planner_model=%s", planner_model)
 
     # ---- Output styling --------------------------------------------------

--- a/src/openjarvis/cli/ask.py
+++ b/src/openjarvis/cli/ask.py
@@ -163,7 +163,11 @@ def _run_research(
         model=planner_model,
         on_event=on_event,
         default_accounts=(
-            accounts if accounts is not None else load_config().agent.default_accounts
+            accounts
+            if accounts is not None
+            else load_config().connectors.google.enabled_aliases(
+                load_config().agent.default_accounts
+            )
         ),
     )
 
@@ -753,6 +757,15 @@ def ask(
     except ValueError as exc:
         raise click.UsageError(str(exc)) from exc
     if requested_accounts:
+        disabled_accounts = [
+            account
+            for account in requested_accounts
+            if not config.connectors.google.is_enabled(account)
+        ]
+        if disabled_accounts:
+            raise click.UsageError(
+                "Disabled Google account profile(s): " + ", ".join(disabled_accounts)
+            )
         research_mode = True
 
     # Resolve effective MemoryFilesConfig with --persona override

--- a/src/openjarvis/cli/channels_cmd.py
+++ b/src/openjarvis/cli/channels_cmd.py
@@ -98,33 +98,19 @@ def imessage_start(
         from openjarvis.agents.deep_research import (
             DeepResearchAgent,
         )
-        from openjarvis.connectors.retriever import (
-            TwoStageRetriever,
+        from openjarvis.agents.tool_resolver import (
+            build_deep_research_tools_from_store,
         )
         from openjarvis.connectors.store import KnowledgeStore
         from openjarvis.engine.ollama import OllamaEngine
-        from openjarvis.tools.knowledge_search import (
-            KnowledgeSearchTool,
-        )
-        from openjarvis.tools.knowledge_sql import (
-            KnowledgeSQLTool,
-        )
-        from openjarvis.tools.scan_chunks import ScanChunksTool
-        from openjarvis.tools.think import ThinkTool
 
         engine = OllamaEngine()
         store = KnowledgeStore()
-        retriever = TwoStageRetriever(store)
-        tools = [
-            KnowledgeSearchTool(retriever=retriever),
-            KnowledgeSQLTool(store=store),
-            ScanChunksTool(
-                store=store,
-                engine=engine,
-                model="qwen3.5:4b",
-            ),
-            ThinkTool(),
-        ]
+        tools = build_deep_research_tools_from_store(
+            engine,
+            "qwen3.5:4b",
+            store,
+        )
         agent = DeepResearchAgent(
             engine=engine,
             model="qwen3.5:4b",

--- a/src/openjarvis/cli/connect_cmd.py
+++ b/src/openjarvis/cli/connect_cmd.py
@@ -37,9 +37,19 @@ def _list_sources(registry: object) -> None:
     console.print(table)
 
 
-def _disconnect_source(registry: object, source: str) -> None:
+def _disconnect_source(registry: object, source: str, account: str = "") -> None:
     """Find and disconnect a registered source connector."""
     console = Console()
+
+    if source == "google" and account:
+        from openjarvis.connectors.oauth import (
+            delete_tokens,
+            google_account_credentials_path,
+        )
+
+        delete_tokens(google_account_credentials_path(account))
+        console.print(f"[green]Disconnected google:{account}.[/green]")
+        return
 
     if not registry.contains(source):  # type: ignore[attr-defined]
         console.print(f"[red]Unknown source: {source}[/red]")
@@ -47,16 +57,66 @@ def _disconnect_source(registry: object, source: str) -> None:
 
     connector_cls = registry.get(source)  # type: ignore[attr-defined]
     try:
-        instance = connector_cls()
+        try:
+            instance = connector_cls(account=account) if account else connector_cls()
+        except TypeError:
+            instance = connector_cls()
         instance.disconnect()
-        console.print(f"[green]Disconnected {source}.[/green]")
+        suffix = f":{account}" if account else ""
+        console.print(f"[green]Disconnected {source}{suffix}.[/green]")
     except Exception as exc:  # noqa: BLE001
         console.print(f"[red]Failed to disconnect {source}: {exc}[/red]")
 
 
-def _connect_source(registry: object, source: str, path: str = "") -> None:
+def _connect_source(
+    registry: object,
+    source: str,
+    path: str = "",
+    account: str = "",
+) -> None:
     """Route connector setup by auth_type."""
     console = Console()
+
+    if source == "google":
+        from openjarvis.connectors.oauth import (
+            OAUTH_PROVIDERS,
+            get_client_credentials,
+            run_connector_oauth,
+            save_client_credentials,
+        )
+
+        try:
+            provider = OAUTH_PROVIDERS["google"]
+            creds = get_client_credentials(provider, account=account)
+            client_id = creds[0] if creds else ""
+            client_secret = creds[1] if creds else ""
+
+            if not client_id or not client_secret:
+                console.print("[cyan]First-time setup for Google.[/cyan]")
+                console.print(
+                    f"[yellow]Create an OAuth app at: {provider.setup_url}[/yellow]"
+                )
+                console.print(f"[dim]{provider.setup_hint}[/dim]")
+                client_id = click.prompt("Client ID")
+                client_secret = click.prompt("Client Secret")
+                save_client_credentials(
+                    provider,
+                    client_id,
+                    client_secret,
+                    account=account,
+                )
+
+            run_connector_oauth(
+                "gmail",
+                client_id,
+                client_secret,
+                account=account,
+            )
+            suffix = f":{account}" if account else ""
+            console.print(f"[green]google{suffix} authorised successfully.[/green]")
+        except Exception as exc:  # noqa: BLE001
+            console.print(f"[red]OAuth flow failed for google: {exc}[/red]")
+        return
 
     if not registry.contains(source):  # type: ignore[attr-defined]
         console.print(f"[red]Unknown source: {source}[/red]")
@@ -104,9 +164,15 @@ def _connect_source(registry: object, source: str, path: str = "") -> None:
         )
 
         try:
-            instance = connector_cls()
+            try:
+                instance = (
+                    connector_cls(account=account) if account else connector_cls()
+                )
+            except TypeError:
+                instance = connector_cls()
             if instance.is_connected():
-                console.print(f"[green]{source} is already connected.[/green]")
+                suffix = f":{account}" if account else ""
+                console.print(f"[green]{source}{suffix} is already connected.[/green]")
                 return
 
             provider = get_provider_for_connector(source)
@@ -114,7 +180,7 @@ def _connect_source(registry: object, source: str, path: str = "") -> None:
                 console.print(f"[red]No OAuth provider configured for {source}.[/red]")
                 return
 
-            creds = get_client_credentials(provider)
+            creds = get_client_credentials(provider, account=account)
             client_id = creds[0] if creds else ""
             client_secret = creds[1] if creds else ""
 
@@ -126,10 +192,16 @@ def _connect_source(registry: object, source: str, path: str = "") -> None:
                 console.print(f"[dim]{provider.setup_hint}[/dim]")
                 client_id = click.prompt("Client ID")
                 client_secret = click.prompt("Client Secret")
-                save_client_credentials(provider, client_id, client_secret)
+                save_client_credentials(
+                    provider,
+                    client_id,
+                    client_secret,
+                    account=account,
+                )
 
-            run_connector_oauth(source, client_id, client_secret)
-            console.print(f"[green]{source} authorised successfully.[/green]")
+            run_connector_oauth(source, client_id, client_secret, account=account)
+            suffix = f":{account}" if account else ""
+            console.print(f"[green]{source}{suffix} authorised successfully.[/green]")
         except Exception as exc:  # noqa: BLE001
             console.print(f"[red]OAuth flow failed for {source}: {exc}[/red]")
 
@@ -193,6 +265,16 @@ def _connect_source(registry: object, source: str, path: str = "") -> None:
     default="",
     help="Path for filesystem connectors (e.g., Obsidian vault).",
 )
+@click.option(
+    "--account",
+    default="",
+    help="Named connector account alias (e.g., personal, work).",
+)
+@click.option(
+    "--profile",
+    default="",
+    help="Alias for --account.",
+)
 @click.pass_context
 def connect(
     ctx: click.Context,
@@ -201,11 +283,15 @@ def connect(
     trigger_sync: bool,
     disconnect_source: str,
     path: str,
+    account: str,
+    profile: str,
 ) -> None:
     """Manage data source connections (Gmail, Obsidian, etc.)."""
     # Lazy imports to avoid top-level side effects
     import openjarvis.connectors  # noqa: F401 — registers all connectors
     from openjarvis.core.registry import ConnectorRegistry
+
+    account_alias = account or profile
 
     if list_sources:
         _list_sources(ConnectorRegistry)
@@ -216,11 +302,11 @@ def connect(
         return
 
     if disconnect_source:
-        _disconnect_source(ConnectorRegistry, disconnect_source)
+        _disconnect_source(ConnectorRegistry, disconnect_source, account=account_alias)
         return
 
     if source:
-        _connect_source(ConnectorRegistry, source, path=path)
+        _connect_source(ConnectorRegistry, source, path=path, account=account_alias)
         return
 
     # No arguments — show help

--- a/src/openjarvis/cli/connect_cmd.py
+++ b/src/openjarvis/cli/connect_cmd.py
@@ -145,11 +145,9 @@ def _migrate_legacy_google_index(account: str) -> None:
                 # ambiguous and must be preserved rather than risking an
                 # unrelated IMAP mailbox.  The other Google source IDs are
                 # unambiguous and safe to migrate by source alone.
-                store.delete_by_sources(unambiguous_sources, unscoped_only=True)
-                store.delete_by_sources(
-                    ("gmail",),
-                    unscoped_only=True,
-                    metadata_connector="gmail",
+                store.delete_unscoped_sources_with_attribution(
+                    unambiguous_sources,
+                    {"gmail": "gmail"},
                 )
             except Exception:
                 for connector_id, checkpoint in old_checkpoints.items():

--- a/src/openjarvis/cli/connect_cmd.py
+++ b/src/openjarvis/cli/connect_cmd.py
@@ -38,7 +38,13 @@ def _list_sources(registry: object) -> None:
         from openjarvis.connectors.oauth import list_google_accounts
 
         for profile in list_google_accounts():
-            status = "connected" if profile["connected"] else "pending"
+            status = (
+                "disabled"
+                if not profile.get("enabled", True)
+                else "connected"
+                if profile["connected"]
+                else "pending"
+            )
             table.add_row(f"google:{profile['account']}", "oauth", status)
     except Exception:  # noqa: BLE001
         pass
@@ -113,6 +119,82 @@ def _purge_google_account_index(account: str) -> None:
                 for key, checkpoint in old_checkpoints.items():
                     engine.restore_checkpoint(key, checkpoint)
                 raise
+
+
+def _migrate_legacy_google_index(account: str) -> None:
+    """Remove unscoped legacy Google rows/checkpoints before named reindexing."""
+    from openjarvis.connectors.oauth import OAUTH_PROVIDERS
+    from openjarvis.connectors.pipeline import IngestionPipeline
+    from openjarvis.connectors.store import KnowledgeStore
+    from openjarvis.connectors.sync_engine import SyncEngine
+
+    connector_ids = tuple(OAUTH_PROVIDERS["google"].connector_ids)
+    with KnowledgeStore() as store:
+        with SyncEngine(pipeline=IngestionPipeline(store=store)) as engine:
+            old_checkpoints = {
+                connector_id: engine.get_checkpoint(connector_id)
+                for connector_id in connector_ids
+            }
+            try:
+                for connector_id in connector_ids:
+                    engine.reset_checkpoint(connector_id)
+                store.delete_by_sources(connector_ids, unscoped_only=True)
+            except Exception:
+                for connector_id, checkpoint in old_checkpoints.items():
+                    engine.restore_checkpoint(connector_id, checkpoint)
+                raise
+
+
+def _sync_sources(registry: object, source: str = "", account: str = "") -> None:
+    """Run an incremental connector sync from the CLI."""
+    from openjarvis.connectors.oauth import OAUTH_PROVIDERS
+    from openjarvis.connectors.pipeline import IngestionPipeline
+    from openjarvis.connectors.store import KnowledgeStore
+    from openjarvis.connectors.sync_engine import SyncEngine
+
+    console = Console()
+    if source == "google":
+        source_ids = list(OAUTH_PROVIDERS["google"].connector_ids)
+    elif source:
+        source_ids = [source]
+    else:
+        source_ids = list(registry.keys())  # type: ignore[attr-defined]
+
+    with KnowledgeStore() as store:
+        with SyncEngine(pipeline=IngestionPipeline(store=store)) as engine:
+            for connector_id in source_ids:
+                if not registry.contains(connector_id):  # type: ignore[attr-defined]
+                    console.print(
+                        f"[yellow]Skipping unknown source {connector_id}.[/yellow]"
+                    )
+                    continue
+                connector_cls = registry.get(connector_id)  # type: ignore[attr-defined]
+                try:
+                    instance = (
+                        connector_cls(account=account) if account else connector_cls()
+                    )
+                except (TypeError, ValueError) as exc:
+                    console.print(
+                        f"[yellow]Skipping {connector_id}: "
+                        f"cannot configure ({exc}).[/yellow]"
+                    )
+                    continue
+                if not instance.is_connected():
+                    suffix = f":{account}" if account else ""
+                    console.print(
+                        f"[yellow]Skipping disconnected "
+                        f"{connector_id}{suffix}.[/yellow]"
+                    )
+                    continue
+                try:
+                    count = engine.sync(instance)
+                    suffix = f":{account}" if account else ""
+                    console.print(
+                        f"[green]Synced {connector_id}{suffix}: "
+                        f"{count} document(s).[/green]"
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    console.print(f"[red]Sync failed for {connector_id}: {exc}[/red]")
 
 
 def _connect_source(
@@ -322,6 +404,14 @@ def _connect_source(
     default="",
     help="Alias for --account.",
 )
+@click.option(
+    "--migrate-legacy-google",
+    is_flag=True,
+    help=(
+        "Delete unscoped legacy Google index rows/checkpoints before "
+        "reindexing them into --account."
+    ),
+)
 @click.pass_context
 def connect(
     ctx: click.Context,
@@ -332,6 +422,7 @@ def connect(
     path: str,
     account: str,
     profile: str,
+    migrate_legacy_google: bool,
 ) -> None:
     """Manage data source connections (Gmail, Obsidian, etc.)."""
     # Lazy imports to avoid top-level side effects
@@ -340,6 +431,7 @@ def connect(
         get_provider_for_connector,
         normalize_account_alias,
     )
+    from openjarvis.core.config import load_config
     from openjarvis.core.registry import ConnectorRegistry
 
     try:
@@ -350,6 +442,10 @@ def connect(
     if account_alias and profile_alias and account_alias != profile_alias:
         raise click.UsageError("--account and --profile must name the same alias")
     account_alias = account_alias or profile_alias
+    if account_alias and not load_config().connectors.google.is_enabled(account_alias):
+        raise click.UsageError(
+            f"Google account profile '{account_alias}' is disabled in config.toml"
+        )
 
     selected_source = disconnect_source or source or ""
     if account_alias and selected_source != "google":
@@ -364,9 +460,16 @@ def connect(
         _list_sources(ConnectorRegistry)
         return
 
-    if trigger_sync:
-        click.echo("Sync not yet implemented in CLI")
-        return
+    if migrate_legacy_google:
+        if not account_alias or selected_source != "google":
+            raise click.UsageError(
+                "--migrate-legacy-google requires `google --account ALIAS`"
+            )
+        _migrate_legacy_google_index(account_alias)
+        click.echo(
+            "Removed legacy unscoped Google rows and checkpoints; "
+            f"reindexing now targets '{account_alias}'."
+        )
 
     if disconnect_source:
         _disconnect_source(ConnectorRegistry, disconnect_source, account=account_alias)
@@ -374,6 +477,12 @@ def connect(
 
     if source:
         _connect_source(ConnectorRegistry, source, path=path, account=account_alias)
+        if trigger_sync:
+            _sync_sources(ConnectorRegistry, source=source, account=account_alias)
+        return
+
+    if trigger_sync:
+        _sync_sources(ConnectorRegistry, account=account_alias)
         return
 
     # No arguments — show help

--- a/src/openjarvis/cli/connect_cmd.py
+++ b/src/openjarvis/cli/connect_cmd.py
@@ -56,27 +56,31 @@ def _disconnect_source(registry: object, source: str, account: str = "") -> None
     """Find and disconnect a registered source connector."""
     console = Console()
 
-    if account:
-        from openjarvis.connectors.oauth import (
-            delete_tokens,
-            get_provider_for_connector,
-            google_account_credentials_path,
-        )
+    from openjarvis.connectors.oauth import (
+        OAUTH_PROVIDERS,
+        delete_provider_tokens,
+        get_provider_for_connector,
+    )
 
-        provider = get_provider_for_connector(source)
-        if source == "google" or (provider and provider.name == "google"):
-            try:
+    provider = (
+        OAUTH_PROVIDERS["google"]
+        if source == "google"
+        else get_provider_for_connector(source)
+    )
+    if provider and provider.name == "google":
+        try:
+            if account:
                 _purge_google_account_index(account)
-                delete_tokens(google_account_credentials_path(account))
-                console.print(
-                    f"[green]Disconnected Google account {account} from all "
-                    "Google connectors.[/green]"
-                )
-            except Exception as exc:  # noqa: BLE001
-                console.print(
-                    f"[red]Failed to disconnect Google account {account}: {exc}[/red]"
-                )
-            return
+            else:
+                _migrate_legacy_google_index("")
+            delete_provider_tokens(provider, account=account)
+            label = f" account {account}" if account else ""
+            console.print(
+                f"[green]Disconnected Google{label} from all Google connectors.[/green]"
+            )
+        except Exception as exc:  # noqa: BLE001
+            console.print(f"[red]Failed to disconnect Google: {exc}[/red]")
+        return
 
     if not registry.contains(source):  # type: ignore[attr-defined]
         console.print(f"[red]Unknown source: {source}[/red]")

--- a/src/openjarvis/cli/connect_cmd.py
+++ b/src/openjarvis/cli/connect_cmd.py
@@ -129,6 +129,7 @@ def _migrate_legacy_google_index(account: str) -> None:
     from openjarvis.connectors.sync_engine import SyncEngine
 
     connector_ids = tuple(OAUTH_PROVIDERS["google"].connector_ids)
+    unambiguous_sources = tuple(cid for cid in connector_ids if cid != "gmail")
     with KnowledgeStore() as store:
         with SyncEngine(pipeline=IngestionPipeline(store=store)) as engine:
             old_checkpoints = {
@@ -138,7 +139,18 @@ def _migrate_legacy_google_index(account: str) -> None:
             try:
                 for connector_id in connector_ids:
                     engine.reset_checkpoint(connector_id)
-                store.delete_by_sources(connector_ids, unscoped_only=True)
+                # Gmail OAuth and Gmail IMAP historically shared
+                # ``source='gmail'``.  Delete Gmail rows only when they carry
+                # positive Google-connector provenance; an unmarked row is
+                # ambiguous and must be preserved rather than risking an
+                # unrelated IMAP mailbox.  The other Google source IDs are
+                # unambiguous and safe to migrate by source alone.
+                store.delete_by_sources(unambiguous_sources, unscoped_only=True)
+                store.delete_by_sources(
+                    ("gmail",),
+                    unscoped_only=True,
+                    metadata_connector="gmail",
+                )
             except Exception:
                 for connector_id, checkpoint in old_checkpoints.items():
                     engine.restore_checkpoint(connector_id, checkpoint)
@@ -202,7 +214,7 @@ def _connect_source(
     source: str,
     path: str = "",
     account: str = "",
-) -> None:
+) -> bool:
     """Route connector setup by auth_type."""
     console = Console()
 
@@ -215,6 +227,11 @@ def _connect_source(
         )
 
         try:
+            from openjarvis.connectors.gmail import GmailConnector
+
+            if account and GmailConnector(account=account).is_connected():
+                console.print(f"[green]google:{account} is already connected.[/green]")
+                return True
             provider = OAUTH_PROVIDERS["google"]
             creds = get_client_credentials(provider, account=account)
             client_id = creds[0] if creds else ""
@@ -243,9 +260,10 @@ def _connect_source(
             )
             suffix = f":{account}" if account else ""
             console.print(f"[green]google{suffix} authorised successfully.[/green]")
+            return True
         except Exception as exc:  # noqa: BLE001
             console.print(f"[red]OAuth flow failed for google: {exc}[/red]")
-        return
+            return False
 
     if not registry.contains(source):  # type: ignore[attr-defined]
         console.print(f"[red]Unknown source: {source}[/red]")
@@ -254,7 +272,7 @@ def _connect_source(
             + ", ".join(registry.keys())  # type: ignore[attr-defined]
             + "[/yellow]"
         )
-        return
+        return False
 
     connector_cls = registry.get(source)  # type: ignore[attr-defined]
     auth_type = getattr(connector_cls, "auth_type", "")
@@ -265,7 +283,7 @@ def _connect_source(
             console.print(
                 f"[red]{source} requires a --path argument (e.g. --path ~/vault).[/red]"
             )
-            return
+            return False
         try:
             instance = connector_cls(vault_path=path)
         except TypeError:
@@ -273,15 +291,17 @@ def _connect_source(
                 instance = connector_cls(path)
             except Exception as exc:  # noqa: BLE001
                 console.print(f"[red]Failed to create {source} connector: {exc}[/red]")
-                return
+                return False
 
         if instance.is_connected():
             console.print(f"[green]{source} connected at path: {path}[/green]")
+            return True
         else:
             console.print(
                 f"[red]{source}: path '{path}' does not exist or is not accessible."
                 "[/red]"
             )
+            return False
 
     elif auth_type == "oauth":
         # OAuth connectors — auto-open browser + catch callback
@@ -302,12 +322,12 @@ def _connect_source(
             if instance.is_connected():
                 suffix = f":{account}" if account else ""
                 console.print(f"[green]{source}{suffix} is already connected.[/green]")
-                return
+                return True
 
             provider = get_provider_for_connector(source)
             if provider is None:
                 console.print(f"[red]No OAuth provider configured for {source}.[/red]")
-                return
+                return False
 
             creds = get_client_credentials(provider, account=account)
             client_id = creds[0] if creds else ""
@@ -331,8 +351,10 @@ def _connect_source(
             run_connector_oauth(source, client_id, client_secret, account=account)
             suffix = f":{account}" if account else ""
             console.print(f"[green]{source}{suffix} authorised successfully.[/green]")
+            return True
         except Exception as exc:  # noqa: BLE001
             console.print(f"[red]OAuth flow failed for {source}: {exc}[/red]")
+            return False
 
     elif auth_type == "token":
         # Token-based connectors (e.g. Oura) — prompt for personal access token
@@ -346,7 +368,7 @@ def _connect_source(
             instance = connector_cls()
             if instance.is_connected():
                 console.print(f"[green]{source} is already connected.[/green]")
-                return
+                return True
 
             token = click.prompt(f"Enter your {source} personal access token")
             token_dir = Path(DEFAULT_CONFIG_DIR) / "connectors"
@@ -355,8 +377,10 @@ def _connect_source(
             token_file.write_text(json.dumps({"token": token}))
             save_tokens(source, {"token": token})
             console.print(f"[green]{source} connected successfully.[/green]")
+            return True
         except Exception as exc:  # noqa: BLE001
             console.print(f"[red]Token setup failed for {source}: {exc}[/red]")
+            return False
 
     else:
         # Generic / bridge connectors
@@ -365,8 +389,10 @@ def _connect_source(
             connected = instance.is_connected()
             status = "connected" if connected else "disconnected"
             console.print(f"{source} status: {status}")
+            return connected
         except Exception as exc:  # noqa: BLE001
             console.print(f"[red]Failed to connect {source}: {exc}[/red]")
+            return False
 
 
 @click.group(invoke_without_command=True)
@@ -442,7 +468,11 @@ def connect(
     if account_alias and profile_alias and account_alias != profile_alias:
         raise click.UsageError("--account and --profile must name the same alias")
     account_alias = account_alias or profile_alias
-    if account_alias and not load_config().connectors.google.is_enabled(account_alias):
+    if (
+        account_alias
+        and not disconnect_source
+        and not load_config().connectors.google.is_enabled(account_alias)
+    ):
         raise click.UsageError(
             f"Google account profile '{account_alias}' is disabled in config.toml"
         )
@@ -471,11 +501,19 @@ def connect(
         return
 
     if source:
-        _connect_source(ConnectorRegistry, source, path=path, account=account_alias)
+        connect_succeeded = _connect_source(
+            ConnectorRegistry,
+            source,
+            path=path,
+            account=account_alias,
+        )
         if migrate_legacy_google:
             from openjarvis.connectors.gmail import GmailConnector
 
-            if not GmailConnector(account=account_alias).is_connected():
+            if (
+                not connect_succeeded
+                or not GmailConnector(account=account_alias).is_connected()
+            ):
                 raise click.ClickException(
                     "Google authorization did not complete; legacy data was not changed"
                 )

--- a/src/openjarvis/cli/connect_cmd.py
+++ b/src/openjarvis/cli/connect_cmd.py
@@ -465,11 +465,6 @@ def connect(
             raise click.UsageError(
                 "--migrate-legacy-google requires `google --account ALIAS`"
             )
-        _migrate_legacy_google_index(account_alias)
-        click.echo(
-            "Removed legacy unscoped Google rows and checkpoints; "
-            f"reindexing now targets '{account_alias}'."
-        )
 
     if disconnect_source:
         _disconnect_source(ConnectorRegistry, disconnect_source, account=account_alias)
@@ -477,6 +472,18 @@ def connect(
 
     if source:
         _connect_source(ConnectorRegistry, source, path=path, account=account_alias)
+        if migrate_legacy_google:
+            from openjarvis.connectors.gmail import GmailConnector
+
+            if not GmailConnector(account=account_alias).is_connected():
+                raise click.ClickException(
+                    "Google authorization did not complete; legacy data was not changed"
+                )
+            _migrate_legacy_google_index(account_alias)
+            click.echo(
+                "Removed legacy unscoped Google rows and checkpoints; "
+                f"reindexing now targets '{account_alias}'."
+            )
         if trigger_sync:
             _sync_sources(ConnectorRegistry, source=source, account=account_alias)
         return

--- a/src/openjarvis/cli/connect_cmd.py
+++ b/src/openjarvis/cli/connect_cmd.py
@@ -34,6 +34,15 @@ def _list_sources(registry: object) -> None:
 
         table.add_row(key, auth_type, status)
 
+    try:
+        from openjarvis.connectors.oauth import list_google_accounts
+
+        for profile in list_google_accounts():
+            status = "connected" if profile["connected"] else "pending"
+            table.add_row(f"google:{profile['account']}", "oauth", status)
+    except Exception:  # noqa: BLE001
+        pass
+
     console.print(table)
 
 
@@ -41,15 +50,27 @@ def _disconnect_source(registry: object, source: str, account: str = "") -> None
     """Find and disconnect a registered source connector."""
     console = Console()
 
-    if source == "google" and account:
+    if account:
         from openjarvis.connectors.oauth import (
             delete_tokens,
+            get_provider_for_connector,
             google_account_credentials_path,
         )
 
-        delete_tokens(google_account_credentials_path(account))
-        console.print(f"[green]Disconnected google:{account}.[/green]")
-        return
+        provider = get_provider_for_connector(source)
+        if source == "google" or (provider and provider.name == "google"):
+            try:
+                _purge_google_account_index(account)
+                delete_tokens(google_account_credentials_path(account))
+                console.print(
+                    f"[green]Disconnected Google account {account} from all "
+                    "Google connectors.[/green]"
+                )
+            except Exception as exc:  # noqa: BLE001
+                console.print(
+                    f"[red]Failed to disconnect Google account {account}: {exc}[/red]"
+                )
+            return
 
     if not registry.contains(source):  # type: ignore[attr-defined]
         console.print(f"[red]Unknown source: {source}[/red]")
@@ -66,6 +87,32 @@ def _disconnect_source(registry: object, source: str, account: str = "") -> None
         console.print(f"[green]Disconnected {source}{suffix}.[/green]")
     except Exception as exc:  # noqa: BLE001
         console.print(f"[red]Failed to disconnect {source}: {exc}[/red]")
+
+
+def _purge_google_account_index(account: str) -> None:
+    """Remove all indexed rows/checkpoints owned by one Google profile."""
+    from openjarvis.connectors.oauth import OAUTH_PROVIDERS
+    from openjarvis.connectors.pipeline import IngestionPipeline
+    from openjarvis.connectors.store import KnowledgeStore
+    from openjarvis.connectors.sync_engine import SyncEngine
+
+    connector_ids = tuple(OAUTH_PROVIDERS["google"].connector_ids)
+    checkpoint_ids = tuple(
+        f"{connector_id}:{account}" for connector_id in connector_ids
+    )
+    with KnowledgeStore() as store:
+        with SyncEngine(pipeline=IngestionPipeline(store=store)) as engine:
+            old_checkpoints = {
+                key: engine.get_checkpoint(key) for key in checkpoint_ids
+            }
+            try:
+                for key in checkpoint_ids:
+                    engine.reset_checkpoint(key)
+                store.delete_by_sources(connector_ids, account=account)
+            except Exception:
+                for key, checkpoint in old_checkpoints.items():
+                    engine.restore_checkpoint(key, checkpoint)
+                raise
 
 
 def _connect_source(
@@ -289,9 +336,29 @@ def connect(
     """Manage data source connections (Gmail, Obsidian, etc.)."""
     # Lazy imports to avoid top-level side effects
     import openjarvis.connectors  # noqa: F401 — registers all connectors
+    from openjarvis.connectors.oauth import (
+        get_provider_for_connector,
+        normalize_account_alias,
+    )
     from openjarvis.core.registry import ConnectorRegistry
 
-    account_alias = account or profile
+    try:
+        account_alias = normalize_account_alias(account)
+        profile_alias = normalize_account_alias(profile)
+    except ValueError as exc:
+        raise click.UsageError(str(exc)) from exc
+    if account_alias and profile_alias and account_alias != profile_alias:
+        raise click.UsageError("--account and --profile must name the same alias")
+    account_alias = account_alias or profile_alias
+
+    selected_source = disconnect_source or source or ""
+    if account_alias and selected_source != "google":
+        provider = get_provider_for_connector(selected_source)
+        if provider is None or provider.name != "google":
+            raise click.UsageError(
+                "Named account profiles are currently supported only for Google "
+                "connectors."
+            )
 
     if list_sources:
         _list_sources(ConnectorRegistry)

--- a/src/openjarvis/cli/deep_research_setup_cmd.py
+++ b/src/openjarvis/cli/deep_research_setup_cmd.py
@@ -278,12 +278,8 @@ def ingest_sources(
 def _launch_chat(store: KnowledgeStore, console: Console) -> None:
     """Start an interactive Deep Research chat session."""
     from openjarvis.agents.deep_research import DeepResearchAgent
-    from openjarvis.connectors.retriever import TwoStageRetriever
+    from openjarvis.agents.tool_resolver import build_deep_research_tools_from_store
     from openjarvis.engine.ollama import OllamaEngine
-    from openjarvis.tools.knowledge_search import KnowledgeSearchTool
-    from openjarvis.tools.knowledge_sql import KnowledgeSQLTool
-    from openjarvis.tools.scan_chunks import ScanChunksTool
-    from openjarvis.tools.think import ThinkTool
 
     console.print("\n[bold]Setting up Deep Research agent...[/bold]")
 
@@ -307,13 +303,7 @@ def _launch_chat(store: KnowledgeStore, console: Console) -> None:
             return
 
     # Tools
-    retriever = TwoStageRetriever(store)
-    tools = [
-        KnowledgeSearchTool(retriever=retriever),
-        KnowledgeSQLTool(store=store),
-        ScanChunksTool(store=store, engine=engine, model=_OLLAMA_MODEL),
-        ThinkTool(),
-    ]
+    tools = build_deep_research_tools_from_store(engine, _OLLAMA_MODEL, store)
 
     # Agent
     agent = DeepResearchAgent(

--- a/src/openjarvis/connectors/gcalendar.py
+++ b/src/openjarvis/connectors/gcalendar.py
@@ -253,9 +253,14 @@ class GCalendarConnector(BaseConnector):
 
     def __init__(self, credentials_path: str = "", account: str = "") -> None:
         self._account = normalize_account_alias(account)
+        self._explicit_credentials_path = bool(credentials_path)
         self._credentials_path = resolve_google_credentials(
             credentials_path or _DEFAULT_CREDENTIALS_PATH,
-            account=self._account if not credentials_path else "",
+            account=self._account,
+            allow_shared_fallback=not self._explicit_credentials_path,
+        )
+        self._mirror_shared_credentials = (
+            not self._explicit_credentials_path and not self._account
         )
         self._items_synced: int = 0
         self._items_total: int = 0

--- a/src/openjarvis/connectors/gcalendar.py
+++ b/src/openjarvis/connectors/gcalendar.py
@@ -18,7 +18,10 @@ from openjarvis.connectors.oauth import (
     GOOGLE_ALL_SCOPES,
     build_google_auth_url,
     delete_tokens,
+    google_account_doc_id,
+    google_account_metadata,
     load_tokens,
+    normalize_account_alias,
     resolve_google_credentials,
     save_tokens,
 )
@@ -248,9 +251,11 @@ class GCalendarConnector(BaseConnector):
     display_name = "Google Calendar"
     auth_type = "oauth"
 
-    def __init__(self, credentials_path: str = "") -> None:
+    def __init__(self, credentials_path: str = "", account: str = "") -> None:
+        self._account = normalize_account_alias(account)
         self._credentials_path = resolve_google_credentials(
-            credentials_path or _DEFAULT_CREDENTIALS_PATH
+            credentials_path or _DEFAULT_CREDENTIALS_PATH,
+            account=self._account if not credentials_path else "",
         )
         self._items_synced: int = 0
         self._items_total: int = 0
@@ -400,7 +405,9 @@ class GCalendarConnector(BaseConnector):
                             break
 
                     doc = Document(
-                        doc_id=f"gcalendar:{evt_id}",
+                        doc_id=google_account_doc_id(
+                            "gcalendar", evt_id, self._account
+                        ),
                         source="gcalendar",
                         doc_type="event",
                         content=content,
@@ -413,6 +420,7 @@ class GCalendarConnector(BaseConnector):
                             "calendar_id": calendar_id,
                             "event_id": evt_id,
                             "response_status": self_status,
+                            **google_account_metadata("gcalendar", self._account),
                         },
                     )
                     synced += 1
@@ -504,6 +512,14 @@ class GCalendarConnector(BaseConnector):
                             ),
                             "default": "primary",
                         },
+                        "account": {
+                            "type": "string",
+                            "description": (
+                                "Optional Google account alias, e.g. 'personal' "
+                                "or 'work'."
+                            ),
+                            "default": self._account,
+                        },
                     },
                     "required": [],
                 },
@@ -534,6 +550,14 @@ class GCalendarConnector(BaseConnector):
                             ),
                             "default": "primary",
                         },
+                        "account": {
+                            "type": "string",
+                            "description": (
+                                "Optional Google account alias, e.g. 'personal' "
+                                "or 'work'."
+                            ),
+                            "default": self._account,
+                        },
                     },
                     "required": ["query"],
                 },
@@ -554,6 +578,14 @@ class GCalendarConnector(BaseConnector):
                                 "Calendar ID to query. Defaults to 'primary'."
                             ),
                             "default": "primary",
+                        },
+                        "account": {
+                            "type": "string",
+                            "description": (
+                                "Optional Google account alias, e.g. 'personal' "
+                                "or 'work'."
+                            ),
+                            "default": self._account,
                         },
                     },
                     "required": [],

--- a/src/openjarvis/connectors/gcalendar.py
+++ b/src/openjarvis/connectors/gcalendar.py
@@ -20,6 +20,7 @@ from openjarvis.connectors.oauth import (
     delete_tokens,
     google_account_doc_id,
     google_account_metadata,
+    google_account_source_id,
     load_tokens,
     normalize_account_alias,
     resolve_google_credentials,
@@ -413,6 +414,7 @@ class GCalendarConnector(BaseConnector):
                         doc_id=google_account_doc_id(
                             "gcalendar", evt_id, self._account
                         ),
+                        source_id=google_account_source_id(evt_id, self._account),
                         source="gcalendar",
                         doc_type="event",
                         content=content,
@@ -425,7 +427,11 @@ class GCalendarConnector(BaseConnector):
                             "calendar_id": calendar_id,
                             "event_id": evt_id,
                             "response_status": self_status,
-                            **google_account_metadata("gcalendar", self._account),
+                            **google_account_metadata(
+                                "gcalendar",
+                                self._account,
+                                str(tokens.get("source_email", "")),
+                            ),
                         },
                     )
                     synced += 1

--- a/src/openjarvis/connectors/gcontacts.py
+++ b/src/openjarvis/connectors/gcontacts.py
@@ -157,9 +157,14 @@ class GContactsConnector(BaseConnector):
 
     def __init__(self, credentials_path: str = "", account: str = "") -> None:
         self._account = normalize_account_alias(account)
+        self._explicit_credentials_path = bool(credentials_path)
         self._credentials_path = resolve_google_credentials(
             credentials_path or _DEFAULT_CREDENTIALS_PATH,
-            account=self._account if not credentials_path else "",
+            account=self._account,
+            allow_shared_fallback=not self._explicit_credentials_path,
+        )
+        self._mirror_shared_credentials = (
+            not self._explicit_credentials_path and not self._account
         )
         self._items_synced: int = 0
         self._items_total: int = 0

--- a/src/openjarvis/connectors/gcontacts.py
+++ b/src/openjarvis/connectors/gcontacts.py
@@ -18,7 +18,10 @@ from openjarvis.connectors.oauth import (
     GOOGLE_ALL_SCOPES,
     build_google_auth_url,
     delete_tokens,
+    google_account_doc_id,
+    google_account_metadata,
     load_tokens,
+    normalize_account_alias,
     resolve_google_credentials,
     save_tokens,
 )
@@ -152,9 +155,11 @@ class GContactsConnector(BaseConnector):
     display_name = "Google Contacts"
     auth_type = "oauth"
 
-    def __init__(self, credentials_path: str = "") -> None:
+    def __init__(self, credentials_path: str = "", account: str = "") -> None:
+        self._account = normalize_account_alias(account)
         self._credentials_path = resolve_google_credentials(
-            credentials_path or _DEFAULT_CREDENTIALS_PATH
+            credentials_path or _DEFAULT_CREDENTIALS_PATH,
+            account=self._account if not credentials_path else "",
         )
         self._items_synced: int = 0
         self._items_total: int = 0
@@ -269,7 +274,9 @@ class GContactsConnector(BaseConnector):
                 content = _format_contact(person)
 
                 doc = Document(
-                    doc_id=f"gcontacts:{resource_name}",
+                    doc_id=google_account_doc_id(
+                        "gcontacts", resource_name, self._account
+                    ),
                     source="gcontacts",
                     doc_type="contact",
                     content=content,
@@ -277,6 +284,7 @@ class GContactsConnector(BaseConnector):
                     author=primary_email,
                     metadata={
                         "resource_name": resource_name,
+                        **google_account_metadata("gcontacts", self._account),
                     },
                 )
                 synced += 1
@@ -330,6 +338,14 @@ class GContactsConnector(BaseConnector):
                             "description": "Maximum number of contacts to return",
                             "default": 20,
                         },
+                        "account": {
+                            "type": "string",
+                            "description": (
+                                "Optional Google account alias, e.g. 'personal' "
+                                "or 'work'."
+                            ),
+                            "default": self._account,
+                        },
                     },
                     "required": ["query"],
                 },
@@ -351,6 +367,14 @@ class GContactsConnector(BaseConnector):
                                 "Contact resource name (e.g. 'people/c123') "
                                 "or email address"
                             ),
+                        },
+                        "account": {
+                            "type": "string",
+                            "description": (
+                                "Optional Google account alias, e.g. 'personal' "
+                                "or 'work'."
+                            ),
+                            "default": self._account,
                         },
                     },
                     "required": ["identifier"],

--- a/src/openjarvis/connectors/gcontacts.py
+++ b/src/openjarvis/connectors/gcontacts.py
@@ -20,6 +20,7 @@ from openjarvis.connectors.oauth import (
     delete_tokens,
     google_account_doc_id,
     google_account_metadata,
+    google_account_source_id,
     load_tokens,
     normalize_account_alias,
     resolve_google_credentials,
@@ -282,6 +283,10 @@ class GContactsConnector(BaseConnector):
                     doc_id=google_account_doc_id(
                         "gcontacts", resource_name, self._account
                     ),
+                    source_id=google_account_source_id(
+                        resource_name,
+                        self._account,
+                    ),
                     source="gcontacts",
                     doc_type="contact",
                     content=content,
@@ -289,7 +294,11 @@ class GContactsConnector(BaseConnector):
                     author=primary_email,
                     metadata={
                         "resource_name": resource_name,
-                        **google_account_metadata("gcontacts", self._account),
+                        **google_account_metadata(
+                            "gcontacts",
+                            self._account,
+                            str(tokens.get("source_email", "")),
+                        ),
                     },
                 )
                 synced += 1

--- a/src/openjarvis/connectors/gdrive.py
+++ b/src/openjarvis/connectors/gdrive.py
@@ -18,7 +18,10 @@ from openjarvis.connectors.oauth import (
     GOOGLE_ALL_SCOPES,
     build_google_auth_url,
     delete_tokens,
+    google_account_doc_id,
+    google_account_metadata,
     load_tokens,
+    normalize_account_alias,
     resolve_google_credentials,
     save_tokens,
 )
@@ -135,9 +138,11 @@ class GDriveConnector(BaseConnector):
     display_name = "Google Drive"
     auth_type = "oauth"
 
-    def __init__(self, credentials_path: str = "") -> None:
+    def __init__(self, credentials_path: str = "", account: str = "") -> None:
+        self._account = normalize_account_alias(account)
         self._credentials_path = resolve_google_credentials(
-            credentials_path or _DEFAULT_CREDENTIALS_PATH
+            credentials_path or _DEFAULT_CREDENTIALS_PATH,
+            account=self._account if not credentials_path else "",
         )
         self._items_synced: int = 0
         self._items_total: int = 0
@@ -270,7 +275,7 @@ class GDriveConnector(BaseConnector):
                     content = f"[File: {name}] ({mime_type})"
 
                 doc = Document(
-                    doc_id=f"gdrive:{file_id}",
+                    doc_id=google_account_doc_id("gdrive", file_id, self._account),
                     source="gdrive",
                     doc_type="document",
                     content=content,
@@ -280,6 +285,7 @@ class GDriveConnector(BaseConnector):
                     metadata={
                         "file_id": file_id,
                         "mime_type": mime_type,
+                        **google_account_metadata("gdrive", self._account),
                     },
                 )
                 synced += 1
@@ -330,6 +336,14 @@ class GDriveConnector(BaseConnector):
                             "description": "Maximum number of files to return",
                             "default": 20,
                         },
+                        "account": {
+                            "type": "string",
+                            "description": (
+                                "Optional Google account alias, e.g. 'personal' "
+                                "or 'work'."
+                            ),
+                            "default": self._account,
+                        },
                     },
                     "required": ["query"],
                 },
@@ -347,6 +361,14 @@ class GDriveConnector(BaseConnector):
                         "file_id": {
                             "type": "string",
                             "description": "Google Drive file ID",
+                        },
+                        "account": {
+                            "type": "string",
+                            "description": (
+                                "Optional Google account alias, e.g. 'personal' "
+                                "or 'work'."
+                            ),
+                            "default": self._account,
                         },
                     },
                     "required": ["file_id"],
@@ -374,6 +396,14 @@ class GDriveConnector(BaseConnector):
                             "type": "integer",
                             "description": "Maximum number of files to return",
                             "default": 20,
+                        },
+                        "account": {
+                            "type": "string",
+                            "description": (
+                                "Optional Google account alias, e.g. 'personal' "
+                                "or 'work'."
+                            ),
+                            "default": self._account,
                         },
                     },
                     "required": [],

--- a/src/openjarvis/connectors/gdrive.py
+++ b/src/openjarvis/connectors/gdrive.py
@@ -140,9 +140,14 @@ class GDriveConnector(BaseConnector):
 
     def __init__(self, credentials_path: str = "", account: str = "") -> None:
         self._account = normalize_account_alias(account)
+        self._explicit_credentials_path = bool(credentials_path)
         self._credentials_path = resolve_google_credentials(
             credentials_path or _DEFAULT_CREDENTIALS_PATH,
-            account=self._account if not credentials_path else "",
+            account=self._account,
+            allow_shared_fallback=not self._explicit_credentials_path,
+        )
+        self._mirror_shared_credentials = (
+            not self._explicit_credentials_path and not self._account
         )
         self._items_synced: int = 0
         self._items_total: int = 0

--- a/src/openjarvis/connectors/gdrive.py
+++ b/src/openjarvis/connectors/gdrive.py
@@ -20,6 +20,7 @@ from openjarvis.connectors.oauth import (
     delete_tokens,
     google_account_doc_id,
     google_account_metadata,
+    google_account_source_id,
     load_tokens,
     normalize_account_alias,
     resolve_google_credentials,
@@ -281,6 +282,7 @@ class GDriveConnector(BaseConnector):
 
                 doc = Document(
                     doc_id=google_account_doc_id("gdrive", file_id, self._account),
+                    source_id=google_account_source_id(file_id, self._account),
                     source="gdrive",
                     doc_type="document",
                     content=content,
@@ -290,7 +292,11 @@ class GDriveConnector(BaseConnector):
                     metadata={
                         "file_id": file_id,
                         "mime_type": mime_type,
-                        **google_account_metadata("gdrive", self._account),
+                        **google_account_metadata(
+                            "gdrive",
+                            self._account,
+                            str(tokens.get("source_email", "")),
+                        ),
                     },
                 )
                 synced += 1

--- a/src/openjarvis/connectors/gmail.py
+++ b/src/openjarvis/connectors/gmail.py
@@ -353,9 +353,14 @@ class GmailConnector(BaseConnector):
 
     def __init__(self, credentials_path: str = "", account: str = "") -> None:
         self._account = normalize_account_alias(account)
+        self._explicit_credentials_path = bool(credentials_path)
         self._credentials_path = resolve_google_credentials(
             credentials_path or _DEFAULT_CREDENTIALS_PATH,
-            account=self._account if not credentials_path else "",
+            account=self._account,
+            allow_shared_fallback=not self._explicit_credentials_path,
+        )
+        self._mirror_shared_credentials = (
+            not self._explicit_credentials_path and not self._account
         )
         self._items_synced: int = 0
         self._items_total: int = 0

--- a/src/openjarvis/connectors/gmail.py
+++ b/src/openjarvis/connectors/gmail.py
@@ -28,7 +28,11 @@ from openjarvis.connectors.oauth import (
     GOOGLE_ALL_SCOPES,
     build_google_auth_url,
     delete_tokens,
+    google_account_doc_id,
+    google_account_metadata,
+    google_account_source_id,
     load_tokens,
+    normalize_account_alias,
     refresh_google_token,
     resolve_google_credentials,
     save_tokens,
@@ -347,9 +351,11 @@ class GmailConnector(BaseConnector):
     display_name = "Gmail"
     auth_type = "oauth"
 
-    def __init__(self, credentials_path: str = "") -> None:
+    def __init__(self, credentials_path: str = "", account: str = "") -> None:
+        self._account = normalize_account_alias(account)
         self._credentials_path = resolve_google_credentials(
-            credentials_path or _DEFAULT_CREDENTIALS_PATH
+            credentials_path or _DEFAULT_CREDENTIALS_PATH,
+            account=self._account if not credentials_path else "",
         )
         self._items_synced: int = 0
         self._items_total: int = 0
@@ -485,9 +491,9 @@ class GmailConnector(BaseConnector):
                 thread_id: Optional[str] = msg.get("threadId")
 
                 doc = Document(
-                    doc_id=f"gmail:{msg_id}",
+                    doc_id=google_account_doc_id("gmail", msg_id, self._account),
                     source="gmail",
-                    source_id=msg_id,
+                    source_id=google_account_source_id(msg_id, self._account),
                     doc_type="email",
                     content=body,
                     title=subject,
@@ -509,6 +515,7 @@ class GmailConnector(BaseConnector):
                         "snippet": msg.get("snippet", ""),
                         "history_id": msg.get("historyId", ""),
                         "size_estimate": msg.get("sizeEstimate", 0),
+                        **google_account_metadata("gmail", self._account),
                     },
                 )
                 synced += 1
@@ -607,6 +614,14 @@ class GmailConnector(BaseConnector):
                             "description": "Maximum number of emails to return",
                             "default": 20,
                         },
+                        "account": {
+                            "type": "string",
+                            "description": (
+                                "Optional Google account alias, e.g. 'personal' "
+                                "or 'work'."
+                            ),
+                            "default": self._account,
+                        },
                     },
                     "required": ["query"],
                 },
@@ -621,6 +636,14 @@ class GmailConnector(BaseConnector):
                         "thread_id": {
                             "type": "string",
                             "description": "Gmail thread ID",
+                        },
+                        "account": {
+                            "type": "string",
+                            "description": (
+                                "Optional Google account alias, e.g. 'personal' "
+                                "or 'work'."
+                            ),
+                            "default": self._account,
                         },
                     },
                     "required": ["thread_id"],
@@ -644,6 +667,14 @@ class GmailConnector(BaseConnector):
                             "type": "integer",
                             "description": "Maximum number of messages to return",
                             "default": 20,
+                        },
+                        "account": {
+                            "type": "string",
+                            "description": (
+                                "Optional Google account alias, e.g. 'personal' "
+                                "or 'work'."
+                            ),
+                            "default": self._account,
                         },
                     },
                     "required": [],

--- a/src/openjarvis/connectors/gmail.py
+++ b/src/openjarvis/connectors/gmail.py
@@ -14,6 +14,7 @@ import re
 from datetime import datetime
 from html.parser import HTMLParser
 from typing import Any, Dict, Iterator, List, Optional, Tuple
+from urllib.parse import quote
 
 import httpx
 
@@ -50,6 +51,22 @@ logger = logging.getLogger(__name__)
 _GMAIL_API_BASE = "https://gmail.googleapis.com/gmail/v1/users/me"
 _GMAIL_SCOPE = "https://www.googleapis.com/auth/gmail.readonly"
 _DEFAULT_CREDENTIALS_PATH = str(DEFAULT_CONFIG_DIR / "connectors" / "gmail.json")
+
+
+def _gmail_message_url(msg_id: str, account: str, source_email: str) -> str:
+    """Build a browser link that cannot silently select the wrong profile."""
+    if not account:
+        return f"https://mail.google.com/mail/u/0/#all/{msg_id}"
+    if not source_email.strip():
+        # A numeric /u/N slot is browser-session-specific and can open a
+        # different identity.  Omit the link until Google supplied an email
+        # provenance claim for this named profile.
+        return ""
+    return (
+        "https://mail.google.com/mail/?authuser="
+        f"{quote(source_email.strip(), safe='')}#all/{msg_id}"
+    )
+
 
 # Token refresh is delegated to the shared google_auth helper so Calendar,
 # Contacts, Drive, and Tasks get the same one-shot 401 retry. ``GmailAuthError``
@@ -512,7 +529,11 @@ class GmailConnector(BaseConnector):
                     # internal hex id, which the ``#all/<id>`` permalink
                     # resolves directly — so citations have a working URL
                     # without relying on _hit_url reconstruction at query time.
-                    url=f"https://mail.google.com/mail/u/0/#all/{msg_id}",
+                    url=_gmail_message_url(
+                        msg_id,
+                        self._account,
+                        str(tokens.get("source_email", "")),
+                    ),
                     metadata={
                         "message_id": msg_id,
                         "rfc_message_id": rfc_message_id,

--- a/src/openjarvis/connectors/gmail.py
+++ b/src/openjarvis/connectors/gmail.py
@@ -520,7 +520,11 @@ class GmailConnector(BaseConnector):
                         "snippet": msg.get("snippet", ""),
                         "history_id": msg.get("historyId", ""),
                         "size_estimate": msg.get("sizeEstimate", 0),
-                        **google_account_metadata("gmail", self._account),
+                        **google_account_metadata(
+                            "gmail",
+                            self._account,
+                            str(tokens.get("source_email", "")),
+                        ),
                     },
                 )
                 synced += 1

--- a/src/openjarvis/connectors/google_tasks.py
+++ b/src/openjarvis/connectors/google_tasks.py
@@ -13,7 +13,13 @@ import httpx
 
 from openjarvis.connectors._stubs import BaseConnector, Document, SyncStatus
 from openjarvis.connectors.google_auth import call_with_refresh
-from openjarvis.connectors.oauth import load_tokens, resolve_google_credentials
+from openjarvis.connectors.oauth import (
+    google_account_doc_id,
+    google_account_metadata,
+    load_tokens,
+    normalize_account_alias,
+    resolve_google_credentials,
+)
 from openjarvis.core.config import DEFAULT_CONFIG_DIR
 from openjarvis.core.registry import ConnectorRegistry
 
@@ -43,9 +49,13 @@ class GoogleTasksConnector(BaseConnector):
     display_name = "Google Tasks"
     auth_type = "oauth"
 
-    def __init__(self, *, credentials_path: str = "") -> None:
+    def __init__(self, *, credentials_path: str = "", account: str = "") -> None:
+        self._account = normalize_account_alias(account)
         self._credentials_path = Path(
-            resolve_google_credentials(credentials_path or _DEFAULT_CREDENTIALS_PATH)
+            resolve_google_credentials(
+                credentials_path or _DEFAULT_CREDENTIALS_PATH,
+                account=self._account if not credentials_path else "",
+            )
         )
         self._status = SyncStatus()
 
@@ -108,7 +118,9 @@ class GoogleTasksConnector(BaseConnector):
                 )
 
                 yield Document(
-                    doc_id=f"gtasks-{task['id']}",
+                    doc_id=google_account_doc_id(
+                        "google_tasks", task["id"], self._account
+                    ),
                     source="google_tasks",
                     doc_type="task",
                     content=task.get("notes", ""),
@@ -120,6 +132,7 @@ class GoogleTasksConnector(BaseConnector):
                         "status": status,
                         "due": due,
                         "completed": task.get("completed", ""),
+                        **google_account_metadata("google_tasks", self._account),
                     },
                 )
 

--- a/src/openjarvis/connectors/google_tasks.py
+++ b/src/openjarvis/connectors/google_tasks.py
@@ -51,11 +51,16 @@ class GoogleTasksConnector(BaseConnector):
 
     def __init__(self, *, credentials_path: str = "", account: str = "") -> None:
         self._account = normalize_account_alias(account)
+        self._explicit_credentials_path = bool(credentials_path)
         self._credentials_path = Path(
             resolve_google_credentials(
                 credentials_path or _DEFAULT_CREDENTIALS_PATH,
-                account=self._account if not credentials_path else "",
+                account=self._account,
+                allow_shared_fallback=not self._explicit_credentials_path,
             )
+        )
+        self._mirror_shared_credentials = (
+            not self._explicit_credentials_path and not self._account
         )
         self._status = SyncStatus()
 

--- a/src/openjarvis/connectors/google_tasks.py
+++ b/src/openjarvis/connectors/google_tasks.py
@@ -16,6 +16,7 @@ from openjarvis.connectors.google_auth import call_with_refresh
 from openjarvis.connectors.oauth import (
     google_account_doc_id,
     google_account_metadata,
+    google_account_source_id,
     load_tokens,
     normalize_account_alias,
     resolve_google_credentials,
@@ -86,6 +87,7 @@ class GoogleTasksConnector(BaseConnector):
     def sync(
         self, *, since: Optional[datetime] = None, cursor: Optional[str] = None
     ) -> Iterator[Document]:
+        tokens = load_tokens(str(self._credentials_path)) or {}
         # call_with_refresh handles the access-token read + one-shot 401 retry.
         task_lists = call_with_refresh(
             _tasks_api_get, str(self._credentials_path), "users/@me/lists"
@@ -126,6 +128,10 @@ class GoogleTasksConnector(BaseConnector):
                     doc_id=google_account_doc_id(
                         "google_tasks", task["id"], self._account
                     ),
+                    source_id=google_account_source_id(
+                        task["id"],
+                        self._account,
+                    ),
                     source="google_tasks",
                     doc_type="task",
                     content=task.get("notes", ""),
@@ -137,7 +143,11 @@ class GoogleTasksConnector(BaseConnector):
                         "status": status,
                         "due": due,
                         "completed": task.get("completed", ""),
-                        **google_account_metadata("google_tasks", self._account),
+                        **google_account_metadata(
+                            "google_tasks",
+                            self._account,
+                            str(tokens.get("source_email", "")),
+                        ),
                     },
                 )
 

--- a/src/openjarvis/connectors/hybrid_search.py
+++ b/src/openjarvis/connectors/hybrid_search.py
@@ -404,11 +404,14 @@ class HybridSearch:
             clauses.append("(" + " OR ".join(source_clauses) + ")")
 
         if accounts:
-            placeholders = ",".join("?" for _ in accounts)
-            clauses.append(
-                f"json_extract({prefix}metadata, '$.account') IN ({placeholders})"
+            from openjarvis.connectors.store import google_account_scope_sql
+
+            account_clause, account_params = google_account_scope_sql(
+                accounts,
+                alias=alias,
             )
-            params.extend(accounts)
+            clauses.append(account_clause)
+            params.extend(account_params)
 
         return " AND ".join(clauses), params
 

--- a/src/openjarvis/connectors/hybrid_search.py
+++ b/src/openjarvis/connectors/hybrid_search.py
@@ -116,6 +116,7 @@ class SearchHit:
     thread_context: List[Dict[str, Any]] = field(default_factory=list)
     account: str = ""
     source_profile: str = ""
+    source_email: str = ""
     # ``url`` is the connector-provided deep-link, persisted on
     # ``knowledge_chunks.url``. Empty when the source didn't supply one — in
     # that case callers may fall back to a doc_id-based reconstruction (Slack,
@@ -136,6 +137,7 @@ class SearchHit:
             "thread_context": self.thread_context,
             "account": self.account,
             "source_profile": self.source_profile,
+            "source_email": self.source_email,
         }
 
 
@@ -838,6 +840,7 @@ class HybridSearch:
                     ),
                     account=str(metadata.get("account", "") or ""),
                     source_profile=str(metadata.get("source_profile", "") or ""),
+                    source_email=str(metadata.get("source_email", "") or ""),
                     url=r["url"] or "",
                 )
             )

--- a/src/openjarvis/connectors/hybrid_search.py
+++ b/src/openjarvis/connectors/hybrid_search.py
@@ -403,7 +403,7 @@ class HybridSearch:
                 params.extend([source, account])
             clauses.append("(" + " OR ".join(source_clauses) + ")")
 
-        if accounts:
+        if accounts is not None:
             from openjarvis.connectors.store import google_account_scope_sql
 
             account_clause, account_params = google_account_scope_sql(

--- a/src/openjarvis/connectors/hybrid_search.py
+++ b/src/openjarvis/connectors/hybrid_search.py
@@ -114,6 +114,8 @@ class SearchHit:
     vector_score: float
     thread_id: str = ""
     thread_context: List[Dict[str, Any]] = field(default_factory=list)
+    account: str = ""
+    source_profile: str = ""
     # ``url`` is the connector-provided deep-link, persisted on
     # ``knowledge_chunks.url``. Empty when the source didn't supply one — in
     # that case callers may fall back to a doc_id-based reconstruction (Slack,
@@ -132,6 +134,8 @@ class SearchHit:
             "chunk_idx": self.chunk_idx,
             "thread_id": self.thread_id,
             "thread_context": self.thread_context,
+            "account": self.account,
+            "source_profile": self.source_profile,
         }
 
 
@@ -173,6 +177,22 @@ def _parse_participants(raw: Any) -> List[str]:
         return []
 
 
+def _split_source_accounts(
+    sources: Optional[Sequence[str]],
+) -> Tuple[List[str], List[Tuple[str, str]]]:
+    """Split source filters into plain sources and ``source:account`` pairs."""
+    plain: List[str] = []
+    scoped: List[Tuple[str, str]] = []
+    for source in sources or []:
+        if ":" in source:
+            base, account = source.split(":", 1)
+            if base and account:
+                scoped.append((base, account))
+                continue
+        plain.append(source)
+    return plain, scoped
+
+
 def _snippet(content: str, max_chars: int = 500) -> str:
     flat = content.strip()
     if len(flat) <= max_chars:
@@ -185,7 +205,10 @@ def _query_tokens(query: str) -> set[str]:
 
 
 def _sources_include_gcalendar(sources: Optional[Sequence[str]]) -> bool:
-    return any(str(source).lower() == "gcalendar" for source in sources or [])
+    return any(
+        str(source).lower().split(":", 1)[0] == "gcalendar"
+        for source in sources or []
+    )
 
 
 def _has_upcoming_calendar_intent(
@@ -330,6 +353,7 @@ class HybridSearch:
         person: Optional[str],
         time_range: Optional[Tuple[Optional[datetime], Optional[datetime]]],
         sources: Optional[Sequence[str]],
+        accounts: Optional[Sequence[str]],
         alias: str = "",
     ) -> Tuple[str, List[Any]]:
         """Return ``(where_fragment, params)`` for the structured filters.
@@ -364,9 +388,26 @@ class HybridSearch:
                 params.append(_iso(end))
 
         if sources:
-            placeholders = ",".join("?" for _ in sources)
-            clauses.append(f"{prefix}source IN ({placeholders})")
-            params.extend(sources)
+            plain_sources, scoped_sources = _split_source_accounts(sources)
+            source_clauses: List[str] = []
+            if plain_sources:
+                placeholders = ",".join("?" for _ in plain_sources)
+                source_clauses.append(f"{prefix}source IN ({placeholders})")
+                params.extend(plain_sources)
+            for source, account in scoped_sources:
+                source_clauses.append(
+                    f"({prefix}source = ? AND "
+                    f"json_extract({prefix}metadata, '$.account') = ?)"
+                )
+                params.extend([source, account])
+            clauses.append("(" + " OR ".join(source_clauses) + ")")
+
+        if accounts:
+            placeholders = ",".join("?" for _ in accounts)
+            clauses.append(
+                f"json_extract({prefix}metadata, '$.account') IN ({placeholders})"
+            )
+            params.extend(accounts)
 
         return " AND ".join(clauses), params
 
@@ -552,10 +593,14 @@ class HybridSearch:
         scoped_sources = list(sources) if sources else None
         has_upcoming_intent = _has_upcoming_calendar_intent(query, scoped_sources)
 
-        if has_upcoming_intent and (
-            scoped_sources is None or _sources_include_gcalendar(scoped_sources)
-        ):
+        if has_upcoming_intent and scoped_sources is None:
             scoped_sources = ["gcalendar"]
+        elif has_upcoming_intent and _sources_include_gcalendar(scoped_sources):
+            scoped_sources = [
+                source
+                for source in scoped_sources or []
+                if str(source).lower().split(":", 1)[0] == "gcalendar"
+            ]
 
         if not _sources_include_gcalendar(scoped_sources):
             return time_range, scoped_sources, False, False
@@ -584,6 +629,7 @@ class HybridSearch:
         person: Optional[str],
         time_range: Optional[Tuple[Optional[datetime], Optional[datetime]]],
         sources: Optional[Sequence[str]],
+        accounts: Optional[Sequence[str]],
         limit: int,
     ) -> List[str]:
         """Return gcalendar rows sorted by normalized event start time."""
@@ -591,6 +637,7 @@ class HybridSearch:
             person=person,
             time_range=None,
             sources=sources,
+            accounts=accounts,
         )
         rows = self._store._conn.execute(
             f"""
@@ -664,6 +711,7 @@ class HybridSearch:
         person: Optional[str] = None,
         time_range: Optional[Tuple[Optional[datetime], Optional[datetime]]] = None,
         sources: Optional[Sequence[str]] = None,
+        accounts: Optional[Sequence[str]] = None,
         limit: int = 20,
     ) -> List[SearchHit]:
         """Run the hybrid pipeline and return up to ``limit`` hits.
@@ -683,10 +731,17 @@ class HybridSearch:
         recall_time_range = None if calendar_timeline else time_range
 
         bm25_filter_sql, bm25_filter_params = self._build_filters(
-            person=person, time_range=recall_time_range, sources=sources, alias="kc"
+            person=person,
+            time_range=recall_time_range,
+            sources=sources,
+            accounts=accounts,
+            alias="kc",
         )
         unaliased_filter_sql, unaliased_filter_params = self._build_filters(
-            person=person, time_range=recall_time_range, sources=sources
+            person=person,
+            time_range=recall_time_range,
+            sources=sources,
+            accounts=accounts,
         )
 
         bm25 = (
@@ -717,6 +772,7 @@ class HybridSearch:
                     person=person,
                     time_range=time_range,
                     sources=sources,
+                    accounts=accounts,
                     limit=limit,
                 )
                 fused = [(chunk_id, 0.0, 0.0, 0.0) for chunk_id in chunk_ids]
@@ -741,7 +797,7 @@ class HybridSearch:
         meta_rows = self._store._conn.execute(
             f"""
             SELECT id, doc_id, content, source, title, author, participants,
-                   timestamp, thread_id, chunk_index, url
+                   timestamp, thread_id, chunk_index, url, metadata
             FROM knowledge_chunks
             WHERE id IN ({placeholders})
             """,
@@ -754,6 +810,7 @@ class HybridSearch:
             r = by_id.get(chunk_id)
             if r is None:
                 continue
+            metadata = json.loads(r["metadata"]) if r["metadata"] else {}
             hits.append(
                 SearchHit(
                     chunk_id=chunk_id,
@@ -769,6 +826,8 @@ class HybridSearch:
                     vector_score=vec_score,
                     thread_id=r["thread_id"] or "",
                     thread_context=self._thread_context(r["thread_id"] or "", chunk_id),
+                    account=str(metadata.get("account", "") or ""),
+                    source_profile=str(metadata.get("source_profile", "") or ""),
                     url=r["url"] or "",
                 )
             )

--- a/src/openjarvis/connectors/hybrid_search.py
+++ b/src/openjarvis/connectors/hybrid_search.py
@@ -206,8 +206,7 @@ def _query_tokens(query: str) -> set[str]:
 
 def _sources_include_gcalendar(sources: Optional[Sequence[str]]) -> bool:
     return any(
-        str(source).lower().split(":", 1)[0] == "gcalendar"
-        for source in sources or []
+        str(source).lower().split(":", 1)[0] == "gcalendar" for source in sources or []
     )
 
 
@@ -532,7 +531,11 @@ class HybridSearch:
     # ------------------------------------------------------------------
 
     def _thread_context(
-        self, thread_id: str, anchor_chunk_id: str
+        self,
+        thread_id: str,
+        anchor_chunk_id: str,
+        source: str,
+        account: str,
     ) -> List[Dict[str, Any]]:
         """Fetch sibling chunks for ``thread_id`` (capped at ``thread_context_cap``).
 
@@ -545,10 +548,13 @@ class HybridSearch:
             """
             SELECT id, chunk_index, content, timestamp, author
             FROM knowledge_chunks
-            WHERE thread_id = ? AND deleted_at IS NULL
+            WHERE thread_id = ?
+              AND source = ?
+              AND COALESCE(json_extract(metadata, '$.account'), '') = ?
+              AND deleted_at IS NULL
             ORDER BY timestamp ASC, chunk_index ASC
             """,
-            (thread_id,),
+            (thread_id, source, account),
         ).fetchall()
         if not rows:
             return []
@@ -824,7 +830,12 @@ class HybridSearch:
                     bm25_score=bm25_score,
                     vector_score=vec_score,
                     thread_id=r["thread_id"] or "",
-                    thread_context=self._thread_context(r["thread_id"] or "", chunk_id),
+                    thread_context=self._thread_context(
+                        r["thread_id"] or "",
+                        chunk_id,
+                        r["source"] or "",
+                        str(metadata.get("account", "") or ""),
+                    ),
                     account=str(metadata.get("account", "") or ""),
                     source_profile=str(metadata.get("source_profile", "") or ""),
                     url=r["url"] or "",

--- a/src/openjarvis/connectors/hybrid_search.py
+++ b/src/openjarvis/connectors/hybrid_search.py
@@ -762,12 +762,11 @@ class HybridSearch:
         if calendar_timeline:
             fused = self._filter_calendar_timeline_fused(fused, time_range)
 
-        # Metadata-only fallback: empty query, or both legs produced nothing
-        # despite a non-empty query. Calendar timeline requests use start-time
-        # ascending; other searches use recency so the agent still gets a
-        # useful corpus snapshot.
+        # Metadata-only fallback is allowed only for genuinely structured
+        # searches. A non-empty lexical query with no hit must remain empty;
+        # returning unrelated recent rows would violate source/account scope.
         if not fused:
-            if calendar_timeline:
+            if calendar_timeline and metadata_only:
                 chunk_ids = self._calendar_timeline_ids(
                     person=person,
                     time_range=time_range,
@@ -776,7 +775,7 @@ class HybridSearch:
                     limit=limit,
                 )
                 fused = [(chunk_id, 0.0, 0.0, 0.0) for chunk_id in chunk_ids]
-            else:
+            elif not query.strip():
                 sql = f"""
                     SELECT id FROM knowledge_chunks
                     WHERE {unaliased_filter_sql}

--- a/src/openjarvis/connectors/oauth.py
+++ b/src/openjarvis/connectors/oauth.py
@@ -325,13 +325,16 @@ def resolve_google_credentials(
 ) -> str:
     """Return the best available Google credentials file path.
 
-    With *account*, returns the segmented account credential file path under
-    ``google/accounts/{alias}.json``. Without an account, checks the
-    connector-specific file first, then optionally falls back to the shared
-    ``google.json`` when ``allow_shared_fallback`` is true. Returns
-    *connector_path* if neither exists (so ``is_connected()`` correctly
-    returns ``False``).
+    When ``allow_shared_fallback`` is false, *connector_path* is treated as an
+    explicit caller-supplied path and always wins, even if an account alias is
+    also supplied. Otherwise, named accounts resolve to the segmented account
+    path under ``google/accounts/{alias}.json``. Default connectors check their
+    connector-specific file first, then optionally fall back to shared
+    ``google.json``.
     """
+    if not allow_shared_fallback:
+        return connector_path
+
     alias = normalize_account_alias(account)
     if alias:
         return google_account_credentials_path(alias)

--- a/src/openjarvis/connectors/oauth.py
+++ b/src/openjarvis/connectors/oauth.py
@@ -184,7 +184,8 @@ def list_google_accounts() -> List[Dict[str, Any]]:
         from openjarvis.core.config import load_config
 
         for raw_alias, profile in load_config().connectors.google.accounts.items():
-            configured[normalize_account_alias(raw_alias)] = profile.enabled
+            alias = normalize_account_alias(raw_alias)
+            configured[alias] = configured.get(alias, True) and profile.enabled
     except (OSError, ValueError):
         configured = {}
 

--- a/src/openjarvis/connectors/oauth.py
+++ b/src/openjarvis/connectors/oauth.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import base64
 import json
 import os
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -24,6 +25,9 @@ from openjarvis.core.config import DEFAULT_CONFIG_DIR
 # ---------------------------------------------------------------------------
 
 _CONNECTORS_DIR = DEFAULT_CONFIG_DIR / "connectors"
+_GOOGLE_ACCOUNT_PROVIDER = "google"
+_GOOGLE_ACCOUNTS_DIR = _CONNECTORS_DIR / _GOOGLE_ACCOUNT_PROVIDER / "accounts"
+_ACCOUNT_ALIAS_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}$")
 
 # ---------------------------------------------------------------------------
 # OAuth provider registry
@@ -129,6 +133,82 @@ def get_provider_for_connector(connector_id: str) -> Optional[OAuthProvider]:
     return None
 
 
+def normalize_account_alias(account: str = "") -> str:
+    """Validate and normalise a connector account/profile alias.
+
+    Empty means "legacy/default credentials". Named aliases are intentionally
+    restricted to a small filesystem-safe slug format because they become JSON
+    filenames under ``~/.openjarvis/connectors/google/accounts``.
+    """
+    alias = account.strip()
+    if not alias:
+        return ""
+    if not _ACCOUNT_ALIAS_RE.fullmatch(alias):
+        raise ValueError(
+            "Account aliases must be 1-64 characters and contain only letters, "
+            "numbers, dots, underscores, or hyphens."
+        )
+    return alias
+
+
+def google_account_credentials_path(account: str) -> str:
+    """Return the credential file path for a named Google account alias."""
+    alias = normalize_account_alias(account)
+    if not alias:
+        raise ValueError("A non-empty Google account alias is required.")
+    return str(_GOOGLE_ACCOUNTS_DIR / f"{alias}.json")
+
+
+def google_account_metadata(connector_id: str, account: str = "") -> Dict[str, str]:
+    """Return provenance metadata for a named connector account."""
+    alias = normalize_account_alias(account)
+    if not alias:
+        return {"connector": connector_id}
+    return {
+        "account": alias,
+        "source_profile": alias,
+        "connector": connector_id,
+        "connector_instance": f"{connector_id}:{alias}",
+    }
+
+
+def google_account_doc_id(connector_id: str, native_id: str, account: str = "") -> str:
+    """Build a collision-safe document ID for optional Google account aliases."""
+    alias = normalize_account_alias(account)
+    if alias:
+        return f"{connector_id}:{alias}:{native_id}"
+    return f"{connector_id}:{native_id}"
+
+
+def google_account_source_id(native_id: str, account: str = "") -> str:
+    """Build a collision-safe source_id while preserving legacy default IDs."""
+    alias = normalize_account_alias(account)
+    if alias:
+        return f"{alias}:{native_id}"
+    return native_id
+
+
+def _credential_paths_for_provider(
+    provider: OAuthProvider,
+    *,
+    account: str = "",
+) -> Tuple[Path, ...]:
+    """Return credential paths for a provider/account combination."""
+    alias = normalize_account_alias(account)
+    if provider.name == _GOOGLE_ACCOUNT_PROVIDER and alias:
+        return (Path(google_account_credentials_path(alias)),)
+    return tuple(_CONNECTORS_DIR / filename for filename in provider.credential_files)
+
+
+def _is_google_account_credentials_path(path: str) -> bool:
+    """Return True when *path* points under the named Google accounts dir."""
+    try:
+        Path(path).resolve().relative_to(_GOOGLE_ACCOUNTS_DIR.resolve())
+        return True
+    except ValueError:
+        return False
+
+
 # ---------------------------------------------------------------------------
 # Credential helpers
 # ---------------------------------------------------------------------------
@@ -136,6 +216,8 @@ def get_provider_for_connector(connector_id: str) -> Optional[OAuthProvider]:
 
 def get_client_credentials(
     provider: OAuthProvider,
+    *,
+    account: str = "",
 ) -> Optional[Tuple[str, str]]:
     """Load stored client_id and client_secret for *provider*.
 
@@ -143,12 +225,19 @@ def get_client_credentials(
     back to environment variables ``OPENJARVIS_{NAME}_CLIENT_ID`` and
     ``OPENJARVIS_{NAME}_CLIENT_SECRET``.
     """
-    # Check credential files
-    for filename in provider.credential_files:
-        path = _CONNECTORS_DIR / filename
+    # Check credential files. For named Google accounts, prefer the alias file
+    # but fall back to legacy provider files below so users do not need to
+    # re-enter OAuth client credentials for every account.
+    for path in _credential_paths_for_provider(provider, account=account):
         tokens = load_tokens(str(path))
         if tokens and tokens.get("client_id") and tokens.get("client_secret"):
             return tokens["client_id"], tokens["client_secret"]
+
+    if provider.name == _GOOGLE_ACCOUNT_PROVIDER and normalize_account_alias(account):
+        for path in _credential_paths_for_provider(provider):
+            tokens = load_tokens(str(path))
+            if tokens and tokens.get("client_id") and tokens.get("client_secret"):
+                return tokens["client_id"], tokens["client_secret"]
 
     # Check environment variables
     prefix = f"OPENJARVIS_{provider.name.upper()}"
@@ -164,10 +253,11 @@ def save_client_credentials(
     provider: OAuthProvider,
     client_id: str,
     client_secret: str,
+    *,
+    account: str = "",
 ) -> None:
     """Persist client credentials so the user never has to enter them again."""
-    for filename in provider.credential_files:
-        path = _CONNECTORS_DIR / filename
+    for path in _credential_paths_for_provider(provider, account=account):
         existing = load_tokens(str(path)) or {}
         existing["client_id"] = client_id
         existing["client_secret"] = client_secret
@@ -227,13 +317,18 @@ def build_google_auth_url(
     return f"{_GOOGLE_AUTH_ENDPOINT}?{urlencode(params)}"
 
 
-def resolve_google_credentials(connector_path: str) -> str:
+def resolve_google_credentials(connector_path: str, *, account: str = "") -> str:
     """Return the best available Google credentials file path.
 
-    Checks the connector-specific file first, then falls back to the
-    shared ``google.json``.  Returns *connector_path* if neither exists
-    (so ``is_connected()`` correctly returns ``False``).
+    With *account*, returns the segmented account credential file path under
+    ``google/accounts/{alias}.json``. Without an account, checks the
+    connector-specific file first, then falls back to the shared
+    ``google.json``. Returns *connector_path* if neither exists (so
+    ``is_connected()`` correctly returns ``False``).
     """
+    alias = normalize_account_alias(account)
+    if alias:
+        return google_account_credentials_path(alias)
     if Path(connector_path).exists():
         return connector_path
     if Path(_SHARED_GOOGLE_CREDENTIALS_PATH).exists():
@@ -540,9 +635,14 @@ def run_oauth_flow(
     }
     save_tokens(credentials_path, token_payload)
 
-    # Also save to the shared Google credentials file so that all Google
-    # connectors can use this token without a separate OAuth flow.
-    if credentials_path != _SHARED_GOOGLE_CREDENTIALS_PATH:
+    # Also save to the shared Google credentials file for the legacy flow so
+    # all Google connectors can use this token without a separate OAuth flow.
+    # Named account aliases must stay segmented and must not overwrite the
+    # default credentials.
+    if (
+        credentials_path != _SHARED_GOOGLE_CREDENTIALS_PATH
+        and not _is_google_account_credentials_path(credentials_path)
+    ):
         save_tokens(_SHARED_GOOGLE_CREDENTIALS_PATH, token_payload)
 
     return tokens
@@ -667,6 +767,8 @@ def run_connector_oauth(
     connector_id: str,
     client_id: str = "",
     client_secret: str = "",
+    *,
+    account: str = "",
 ) -> Dict[str, Any]:
     """Run a complete OAuth flow for *connector_id*.
 
@@ -686,7 +788,7 @@ def run_connector_oauth(
 
     # Resolve credentials
     if not (client_id and client_secret):
-        creds = get_client_credentials(provider)
+        creds = get_client_credentials(provider, account=account)
         if creds:
             client_id, client_secret = creds
     if not (client_id and client_secret):
@@ -732,8 +834,9 @@ def run_connector_oauth(
         "client_secret": client_secret,
     }
 
-    # Save to all credential files for this provider
-    for filename in provider.credential_files:
-        save_tokens(str(_CONNECTORS_DIR / filename), payload)
+    # Save to the legacy provider files, or to one segmented account file when
+    # a named Google alias is supplied.
+    for path in _credential_paths_for_provider(provider, account=account):
+        save_tokens(str(path), payload)
 
     return tokens

--- a/src/openjarvis/connectors/oauth.py
+++ b/src/openjarvis/connectors/oauth.py
@@ -317,21 +317,27 @@ def build_google_auth_url(
     return f"{_GOOGLE_AUTH_ENDPOINT}?{urlencode(params)}"
 
 
-def resolve_google_credentials(connector_path: str, *, account: str = "") -> str:
+def resolve_google_credentials(
+    connector_path: str,
+    *,
+    account: str = "",
+    allow_shared_fallback: bool = True,
+) -> str:
     """Return the best available Google credentials file path.
 
     With *account*, returns the segmented account credential file path under
     ``google/accounts/{alias}.json``. Without an account, checks the
-    connector-specific file first, then falls back to the shared
-    ``google.json``. Returns *connector_path* if neither exists (so
-    ``is_connected()`` correctly returns ``False``).
+    connector-specific file first, then optionally falls back to the shared
+    ``google.json`` when ``allow_shared_fallback`` is true. Returns
+    *connector_path* if neither exists (so ``is_connected()`` correctly
+    returns ``False``).
     """
     alias = normalize_account_alias(account)
     if alias:
         return google_account_credentials_path(alias)
     if Path(connector_path).exists():
         return connector_path
-    if Path(_SHARED_GOOGLE_CREDENTIALS_PATH).exists():
+    if allow_shared_fallback and Path(_SHARED_GOOGLE_CREDENTIALS_PATH).exists():
         return _SHARED_GOOGLE_CREDENTIALS_PATH
     return connector_path
 
@@ -382,6 +388,22 @@ def delete_tokens(path: str) -> None:
     p = Path(path)
     if p.exists():
         p.unlink()
+
+
+def _persist_google_oauth_tokens(
+    credentials_path: str,
+    token_payload: Dict[str, Any],
+    *,
+    mirror_shared_credentials: bool = True,
+) -> None:
+    """Persist Google OAuth tokens and optionally mirror to legacy shared auth."""
+    save_tokens(credentials_path, token_payload)
+
+    if mirror_shared_credentials and (
+        credentials_path != _SHARED_GOOGLE_CREDENTIALS_PATH
+        and not _is_google_account_credentials_path(credentials_path)
+    ):
+        save_tokens(_SHARED_GOOGLE_CREDENTIALS_PATH, token_payload)
 
 
 def refresh_google_token(path: str) -> Optional[str]:
@@ -494,6 +516,8 @@ def run_oauth_flow(
     client_secret: str,
     scopes: List[str],
     credentials_path: str,
+    *,
+    mirror_shared_credentials: bool = True,
     redirect_uri: str = _DEFAULT_REDIRECT_URI,
 ) -> Dict[str, Any]:
     """Run the full OAuth flow: browser consent, callback, token exchange.
@@ -518,6 +542,10 @@ def run_oauth_flow(
         List of OAuth scopes to request.
     credentials_path:
         Where to persist the resulting tokens.
+    mirror_shared_credentials:
+        When true, also mirror the resulting tokens into the legacy shared
+        Google credentials file. Set this to false for explicit temp paths or
+        named account aliases so tests and segmented profiles remain isolated.
     redirect_uri:
         Local callback URI.  Defaults to ``http://localhost:8789/callback``.
 
@@ -633,17 +661,11 @@ def run_oauth_flow(
         "client_id": client_id,
         "client_secret": client_secret,
     }
-    save_tokens(credentials_path, token_payload)
-
-    # Also save to the shared Google credentials file for the legacy flow so
-    # all Google connectors can use this token without a separate OAuth flow.
-    # Named account aliases must stay segmented and must not overwrite the
-    # default credentials.
-    if (
-        credentials_path != _SHARED_GOOGLE_CREDENTIALS_PATH
-        and not _is_google_account_credentials_path(credentials_path)
-    ):
-        save_tokens(_SHARED_GOOGLE_CREDENTIALS_PATH, token_payload)
+    _persist_google_oauth_tokens(
+        credentials_path,
+        token_payload,
+        mirror_shared_credentials=mirror_shared_credentials,
+    )
 
     return tokens
 

--- a/src/openjarvis/connectors/oauth.py
+++ b/src/openjarvis/connectors/oauth.py
@@ -179,18 +179,34 @@ def google_account_credentials_path(account: str) -> str:
 
 def list_google_accounts() -> List[Dict[str, Any]]:
     """Return named Google profiles without exposing credential contents."""
-    if not _GOOGLE_ACCOUNTS_DIR.is_dir():
-        return []
+    configured: Dict[str, bool] = {}
+    try:
+        from openjarvis.core.config import load_config
+
+        for raw_alias, profile in load_config().connectors.google.accounts.items():
+            configured[normalize_account_alias(raw_alias)] = profile.enabled
+    except (OSError, ValueError):
+        configured = {}
+
+    paths_by_alias: Dict[str, Path] = {}
+    if _GOOGLE_ACCOUNTS_DIR.is_dir():
+        for path in sorted(_GOOGLE_ACCOUNTS_DIR.glob("*.json")):
+            try:
+                paths_by_alias[normalize_account_alias(path.stem)] = path
+            except ValueError:
+                continue
+
     accounts: List[Dict[str, Any]] = []
-    for path in sorted(_GOOGLE_ACCOUNTS_DIR.glob("*.json")):
+    for alias in sorted(set(configured) | set(paths_by_alias)):
+        path = paths_by_alias.get(alias)
         try:
-            alias = normalize_account_alias(path.stem)
-        except ValueError:
-            continue
-        tokens = load_tokens(str(path))
+            tokens = load_tokens(str(path)) if path else None
+        except OSError:
+            tokens = None
         accounts.append(
             {
                 "account": alias,
+                "enabled": configured.get(alias, True),
                 "connected": bool(
                     tokens and (tokens.get("access_token") or tokens.get("token"))
                 ),
@@ -221,11 +237,12 @@ def google_account_metadata(
 
 
 def google_source_email_from_tokens(tokens: Dict[str, Any]) -> str:
-    """Extract Google's verified email claim for provenance metadata only.
+    """Extract Google's provider-asserted email claim for provenance only.
 
     The ID token arrives directly from Google's TLS-authenticated token
-    endpoint. The claim is not used for authorization or account selection;
-    the user-controlled local alias remains the security boundary.
+    endpoint, but this helper does not independently verify its signature,
+    issuer, audience, or nonce. The claim is never used for authorization or
+    account selection; the user-controlled local alias remains the boundary.
     """
     id_token = tokens.get("id_token")
     if not isinstance(id_token, str):

--- a/src/openjarvis/connectors/oauth.py
+++ b/src/openjarvis/connectors/oauth.py
@@ -483,6 +483,16 @@ def delete_tokens(path: str) -> None:
         p.unlink()
 
 
+def delete_provider_tokens(provider: OAuthProvider, *, account: str = "") -> None:
+    """Delete every credential file owned by one provider lifecycle."""
+    alias = normalize_account_alias(account)
+    if provider.name == "google" and alias:
+        delete_tokens(google_account_credentials_path(alias))
+        return
+    for filename in provider.credential_files:
+        delete_tokens(str(_CONNECTORS_DIR / filename))
+
+
 def _persist_google_oauth_tokens(
     credentials_path: str,
     token_payload: Dict[str, Any],

--- a/src/openjarvis/connectors/oauth.py
+++ b/src/openjarvis/connectors/oauth.py
@@ -9,9 +9,11 @@ Provides:
 from __future__ import annotations
 
 import base64
+import binascii
 import json
 import os
 import re
+import secrets
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -28,6 +30,14 @@ _CONNECTORS_DIR = DEFAULT_CONFIG_DIR / "connectors"
 _GOOGLE_ACCOUNT_PROVIDER = "google"
 _GOOGLE_ACCOUNTS_DIR = _CONNECTORS_DIR / _GOOGLE_ACCOUNT_PROVIDER / "accounts"
 _ACCOUNT_ALIAS_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}$")
+_WINDOWS_RESERVED_NAMES = {
+    "CON",
+    "PRN",
+    "AUX",
+    "NUL",
+    *(f"COM{i}" for i in range(1, 10)),
+    *(f"LPT{i}" for i in range(1, 10)),
+}
 
 # ---------------------------------------------------------------------------
 # OAuth provider registry
@@ -140,10 +150,18 @@ def normalize_account_alias(account: str = "") -> str:
     restricted to a small filesystem-safe slug format because they become JSON
     filenames under ``~/.openjarvis/connectors/google/accounts``.
     """
-    alias = account.strip()
+    # Alias names become cross-platform filenames.  Normalize case so
+    # ``Work`` and ``work`` cannot silently address the same file on default
+    # macOS/Windows filesystems while remaining distinct on Linux.
+    alias = account.strip().lower()
     if not alias:
         return ""
-    if not _ACCOUNT_ALIAS_RE.fullmatch(alias):
+    reserved_stem = alias.split(".", 1)[0].upper()
+    if (
+        not _ACCOUNT_ALIAS_RE.fullmatch(alias)
+        or alias.endswith(".")
+        or reserved_stem in _WINDOWS_RESERVED_NAMES
+    ):
         raise ValueError(
             "Account aliases must be 1-64 characters and contain only letters, "
             "numbers, dots, underscores, or hyphens."
@@ -159,17 +177,71 @@ def google_account_credentials_path(account: str) -> str:
     return str(_GOOGLE_ACCOUNTS_DIR / f"{alias}.json")
 
 
-def google_account_metadata(connector_id: str, account: str = "") -> Dict[str, str]:
+def list_google_accounts() -> List[Dict[str, Any]]:
+    """Return named Google profiles without exposing credential contents."""
+    if not _GOOGLE_ACCOUNTS_DIR.is_dir():
+        return []
+    accounts: List[Dict[str, Any]] = []
+    for path in sorted(_GOOGLE_ACCOUNTS_DIR.glob("*.json")):
+        try:
+            alias = normalize_account_alias(path.stem)
+        except ValueError:
+            continue
+        tokens = load_tokens(str(path))
+        accounts.append(
+            {
+                "account": alias,
+                "connected": bool(
+                    tokens and (tokens.get("access_token") or tokens.get("token"))
+                ),
+                "source_email": str(tokens.get("source_email", "")) if tokens else "",
+            }
+        )
+    return accounts
+
+
+def google_account_metadata(
+    connector_id: str,
+    account: str = "",
+    source_email: str = "",
+) -> Dict[str, str]:
     """Return provenance metadata for a named connector account."""
     alias = normalize_account_alias(account)
     if not alias:
         return {"connector": connector_id}
-    return {
+    metadata = {
         "account": alias,
         "source_profile": alias,
         "connector": connector_id,
         "connector_instance": f"{connector_id}:{alias}",
     }
+    if source_email.strip():
+        metadata["source_email"] = source_email.strip()
+    return metadata
+
+
+def google_source_email_from_tokens(tokens: Dict[str, Any]) -> str:
+    """Extract Google's verified email claim for provenance metadata only.
+
+    The ID token arrives directly from Google's TLS-authenticated token
+    endpoint. The claim is not used for authorization or account selection;
+    the user-controlled local alias remains the security boundary.
+    """
+    id_token = tokens.get("id_token")
+    if not isinstance(id_token, str):
+        return ""
+    parts = id_token.split(".")
+    if len(parts) != 3:
+        return ""
+    try:
+        encoded = parts[1] + "=" * (-len(parts[1]) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(encoded).decode("utf-8"))
+    except (binascii.Error, ValueError, UnicodeDecodeError, json.JSONDecodeError):
+        return ""
+    if not isinstance(payload, dict) or payload.get("email_verified") is not True:
+        return ""
+    email = payload.get("email")
+    return email.strip() if isinstance(email, str) else ""
 
 
 def google_account_doc_id(connector_id: str, native_id: str, account: str = "") -> str:
@@ -663,6 +735,7 @@ def run_oauth_flow(
         "expires_in": tokens.get("expires_in", 3600),
         "client_id": client_id,
         "client_secret": client_secret,
+        "source_email": google_source_email_from_tokens(tokens),
     }
     _persist_google_oauth_tokens(
         credentials_path,
@@ -683,8 +756,9 @@ def _wait_for_callback_code(
     port: int = 8789,
     path: str = "/callback",
     timeout: int = 120,
+    expected_state: str = "",
 ) -> str:
-    """Start a localhost HTTP server and wait for ``?code=`` on *path*.
+    """Wait for a code on the exact callback path with matching OAuth state.
 
     Returns the authorization code received from the OAuth redirect.
     """
@@ -696,7 +770,13 @@ def _wait_for_callback_code(
 
     class _Handler(BaseHTTPRequestHandler):
         def do_GET(self) -> None:  # noqa: N802
-            params = parse_qs(urlparse(self.path).query)
+            parsed = urlparse(self.path)
+            params = parse_qs(parsed.query)
+            state = params.get("state", [""])[0]
+            if parsed.path != path or not expected_state or state != expected_state:
+                self.send_response(400)
+                self.end_headers()
+                return
             if "code" in params:
                 auth_code.append(params["code"][0])
                 self.send_response(200)
@@ -744,9 +824,10 @@ def _wait_for_callback_code(
     time.sleep(0.3)
 
     server = HTTPServer((host, port), _Handler)
-    server.timeout = timeout
+    deadline = time.monotonic() + timeout
+    server.timeout = min(1.0, float(timeout))
 
-    while not auth_code and not error:
+    while not auth_code and not error and time.monotonic() < deadline:
         server.handle_request()
     server.server_close()
 
@@ -835,6 +916,8 @@ def run_connector_oauth(
         "scope": " ".join(provider.scopes),
         **provider.extra_auth_params,
     }
+    state = secrets.token_urlsafe(32)
+    params["state"] = state
     auth_url = f"{provider.auth_endpoint}?{urlencode(params)}"
 
     # Open browser and wait for callback
@@ -843,6 +926,7 @@ def run_connector_oauth(
         host=provider.callback_host,
         port=provider.callback_port,
         path=provider.callback_path,
+        expected_state=state,
     )
 
     # Exchange code for tokens
@@ -857,6 +941,9 @@ def run_connector_oauth(
         "expires_in": tokens.get("expires_in", 3600),
         "client_id": client_id,
         "client_secret": client_secret,
+        "source_email": google_source_email_from_tokens(tokens)
+        if provider.name == _GOOGLE_ACCOUNT_PROVIDER
+        else "",
     }
 
     # Save to the legacy provider files, or to one segmented account file when

--- a/src/openjarvis/connectors/retriever.py
+++ b/src/openjarvis/connectors/retriever.py
@@ -240,6 +240,7 @@ class TwoStageRetriever:
         *,
         top_k: int = 10,
         source: str = "",
+        account: str = "",
         doc_type: str = "",
         author: str = "",
         since: str = "",
@@ -254,7 +255,10 @@ class TwoStageRetriever:
         top_k:
             Maximum number of results to return.
         source:
-            Restrict to chunks from this source (e.g. ``"gmail"``).
+            Restrict to chunks from this source (e.g. ``"gmail"`` or
+            ``"gmail:work"``).
+        account:
+            Restrict to chunks from a named connector account alias.
         doc_type:
             Restrict to chunks of this doc type (e.g. ``"email"``).
         author:
@@ -276,6 +280,8 @@ class TwoStageRetriever:
         filter_kwargs = {}
         if source:
             filter_kwargs["source"] = source
+        if account:
+            filter_kwargs["account"] = account
         if doc_type:
             filter_kwargs["doc_type"] = doc_type
         if author:

--- a/src/openjarvis/connectors/retriever.py
+++ b/src/openjarvis/connectors/retriever.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, List, Optional, Sequence
 
 from openjarvis.connectors.store import KnowledgeStore
 from openjarvis.tools.storage._stubs import RetrievalResult
@@ -241,6 +241,7 @@ class TwoStageRetriever:
         top_k: int = 10,
         source: str = "",
         account: str = "",
+        accounts: Optional[Sequence[str]] = None,
         doc_type: str = "",
         author: str = "",
         since: str = "",
@@ -259,6 +260,9 @@ class TwoStageRetriever:
             ``"gmail:work"``).
         account:
             Restrict to chunks from a named connector account alias.
+        accounts:
+            Restrict Google rows to these aliases while retaining unscoped
+            rows from non-Google connectors. An empty list excludes Google.
         doc_type:
             Restrict to chunks of this doc type (e.g. ``"email"``).
         author:
@@ -282,6 +286,8 @@ class TwoStageRetriever:
             filter_kwargs["source"] = source
         if account:
             filter_kwargs["account"] = account
+        elif accounts is not None:
+            filter_kwargs["accounts"] = accounts
         if doc_type:
             filter_kwargs["doc_type"] = doc_type
         if author:

--- a/src/openjarvis/connectors/store.py
+++ b/src/openjarvis/connectors/store.py
@@ -378,6 +378,11 @@ class KnowledgeStore(MemoryBackend):
         since_str = _to_iso(since) if since is not None else None
         until_str = _to_iso(until) if until is not None else None
         source, source_account = _split_source_account(source)
+        if account and source_account and account != source_account:
+            raise ValueError(
+                "Conflicting account filters: the scoped source and explicit "
+                "account must match"
+            )
         account = account or source_account
 
         # Build the WHERE clause for filter columns

--- a/src/openjarvis/connectors/store.py
+++ b/src/openjarvis/connectors/store.py
@@ -41,6 +41,14 @@ def google_account_scope_sql(
         f"CASE WHEN json_valid({prefix}metadata) "
         f"THEN json_extract({prefix}metadata, '$.account') END"
     )
+    connector_expr = (
+        f"CASE WHEN json_valid({prefix}metadata) "
+        f"THEN json_extract({prefix}metadata, '$.connector') END"
+    )
+    imap_uid_expr = (
+        f"CASE WHEN json_valid({prefix}metadata) "
+        f"THEN json_extract({prefix}metadata, '$.imap_uid') END"
+    )
     google_sources = tuple(OAUTH_PROVIDERS["google"].connector_ids)
     google_placeholders = ", ".join("?" for _ in google_sources)
     params: list[Any] = []
@@ -50,10 +58,13 @@ def google_account_scope_sql(
         allowed = f"{account_expr} IN ({account_placeholders})"
         params.extend(accounts)
     params.extend(google_sources)
-    clause = (
-        f"({allowed} OR (COALESCE({account_expr}, '') = '' AND "
-        f"{prefix}source NOT IN ({google_placeholders})))"
+    non_google_row = (
+        f"({prefix}source NOT IN ({google_placeholders}) OR "
+        f"({prefix}source = 'gmail' AND "
+        f"({connector_expr} = 'gmail_imap' OR "
+        f"COALESCE({imap_uid_expr}, '') != '')))"
     )
+    clause = f"({allowed} OR (COALESCE({account_expr}, '') = '' AND {non_google_row}))"
     return clause, params
 
 

--- a/src/openjarvis/connectors/store.py
+++ b/src/openjarvis/connectors/store.py
@@ -15,11 +15,47 @@ import time
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Union
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Union
 
 from openjarvis.core.events import EventType, get_event_bus
 from openjarvis.core.registry import MemoryRegistry
 from openjarvis.tools.storage._stubs import MemoryBackend, RetrievalResult
+
+
+def google_account_scope_sql(
+    accounts: Sequence[str],
+    *,
+    alias: str = "",
+) -> tuple[str, list[Any]]:
+    """Build a Google-profile boundary while retaining other connectors.
+
+    Named account configuration scopes the five connectors sharing a Google
+    OAuth grant. It must not hide unrelated Slack/Obsidian/etc. rows, but it
+    must exclude legacy unscoped Google rows because those belong to a
+    different credential boundary.
+    """
+    from openjarvis.connectors.oauth import OAUTH_PROVIDERS
+
+    prefix = f"{alias}." if alias else ""
+    account_expr = (
+        f"CASE WHEN json_valid({prefix}metadata) "
+        f"THEN json_extract({prefix}metadata, '$.account') END"
+    )
+    google_sources = tuple(OAUTH_PROVIDERS["google"].connector_ids)
+    google_placeholders = ", ".join("?" for _ in google_sources)
+    params: list[Any] = []
+    allowed = "0"
+    if accounts:
+        account_placeholders = ", ".join("?" for _ in accounts)
+        allowed = f"{account_expr} IN ({account_placeholders})"
+        params.extend(accounts)
+    params.extend(google_sources)
+    clause = (
+        f"({allowed} OR (COALESCE({account_expr}, '') = '' AND "
+        f"{prefix}source NOT IN ({google_placeholders})))"
+    )
+    return clause, params
+
 
 # ---------------------------------------------------------------------------
 # DDL
@@ -353,6 +389,7 @@ class KnowledgeStore(MemoryBackend):
         top_k: int = 5,
         source: Optional[str] = None,
         account: Optional[str] = None,
+        accounts: Optional[Sequence[str]] = None,
         doc_type: Optional[str] = None,
         author: Optional[str] = None,
         since: Optional[Union[datetime, str]] = None,
@@ -378,6 +415,8 @@ class KnowledgeStore(MemoryBackend):
         since_str = _to_iso(since) if since is not None else None
         until_str = _to_iso(until) if until is not None else None
         source, source_account = _split_source_account(source)
+        if account is not None and accounts is not None:
+            raise ValueError("account and accounts filters are mutually exclusive")
         if account and source_account and account != source_account:
             raise ValueError(
                 "Conflicting account filters: the scoped source and explicit "
@@ -395,6 +434,13 @@ class KnowledgeStore(MemoryBackend):
         if account is not None:
             filters.append("json_extract(kc.metadata, '$.account') = ?")
             params.append(account)
+        elif accounts is not None:
+            account_clause, account_params = google_account_scope_sql(
+                accounts,
+                alias="kc",
+            )
+            filters.append(account_clause)
+            params.extend(account_params)
         if doc_type is not None:
             filters.append("kc.doc_type = ?")
             params.append(doc_type)
@@ -462,6 +508,7 @@ class KnowledgeStore(MemoryBackend):
                     "doc_type": doc_type,
                     "author": author,
                     "account": account,
+                    "accounts": list(accounts) if accounts is not None else None,
                     "since": since_str,
                     "until": until_str,
                 },
@@ -607,20 +654,9 @@ class KnowledgeStore(MemoryBackend):
         where = "source IS NOT NULL AND source != ''"
         params: tuple[Any, ...] = ()
         if account_scope is not None:
-            unscoped = (
-                "COALESCE(CASE WHEN json_valid(metadata) "
-                "THEN json_extract(metadata, '$.account') END, '') = ''"
-            )
-            if account_scope:
-                placeholders = ", ".join("?" for _ in account_scope)
-                where += (
-                    f" AND ({unscoped} OR CASE WHEN json_valid(metadata) "
-                    "THEN json_extract(metadata, '$.account') END "
-                    f"IN ({placeholders}))"
-                )
-                params = account_scope
-            else:
-                where += f" AND {unscoped}"
+            account_clause, account_params = google_account_scope_sql(account_scope)
+            where += f" AND {account_clause}"
+            params = tuple(account_params)
         try:
             rows = self._conn.execute(
                 "SELECT DISTINCT source, "

--- a/src/openjarvis/connectors/store.py
+++ b/src/openjarvis/connectors/store.py
@@ -617,10 +617,20 @@ class KnowledgeStore(MemoryBackend):
             predicates.append(f"source IN ({placeholders})")
             params.extend(unique_sources)
         for source, connector in attributed:
-            predicates.append(
-                "(source = ? AND CASE WHEN json_valid(metadata) "
-                "THEN json_extract(metadata, '$.connector') END = ?)"
+            connector_match = (
+                "CASE WHEN json_valid(metadata) "
+                "THEN json_extract(metadata, '$.connector') END = ?"
             )
+            if connector == "gmail_imap":
+                # Historical Gmail IMAP rows predate the connector marker but
+                # always carry the UID used for stable mailbox identity.
+                predicates.append(
+                    f"(source = ? AND ({connector_match} OR "
+                    "COALESCE(CASE WHEN json_valid(metadata) "
+                    "THEN json_extract(metadata, '$.imap_uid') END, '') != ''))"
+                )
+            else:
+                predicates.append(f"(source = ? AND {connector_match})")
             params.extend((source, connector))
         if not predicates:
             return 0

--- a/src/openjarvis/connectors/store.py
+++ b/src/openjarvis/connectors/store.py
@@ -497,6 +497,7 @@ class KnowledgeStore(MemoryBackend):
         *,
         account: Optional[str] = None,
         unscoped_only: bool = False,
+        metadata_connector: Optional[str] = None,
     ) -> int:
         """Atomically delete chunks belonging to *sources* and optional account."""
         if account is not None and unscoped_only:
@@ -512,6 +513,9 @@ class KnowledgeStore(MemoryBackend):
             params = (*params, account)
         elif unscoped_only:
             where += " AND COALESCE(json_extract(metadata, '$.account'), '') = ''"
+        if metadata_connector is not None:
+            where += " AND json_extract(metadata, '$.connector') = ?"
+            params = (*params, metadata_connector)
         try:
             cur = self._conn.execute(
                 f"DELETE FROM knowledge_chunks WHERE {where}",

--- a/src/openjarvis/connectors/store.py
+++ b/src/openjarvis/connectors/store.py
@@ -556,12 +556,21 @@ class KnowledgeStore(MemoryBackend):
         where = f"source IN ({placeholders})"
         params: tuple[Any, ...] = unique_sources
         if account is not None:
-            where += " AND json_extract(metadata, '$.account') = ?"
+            where += (
+                " AND CASE WHEN json_valid(metadata) "
+                "THEN json_extract(metadata, '$.account') END = ?"
+            )
             params = (*params, account)
         elif unscoped_only:
-            where += " AND COALESCE(json_extract(metadata, '$.account'), '') = ''"
+            where += (
+                " AND COALESCE(CASE WHEN json_valid(metadata) "
+                "THEN json_extract(metadata, '$.account') END, '') = ''"
+            )
         if metadata_connector is not None:
-            where += " AND json_extract(metadata, '$.connector') = ?"
+            where += (
+                " AND CASE WHEN json_valid(metadata) "
+                "THEN json_extract(metadata, '$.connector') END = ?"
+            )
             params = (*params, metadata_connector)
         try:
             cur = self._conn.execute(

--- a/src/openjarvis/connectors/store.py
+++ b/src/openjarvis/connectors/store.py
@@ -589,27 +589,54 @@ class KnowledgeStore(MemoryBackend):
         row = self._conn.execute("SELECT COUNT(*) FROM knowledge_chunks").fetchone()
         return row[0] if row else 0
 
-    def distinct_sources(self) -> List[str]:
+    def distinct_sources(
+        self,
+        accounts: Optional[Iterable[str]] = None,
+    ) -> List[str]:
         """Return the sorted list of distinct ``source`` values currently indexed.
 
         Used by the research agent to populate the system prompt with the
         sources the user actually has connected — so the model doesn't
         mention "Notion" or "Apple Notes" when nothing from those sources
-        is in the corpus.
+        is in the corpus.  When *accounts* is supplied, account-scoped rows
+        outside that boundary are hidden while unscoped/legacy rows remain
+        visible.  ``None`` preserves the legacy unrestricted behaviour; an
+        empty iterable exposes only unscoped rows.
         """
+        account_scope = None if accounts is None else tuple(dict.fromkeys(accounts))
+        where = "source IS NOT NULL AND source != ''"
+        params: tuple[Any, ...] = ()
+        if account_scope is not None:
+            unscoped = (
+                "COALESCE(CASE WHEN json_valid(metadata) "
+                "THEN json_extract(metadata, '$.account') END, '') = ''"
+            )
+            if account_scope:
+                placeholders = ", ".join("?" for _ in account_scope)
+                where += (
+                    f" AND ({unscoped} OR CASE WHEN json_valid(metadata) "
+                    "THEN json_extract(metadata, '$.account') END "
+                    f"IN ({placeholders}))"
+                )
+                params = account_scope
+            else:
+                where += f" AND {unscoped}"
         try:
             rows = self._conn.execute(
                 "SELECT DISTINCT source, "
-                "json_extract(metadata, '$.account') AS account "
+                "CASE WHEN json_valid(metadata) "
+                "THEN json_extract(metadata, '$.account') END AS account "
                 "FROM knowledge_chunks "
-                "WHERE source IS NOT NULL AND source != '' "
-                "ORDER BY source, account"
+                f"WHERE {where} "
+                "ORDER BY source, account",
+                params,
             ).fetchall()
         except sqlite3.OperationalError:
             rows = self._conn.execute(
                 "SELECT DISTINCT source, NULL AS account FROM knowledge_chunks "
-                "WHERE source IS NOT NULL AND source != '' "
-                "ORDER BY source"
+                f"WHERE {where} "
+                "ORDER BY source",
+                params,
             ).fetchall()
 
         sources: set[str] = set()

--- a/src/openjarvis/connectors/store.py
+++ b/src/openjarvis/connectors/store.py
@@ -527,6 +527,52 @@ class KnowledgeStore(MemoryBackend):
             raise
         return cur.rowcount
 
+    def delete_unscoped_sources_with_attribution(
+        self,
+        unambiguous_sources: Iterable[str],
+        attributed_sources: Dict[str, str],
+    ) -> int:
+        """Atomically delete legacy unscoped rows with safe attribution.
+
+        Sources in ``unambiguous_sources`` are deleted by source ID.  Entries
+        in ``attributed_sources`` are deleted only when their metadata carries
+        the matching connector marker.  One DELETE statement covers both sets
+        so a database error cannot commit only half of a migration.
+        Malformed legacy metadata is treated as unscoped but never as positive
+        attribution.
+        """
+        unique_sources = tuple(dict.fromkeys(unambiguous_sources))
+        attributed = tuple(dict(attributed_sources).items())
+        predicates: List[str] = []
+        params: List[Any] = []
+        if unique_sources:
+            placeholders = ", ".join("?" for _ in unique_sources)
+            predicates.append(f"source IN ({placeholders})")
+            params.extend(unique_sources)
+        for source, connector in attributed:
+            predicates.append(
+                "(source = ? AND CASE WHEN json_valid(metadata) "
+                "THEN json_extract(metadata, '$.connector') END = ?)"
+            )
+            params.extend((source, connector))
+        if not predicates:
+            return 0
+        where = (
+            "COALESCE(CASE WHEN json_valid(metadata) "
+            "THEN json_extract(metadata, '$.account') END, '') = '' "
+            f"AND ({' OR '.join(predicates)})"
+        )
+        try:
+            cur = self._conn.execute(
+                f"DELETE FROM knowledge_chunks WHERE {where}",
+                tuple(params),
+            )
+            self._conn.commit()
+        except Exception:
+            self._conn.rollback()
+            raise
+        return cur.rowcount
+
     def clear(self) -> None:
         """Remove all stored chunks."""
         self._conn.executescript(

--- a/src/openjarvis/connectors/store.py
+++ b/src/openjarvis/connectors/store.py
@@ -140,6 +140,16 @@ def _to_epoch(ts: Union[datetime, str, float, int]) -> float:
     return ts.timestamp()
 
 
+def _split_source_account(source: Optional[str]) -> tuple[Optional[str], Optional[str]]:
+    """Parse optional ``source:account`` filters while preserving legacy source."""
+    if not source or ":" not in source:
+        return source, None
+    base, account = source.split(":", 1)
+    if not base or not account:
+        return source, None
+    return base, account
+
+
 # ---------------------------------------------------------------------------
 # KnowledgeStore
 # ---------------------------------------------------------------------------
@@ -342,6 +352,7 @@ class KnowledgeStore(MemoryBackend):
         *,
         top_k: int = 5,
         source: Optional[str] = None,
+        account: Optional[str] = None,
         doc_type: Optional[str] = None,
         author: Optional[str] = None,
         since: Optional[Union[datetime, str]] = None,
@@ -354,7 +365,8 @@ class KnowledgeStore(MemoryBackend):
         ----------
         query:    Full-text search query.
         top_k:    Maximum number of results.
-        source:   Restrict to chunks from this source (e.g. "gmail").
+        source:   Restrict to chunks from this source (e.g. "gmail" or "gmail:work").
+        account:  Restrict to chunks from a named connector account alias.
         doc_type: Restrict to chunks of this type (e.g. "email").
         author:   Restrict to chunks authored by this person.
         since:    Exclude chunks whose timestamp is earlier than this value.
@@ -365,6 +377,8 @@ class KnowledgeStore(MemoryBackend):
 
         since_str = _to_iso(since) if since is not None else None
         until_str = _to_iso(until) if until is not None else None
+        source, source_account = _split_source_account(source)
+        account = account or source_account
 
         # Build the WHERE clause for filter columns
         filters: List[str] = []
@@ -373,6 +387,9 @@ class KnowledgeStore(MemoryBackend):
         if source is not None:
             filters.append("kc.source = ?")
             params.append(source)
+        if account is not None:
+            filters.append("json_extract(kc.metadata, '$.account') = ?")
+            params.append(account)
         if doc_type is not None:
             filters.append("kc.doc_type = ?")
             params.append(doc_type)
@@ -439,6 +456,7 @@ class KnowledgeStore(MemoryBackend):
                     "source": source,
                     "doc_type": doc_type,
                     "author": author,
+                    "account": account,
                     "since": since_str,
                     "until": until_str,
                 },
@@ -468,16 +486,26 @@ class KnowledgeStore(MemoryBackend):
         """
         return self.delete_by_sources((source,))
 
-    def delete_by_sources(self, sources: Iterable[str]) -> int:
-        """Atomically delete chunks belonging to any of *sources*."""
+    def delete_by_sources(
+        self,
+        sources: Iterable[str],
+        *,
+        account: Optional[str] = None,
+    ) -> int:
+        """Atomically delete chunks belonging to *sources* and optional account."""
         unique_sources = tuple(dict.fromkeys(sources))
         if not unique_sources:
             return 0
         placeholders = ", ".join("?" for _ in unique_sources)
+        where = f"source IN ({placeholders})"
+        params: tuple[Any, ...] = unique_sources
+        if account is not None:
+            where += " AND json_extract(metadata, '$.account') = ?"
+            params = (*params, account)
         try:
             cur = self._conn.execute(
-                f"DELETE FROM knowledge_chunks WHERE source IN ({placeholders})",
-                unique_sources,
+                f"DELETE FROM knowledge_chunks WHERE {where}",
+                params,
             )
             self._conn.commit()
         except Exception:
@@ -509,12 +537,29 @@ class KnowledgeStore(MemoryBackend):
         mention "Notion" or "Apple Notes" when nothing from those sources
         is in the corpus.
         """
-        rows = self._conn.execute(
-            "SELECT DISTINCT source FROM knowledge_chunks "
-            "WHERE source IS NOT NULL AND source != '' "
-            "ORDER BY source"
-        ).fetchall()
-        return [r[0] for r in rows]
+        try:
+            rows = self._conn.execute(
+                "SELECT DISTINCT source, "
+                "json_extract(metadata, '$.account') AS account "
+                "FROM knowledge_chunks "
+                "WHERE source IS NOT NULL AND source != '' "
+                "ORDER BY source, account"
+            ).fetchall()
+        except sqlite3.OperationalError:
+            rows = self._conn.execute(
+                "SELECT DISTINCT source, NULL AS account FROM knowledge_chunks "
+                "WHERE source IS NOT NULL AND source != '' "
+                "ORDER BY source"
+            ).fetchall()
+
+        sources: set[str] = set()
+        for row in rows:
+            source = row["source"]
+            account = row["account"]
+            sources.add(source)
+            if account:
+                sources.add(f"{source}:{account}")
+        return sorted(sources)
 
     def close(self) -> None:
         """Close the underlying SQLite connection."""

--- a/src/openjarvis/connectors/store.py
+++ b/src/openjarvis/connectors/store.py
@@ -496,8 +496,11 @@ class KnowledgeStore(MemoryBackend):
         sources: Iterable[str],
         *,
         account: Optional[str] = None,
+        unscoped_only: bool = False,
     ) -> int:
         """Atomically delete chunks belonging to *sources* and optional account."""
+        if account is not None and unscoped_only:
+            raise ValueError("account and unscoped_only are mutually exclusive")
         unique_sources = tuple(dict.fromkeys(sources))
         if not unique_sources:
             return 0
@@ -507,6 +510,8 @@ class KnowledgeStore(MemoryBackend):
         if account is not None:
             where += " AND json_extract(metadata, '$.account') = ?"
             params = (*params, account)
+        elif unscoped_only:
+            where += " AND COALESCE(json_extract(metadata, '$.account'), '') = ''"
         try:
             cur = self._conn.execute(
                 f"DELETE FROM knowledge_chunks WHERE {where}",

--- a/src/openjarvis/connectors/sync_engine.py
+++ b/src/openjarvis/connectors/sync_engine.py
@@ -16,9 +16,10 @@ Typical usage::
 
 from __future__ import annotations
 
+import os
 import sqlite3
 import threading
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -99,9 +100,14 @@ class SyncEngine:
         exception is re-raised so callers can handle it.
         """
         connector_id: str = connector.connector_id
+        account = str(getattr(connector, "_account", "") or "").strip()
+        checkpoint_id = f"{connector_id}:{account}" if account else connector_id
 
-        # Load any previous checkpoint so we can resume.
-        checkpoint = self.get_checkpoint(connector_id)
+        # Load any previous checkpoint so we can resume. Named account aliases
+        # must have independent checkpoints; otherwise syncing personal-main
+        # makes work-main resume from personal's last_sync and silently skip
+        # account-specific mail.
+        checkpoint = self.get_checkpoint(checkpoint_id)
         prior_cursor: Optional[str] = checkpoint["cursor"] if checkpoint else None
         prior_items: int = checkpoint["items_synced"] if checkpoint else 0
 
@@ -109,6 +115,17 @@ class SyncEngine:
         if checkpoint and checkpoint.get("last_sync"):
             try:
                 since = datetime.fromisoformat(checkpoint["last_sync"])
+                # Gmail and similar APIs often filter by message Date/internal
+                # timestamp, not by the moment OpenJarvis last polled. A new
+                # email can legitimately have a Date a few minutes before the
+                # checkpoint wall clock, so exact `after:last_sync` polling can
+                # miss it forever. Re-fetch a bounded overlap and rely on the
+                # store natural key to ignore already-ingested documents.
+                lookback_seconds = int(
+                    os.environ.get("OPENJARVIS_SYNC_LOOKBACK_SECONDS", "86400")
+                )
+                if lookback_seconds > 0:
+                    since = since - timedelta(seconds=lookback_seconds)
             except (ValueError, TypeError):
                 pass
 
@@ -139,7 +156,7 @@ class SyncEngine:
                     # successful completion would permanently skip
                     # whatever wasn't reached if the sync then fails (#782).
                     self._save_checkpoint(
-                        connector_id,
+                        checkpoint_id,
                         prior_items + items_ingested,
                         cursor=current_cursor,
                     )
@@ -150,7 +167,7 @@ class SyncEngine:
 
         except Exception as exc:
             self._save_checkpoint(
-                connector_id,
+                checkpoint_id,
                 prior_items + items_ingested,
                 cursor=current_cursor,
                 error=str(exc),
@@ -163,7 +180,7 @@ class SyncEngine:
             # advancing it here could make the next sync skip documents that
             # the cancelled run never reached (#782).
             self._save_checkpoint(
-                connector_id,
+                checkpoint_id,
                 prior_items + items_ingested,
                 cursor=current_cursor,
                 error=None,
@@ -173,7 +190,7 @@ class SyncEngine:
         # Final checkpoint on successful completion — clear any previous
         # error and advance the watermark to when this sync started.
         self._save_checkpoint(
-            connector_id,
+            checkpoint_id,
             prior_items + items_ingested,
             cursor=current_cursor,
             error=None,

--- a/src/openjarvis/connectors/sync_engine.py
+++ b/src/openjarvis/connectors/sync_engine.py
@@ -16,10 +16,9 @@ Typical usage::
 
 from __future__ import annotations
 
-import os
 import sqlite3
 import threading
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -115,17 +114,6 @@ class SyncEngine:
         if checkpoint and checkpoint.get("last_sync"):
             try:
                 since = datetime.fromisoformat(checkpoint["last_sync"])
-                # Gmail and similar APIs often filter by message Date/internal
-                # timestamp, not by the moment OpenJarvis last polled. A new
-                # email can legitimately have a Date a few minutes before the
-                # checkpoint wall clock, so exact `after:last_sync` polling can
-                # miss it forever. Re-fetch a bounded overlap and rely on the
-                # store natural key to ignore already-ingested documents.
-                lookback_seconds = int(
-                    os.environ.get("OPENJARVIS_SYNC_LOOKBACK_SECONDS", "86400")
-                )
-                if lookback_seconds > 0:
-                    since = since - timedelta(seconds=lookback_seconds)
             except (ValueError, TypeError):
                 pass
 

--- a/src/openjarvis/core/config.py
+++ b/src/openjarvis/core/config.py
@@ -1712,6 +1712,32 @@ class GoogleConnectorsConfig:
 
     accounts: Dict[str, GoogleAccountProfileConfig] = field(default_factory=dict)
 
+    def is_enabled(self, account: str) -> bool:
+        """Return whether a configured alias may be used at runtime.
+
+        Unlisted aliases remain enabled for backwards-compatible ad-hoc CLI
+        profiles. Once declared in config, ``enabled = false`` is enforced by
+        connector-aware entry points.
+        """
+        from openjarvis.connectors.oauth import normalize_account_alias
+
+        alias = normalize_account_alias(account)
+        for configured, profile in self.accounts.items():
+            if normalize_account_alias(configured) == alias:
+                return profile.enabled
+        return True
+
+    def enabled_aliases(self, accounts: List[str]) -> List[str]:
+        """Normalize, de-duplicate, and discard disabled configured aliases."""
+        from openjarvis.connectors.oauth import normalize_account_alias
+
+        enabled: List[str] = []
+        for account in accounts:
+            alias = normalize_account_alias(account)
+            if self.is_enabled(alias) and alias not in enabled:
+                enabled.append(alias)
+        return enabled
+
 
 @dataclass
 class ConnectorsConfig:

--- a/src/openjarvis/core/config.py
+++ b/src/openjarvis/core/config.py
@@ -1722,10 +1722,27 @@ class GoogleConnectorsConfig:
         from openjarvis.connectors.oauth import normalize_account_alias
 
         alias = normalize_account_alias(account)
-        for configured, profile in self.accounts.items():
-            if normalize_account_alias(configured) == alias:
-                return profile.enabled
-        return True
+        matches = [
+            profile.enabled
+            for configured, profile in self.accounts.items()
+            if normalize_account_alias(configured) == alias
+        ]
+        return all(matches) if matches else True
+
+    def validate_aliases(self) -> None:
+        """Reject config keys that collapse to the same canonical alias."""
+        from openjarvis.connectors.oauth import normalize_account_alias
+
+        seen: Dict[str, str] = {}
+        for configured in self.accounts:
+            alias = normalize_account_alias(configured)
+            previous = seen.get(alias)
+            if previous is not None:
+                raise ValueError(
+                    "Duplicate Google account profile aliases after normalization: "
+                    f"{previous!r} and {configured!r}"
+                )
+            seen[alias] = configured
 
     def enabled_aliases(self, accounts: List[str]) -> List[str]:
         """Normalize, de-duplicate, and discard disabled configured aliases."""
@@ -2114,6 +2131,7 @@ def load_config(path: Optional[Path] = None) -> JarvisConfig:
                     getattr(cfg, section_name),
                     data[section_name],
                 )
+        cfg.connectors.google.validate_aliases()
 
         # Memory: accept [memory] (old) → maps to tools.storage
         if "memory" in data:

--- a/src/openjarvis/core/config.py
+++ b/src/openjarvis/core/config.py
@@ -1108,6 +1108,7 @@ class AgentConfig:
     system_prompt: str = ""  # inline system prompt (takes precedence if set)
     system_prompt_path: str = ""  # path to system prompt file (.txt, .md)
     context_from_memory: bool = True  # inject relevant memory context into prompts
+    default_accounts: List[str] = field(default_factory=list)
     default_system_prompt: str = (
         "You are OpenJarvis, a helpful AI assistant running locally on the "
         "user's own hardware. You are not a cloud service, and you are not "
@@ -1678,6 +1679,7 @@ class DigestConfig:
         default_factory=lambda: ["github", "financial", "music", "fitness"]
     )
     honorific: str = "sir"
+    accounts: List[str] = field(default_factory=list)
     voice_id: str = ""
     voice_speed: float = 1.0
     tts_backend: str = "cartesia"
@@ -1695,6 +1697,27 @@ class DigestConfig:
     world: DigestSectionConfig = field(
         default_factory=lambda: DigestSectionConfig(sources=[])
     )
+
+
+@dataclass
+class GoogleAccountProfileConfig:
+    """Configuration for one named Google connector profile."""
+
+    enabled: bool = True
+
+
+@dataclass
+class GoogleConnectorsConfig:
+    """Named Google profiles available to connector-aware workflows."""
+
+    accounts: Dict[str, GoogleAccountProfileConfig] = field(default_factory=dict)
+
+
+@dataclass
+class ConnectorsConfig:
+    """Connector-specific configuration."""
+
+    google: GoogleConnectorsConfig = field(default_factory=GoogleConnectorsConfig)
 
 
 @dataclass
@@ -1729,6 +1752,7 @@ class JarvisConfig:
     system_prompt: SystemPromptConfig = field(default_factory=SystemPromptConfig)
     compression: CompressionConfig = field(default_factory=CompressionConfig)
     skills: SkillsConfig = field(default_factory=SkillsConfig)
+    connectors: ConnectorsConfig = field(default_factory=ConnectorsConfig)
     digest: DigestConfig = field(default_factory=DigestConfig)
     proactive: ProactiveConfig = field(default_factory=ProactiveConfig)
     mining: Optional["MiningConfig"] = None
@@ -1856,6 +1880,23 @@ def _apply_toml_section(target: Any, section: Dict[str, Any]) -> None:
                 if hasattr(nested, "__dataclass_fields__"):
                     _apply_toml_section(nested, value)
                 else:
+                    field_type = None
+                    if hasattr(target, "__dataclass_fields__"):
+                        field_obj = target.__dataclass_fields__.get(key)
+                        if field_obj is not None:
+                            field_type = type_hints.get(key, field_obj.type)
+                    type_args = get_args(field_type) if field_type else ()
+                    value_type = type_args[1] if len(type_args) == 2 else None
+                    if get_origin(field_type) is dict and is_dataclass(value_type):
+                        converted = {}
+                        for item_key, item_value in value.items():
+                            if isinstance(item_value, dict):
+                                item = value_type()
+                                _apply_toml_section(item, item_value)
+                                converted[item_key] = item
+                            else:
+                                converted[item_key] = item_value
+                        value = converted
                     setattr(target, key, value)
             else:
                 # Normalise TOML arrays → comma-separated string.
@@ -2030,6 +2071,7 @@ def load_config(path: Optional[Path] = None) -> JarvisConfig:
             "system_prompt",
             "compression",
             "skills",
+            "connectors",
         )
         for section_name in top_sections:
             if section_name in data:
@@ -2345,6 +2387,7 @@ __all__ = [
     "CapabilitiesConfig",
     "ChannelConfig",
     "ConfigurationError",
+    "ConnectorsConfig",
     "DEFAULT_CONFIG_DIR",
     "DEFAULT_CONFIG_PATH",
     "DiscordChannelConfig",
@@ -2357,6 +2400,8 @@ __all__ = [
     "EngineConfig",
     "FeishuChannelConfig",
     "GoogleChatChannelConfig",
+    "GoogleAccountProfileConfig",
+    "GoogleConnectorsConfig",
     "GpuInfo",
     "HardwareInfo",
     "IRCChannelConfig",

--- a/src/openjarvis/core/config.py
+++ b/src/openjarvis/core/config.py
@@ -1738,6 +1738,15 @@ class GoogleConnectorsConfig:
                 enabled.append(alias)
         return enabled
 
+    def account_scope(self, accounts: List[str]) -> Optional[List[str]]:
+        """Return the enforced runtime scope for a configured alias list.
+
+        ``None`` means no boundary was configured.  An empty list means a
+        boundary exists but every named profile is disabled; callers must
+        preserve that distinction and match no Google data.
+        """
+        return self.enabled_aliases(accounts) if accounts else None
+
 
 @dataclass
 class ConnectorsConfig:

--- a/src/openjarvis/engine/ollama.py
+++ b/src/openjarvis/engine/ollama.py
@@ -134,15 +134,7 @@ class OllamaEngine(AsyncHTTPEngineMixin, InferenceEngine):
         # the async stream path with no real Ollama server. ``None`` in production so
         # httpx uses its default networking.
         self._async_transport: httpx.AsyncBaseTransport | None = None
-        # Do not inherit proxy/environment transport settings for LAN Ollama.
-        # On macOS, httpx trust_env=True can route private-subnet requests
-        # through system proxy discovery and intermittently time out even when
-        # direct curl and trust_env=False succeed.
-        self._client = httpx.Client(
-            base_url=self._host,
-            timeout=timeout,
-            trust_env=False,
-        )
+        self._client = httpx.Client(base_url=self._host, timeout=timeout)
         # Last stream usage — captured from Ollama's final chunk
         self._last_stream_usage: Dict[str, int] = {}
 
@@ -548,12 +540,7 @@ class OllamaEngine(AsyncHTTPEngineMixin, InferenceEngine):
 
     def health(self) -> bool:
         try:
-            # LAN-hosted Ollama can take longer than localhost to accept the
-            # first connection, especially while models/Rust extensions are
-            # warming. Keep the probe short enough for discovery, but not so
-            # short that `serve` rejects a reachable subnet Ollama instance.
-            timeout = float(os.environ.get("OPENJARVIS_OLLAMA_HEALTH_TIMEOUT", "10"))
-            resp = self._client.get("/api/tags", timeout=timeout)
+            resp = self._client.get("/api/tags", timeout=2.0)
             return resp.status_code == 200
         except Exception as exc:
             logger.debug("Ollama health check failed at %s: %s", self._host, exc)

--- a/src/openjarvis/engine/ollama.py
+++ b/src/openjarvis/engine/ollama.py
@@ -134,7 +134,15 @@ class OllamaEngine(AsyncHTTPEngineMixin, InferenceEngine):
         # the async stream path with no real Ollama server. ``None`` in production so
         # httpx uses its default networking.
         self._async_transport: httpx.AsyncBaseTransport | None = None
-        self._client = httpx.Client(base_url=self._host, timeout=timeout)
+        # Do not inherit proxy/environment transport settings for LAN Ollama.
+        # On macOS, httpx trust_env=True can route private-subnet requests
+        # through system proxy discovery and intermittently time out even when
+        # direct curl and trust_env=False succeed.
+        self._client = httpx.Client(
+            base_url=self._host,
+            timeout=timeout,
+            trust_env=False,
+        )
         # Last stream usage — captured from Ollama's final chunk
         self._last_stream_usage: Dict[str, int] = {}
 
@@ -540,7 +548,12 @@ class OllamaEngine(AsyncHTTPEngineMixin, InferenceEngine):
 
     def health(self) -> bool:
         try:
-            resp = self._client.get("/api/tags", timeout=2.0)
+            # LAN-hosted Ollama can take longer than localhost to accept the
+            # first connection, especially while models/Rust extensions are
+            # warming. Keep the probe short enough for discovery, but not so
+            # short that `serve` rejects a reachable subnet Ollama instance.
+            timeout = float(os.environ.get("OPENJARVIS_OLLAMA_HEALTH_TIMEOUT", "10"))
+            resp = self._client.get("/api/tags", timeout=timeout)
             return resp.status_code == 200
         except Exception as exc:
             logger.debug("Ollama health check failed at %s: %s", self._host, exc)

--- a/src/openjarvis/sdk.py
+++ b/src/openjarvis/sdk.py
@@ -499,9 +499,14 @@ class Jarvis:
                         expand_account_sources,
                     )
 
+                    configured_accounts = dc.accounts
+                    enabled_accounts = self._config.connectors.google.account_scope(
+                        configured_accounts
+                    )
                     section_sources[s] = expand_account_sources(
                         sc.sources,
-                        self._config.connectors.google.enabled_aliases(dc.accounts),
+                        enabled_accounts,
+                        is_account_enabled=self._config.connectors.google.is_enabled,
                     )
             agent_kwargs.update(
                 {

--- a/src/openjarvis/sdk.py
+++ b/src/openjarvis/sdk.py
@@ -501,7 +501,7 @@ class Jarvis:
 
                     section_sources[s] = expand_account_sources(
                         sc.sources,
-                        dc.accounts,
+                        self._config.connectors.google.enabled_aliases(dc.accounts),
                     )
             agent_kwargs.update(
                 {

--- a/src/openjarvis/sdk.py
+++ b/src/openjarvis/sdk.py
@@ -495,7 +495,14 @@ class Jarvis:
             for s in dc.sections:
                 sc = getattr(dc, s, None)
                 if sc and hasattr(sc, "sources"):
-                    section_sources[s] = sc.sources
+                    from openjarvis.agents.morning_digest import (
+                        expand_account_sources,
+                    )
+
+                    section_sources[s] = expand_account_sources(
+                        sc.sources,
+                        dc.accounts,
+                    )
             agent_kwargs.update(
                 {
                     "persona": dc.persona,

--- a/src/openjarvis/server/auth_middleware.py
+++ b/src/openjarvis/server/auth_middleware.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 import logging
 import os
+import re
 import secrets
 
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -78,6 +79,14 @@ class AuthMiddleware(BaseHTTPMiddleware):
         by unauthenticated clients, so it is gated alongside ``/v1`` and
         ``/api``. ``/health`` stays open for liveness probes.
         """
+        # OAuth providers cannot attach OpenJarvis's bearer key when they
+        # redirect the browser back to us.  The callback is nevertheless
+        # authenticated by a short-lived, one-time, connector-bound ``state``
+        # token issued from the protected start endpoint.  Keep only the
+        # callback public; initiation and every other connector route remain
+        # behind API-key auth.
+        if re.fullmatch(r"/v1/connectors/[^/]+/oauth/callback", path):
+            return False
         return (
             path.startswith("/v1/")
             or path.startswith("/api/")

--- a/src/openjarvis/server/connectors_router.py
+++ b/src/openjarvis/server/connectors_router.py
@@ -901,25 +901,12 @@ def create_connectors_router():
                 ),
             )
 
-        _revoke_oauth_states(tuple(target_ids), account)
-
-        # Only revoke/delete credentials after the worker has relinquished
-        # the old connection.  A timeout must leave the connector usable and
-        # reject reconnect attempts, rather than silently switching source
-        # state underneath a still-running writer.
-        try:
-            for instance in targets.values():
-                instance.disconnect()
-            if provider and provider.name == "google":
-                from openjarvis.connectors.oauth import delete_provider_tokens
-
-                delete_provider_tokens(provider, account=account)
-        except Exception as exc:
-            raise HTTPException(status_code=500, detail=str(exc))
         # A source can be shared by multiple connector implementations
         # (Gmail OAuth and Gmail IMAP both write source='gmail'). Preserve it
-        # while another owner is connected; otherwise purge it only after the
-        # in-flight writer has stopped.
+        # while another owner is connected.  Determine ownership before
+        # disconnecting the target provider so cleanup can fail without
+        # destroying credentials and trapping the user in a half-disconnected
+        # state.
         purge_sources = {
             source
             for target_id, instance in targets.items()
@@ -927,7 +914,7 @@ def create_connectors_router():
         }
         if not account:
             for other_id in ConnectorRegistry.keys():
-                if other_id == connector_id:
+                if other_id in target_ids:
                     continue
                 other_cls = ConnectorRegistry.get(other_id)
                 shared = purge_sources.intersection(
@@ -972,8 +959,22 @@ def create_connectors_router():
             )
             raise HTTPException(
                 status_code=500,
-                detail=f"Disconnected, but indexed-data cleanup failed: {exc}",
+                detail=f"Disconnect cleanup failed; credentials were preserved: {exc}",
             )
+
+        # Revoke credentials only after all indexed data and checkpoints have
+        # been cleaned successfully.  A cleanup error must leave the existing
+        # connection intact so the operation can be retried safely.
+        _revoke_oauth_states(tuple(target_ids), account)
+        try:
+            for instance in targets.values():
+                instance.disconnect()
+            if provider and provider.name == "google":
+                from openjarvis.connectors.oauth import delete_provider_tokens
+
+                delete_provider_tokens(provider, account=account)
+        except Exception as exc:
+            raise HTTPException(status_code=500, detail=str(exc))
 
         with _sync_lock:
             for sync_key in sync_keys.values():

--- a/src/openjarvis/server/connectors_router.py
+++ b/src/openjarvis/server/connectors_router.py
@@ -153,6 +153,14 @@ def create_connectors_router():
                 "Named account profiles are currently supported only for Google "
                 "connectors.",
             )
+        if alias:
+            from openjarvis.core.config import load_config
+
+            if not load_config().connectors.google.is_enabled(alias):
+                raise HTTPException(
+                    403,
+                    f"Google account profile '{alias}' is disabled in config.toml",
+                )
         return alias
 
     def _normalise_request_account(

--- a/src/openjarvis/server/connectors_router.py
+++ b/src/openjarvis/server/connectors_router.py
@@ -955,9 +955,9 @@ def create_connectors_router():
                     old_checkpoints = {
                         key: engine.get_checkpoint(key) for key in sync_keys.values()
                     }
-                    for key in sync_keys.values():
-                        engine.reset_checkpoint(key)
                     try:
+                        for key in sync_keys.values():
+                            engine.reset_checkpoint(key)
                         if not account and provider and provider.name == "google":
                             store.delete_unscoped_sources_with_attribution(
                                 purge_sources,

--- a/src/openjarvis/server/connectors_router.py
+++ b/src/openjarvis/server/connectors_router.py
@@ -912,6 +912,7 @@ def create_connectors_router():
             for target_id, instance in targets.items()
             for source in _knowledge_sources(target_id, instance)
         }
+        attributed_shared_sources: Dict[str, str] = {}
         if not account:
             for other_id in ConnectorRegistry.keys():
                 if other_id in target_ids:
@@ -924,6 +925,19 @@ def create_connectors_router():
                     continue
                 try:
                     if _get_or_create(other_id).is_connected():
+                        # Gmail OAuth and Gmail IMAP intentionally share the
+                        # ``gmail`` source.  Preserve ambiguous IMAP rows, but
+                        # still remove rows that positively identify the
+                        # disconnecting OAuth connector in metadata.
+                        for source in shared:
+                            provenance_owners = [
+                                target_id
+                                for target_id, target in targets.items()
+                                if target_id == source
+                                and source in _knowledge_sources(target_id, target)
+                            ]
+                            if len(provenance_owners) == 1:
+                                attributed_shared_sources[source] = provenance_owners[0]
                         purge_sources.difference_update(shared)
                 except Exception:
                     # If ownership cannot be established safely, retain data.
@@ -944,10 +958,16 @@ def create_connectors_router():
                     for key in sync_keys.values():
                         engine.reset_checkpoint(key)
                     try:
-                        store.delete_by_sources(
-                            purge_sources,
-                            account=account or None,
-                        )
+                        if not account and attributed_shared_sources:
+                            store.delete_unscoped_sources_with_attribution(
+                                purge_sources,
+                                attributed_shared_sources,
+                            )
+                        else:
+                            store.delete_by_sources(
+                                purge_sources,
+                                account=account or None,
+                            )
                     except Exception:
                         for key, checkpoint in old_checkpoints.items():
                             engine.restore_checkpoint(key, checkpoint)

--- a/src/openjarvis/server/connectors_router.py
+++ b/src/openjarvis/server/connectors_router.py
@@ -332,8 +332,7 @@ def create_connectors_router():
     # instance, checkpoint, and source-ownership state. Serializing them
     # globally keeps connect/disconnect/manual-sync decisions atomic,
     # including ownership checks for sources shared by multiple connectors.
-    _lifecycle_lock = threading.RLock()
-    _lifecycle_async_lock = asyncio.Lock()
+    _lifecycle_lock = threading.Lock()
     _oauth_state_lock = threading.Lock()
     _oauth_states: Dict[str, tuple[str, str, float]] = {}
     _OAUTH_STATE_TTL_SECONDS = 600.0
@@ -426,16 +425,18 @@ def create_connectors_router():
     def _serialized_async(func):
         @wraps(func)
         async def wrapped(*args, **kwargs):
-            async with _lifecycle_async_lock:
+            # ``threading.RLock`` is unsafe here: concurrent ASGI coroutines
+            # run on the same event-loop thread and therefore re-enter it.
+            # A plain cross-thread lock plus non-blocking async polling works
+            # both in production's single loop and TestClient's multi-thread
+            # portals, while cancellation during the wait cannot orphan an
+            # acquired lock in a worker thread.
+            while not _lifecycle_lock.acquire(blocking=False):
+                await asyncio.sleep(0.01)
+            try:
                 return await func(*args, **kwargs)
-
-        return wrapped
-
-    def _serialized_sync(func):
-        @wraps(func)
-        def wrapped(*args, **kwargs):
-            with _lifecycle_lock:
-                return func(*args, **kwargs)
+            finally:
+                _lifecycle_lock.release()
 
         return wrapped
 
@@ -463,7 +464,6 @@ def create_connectors_router():
             return "Connection timed out."
         return raw
 
-    @_serialized_sync
     def _start_sync(connector_id: str, instance: Any, account: str = "") -> str:
         """Spawn a background sync; returns ``"started"`` or ``"already_syncing"``.
 
@@ -799,7 +799,14 @@ def create_connectors_router():
         # immediately — the user shouldn't have to click "Sync Now".
         sync_status: Optional[str] = None
         if instance.is_connected():
-            sync_status = _start_sync(connector_id, instance, account)
+            from starlette.concurrency import run_in_threadpool
+
+            sync_status = await run_in_threadpool(
+                _start_sync,
+                connector_id,
+                instance,
+                account,
+            )
 
         return {
             "connector_id": connector_id,
@@ -1145,8 +1152,8 @@ def create_connectors_router():
         )
 
     @router.post("/{connector_id}/sync")
-    @_serialized_sync
-    def trigger_sync(connector_id: str, account: str = "") -> Dict[str, Any]:
+    @_serialized_async
+    async def trigger_sync(connector_id: str, account: str = "") -> Dict[str, Any]:
         """Trigger a sync in the background and return immediately."""
         _ensure_connectors_registered()
         if not ConnectorRegistry.contains(connector_id):
@@ -1162,7 +1169,9 @@ def create_connectors_router():
                 status_code=400,
                 detail=f"Connector '{connector_id}' is not connected",
             )
-        status = _start_sync(connector_id, inst, account)
+        from starlette.concurrency import run_in_threadpool
+
+        status = await run_in_threadpool(_start_sync, connector_id, inst, account)
         return {
             "connector_id": connector_id,
             "account": account or None,

--- a/src/openjarvis/server/connectors_router.py
+++ b/src/openjarvis/server/connectors_router.py
@@ -1019,7 +1019,7 @@ def create_connectors_router():
             last_sync_str = None
 
         # Determine effective state
-        if _disconnect_pending(connector_id):
+        if _disconnect_pending(sync_key):
             effective_state = "stopping"
         elif is_bg_running:
             effective_state = "syncing"

--- a/src/openjarvis/server/connectors_router.py
+++ b/src/openjarvis/server/connectors_router.py
@@ -138,7 +138,12 @@ def create_connectors_router():
     def _instance_key(connector_id: str, account: str = "") -> str:
         return f"{connector_id}:{account}" if account else connector_id
 
-    def _normalise_account(connector_id: str, account: str = "") -> str:
+    def _normalise_account(
+        connector_id: str,
+        account: str = "",
+        *,
+        allow_disabled: bool = False,
+    ) -> str:
         """Validate account aliases and reject false isolation for other providers."""
         from openjarvis.connectors.oauth import (
             get_provider_for_connector,
@@ -153,7 +158,7 @@ def create_connectors_router():
                 "Named account profiles are currently supported only for Google "
                 "connectors.",
             )
-        if alias:
+        if alias and not allow_disabled:
             from openjarvis.core.config import load_config
 
             if not load_config().connectors.google.is_enabled(alias):
@@ -360,6 +365,18 @@ def create_connectors_router():
         if stored_connector != connector_id or deadline <= time.monotonic():
             raise HTTPException(400, "Invalid or expired OAuth state")
         return account
+
+    def _revoke_oauth_states(connector_ids: tuple[str, ...], account: str) -> None:
+        """Invalidate pending callbacks for a disconnected provider profile."""
+        connector_set = set(connector_ids)
+        with _oauth_state_lock:
+            stale = [
+                state
+                for state, (connector_id, state_account, _) in _oauth_states.items()
+                if connector_id in connector_set and state_account == account
+            ]
+            for state in stale:
+                _oauth_states.pop(state, None)
 
     def _disconnect_pending(sync_key: str) -> bool:
         """Whether a prior disconnect is waiting for its worker to stop."""
@@ -658,6 +675,12 @@ def create_connectors_router():
         if directive is not None:
             return directive
 
+        from openjarvis.connectors.oauth import get_provider_for_connector
+
+        provider = get_provider_for_connector(connector_id)
+        if provider is not None and (req.code or req.token):
+            _reject_active_provider_syncs(tuple(provider.connector_ids), account)
+
         instance = _get_or_create(connector_id, account)
 
         try:
@@ -794,7 +817,11 @@ def create_connectors_router():
                 status_code=404,
                 detail=f"Connector '{connector_id}' not found",
             )
-        account = _normalise_account(connector_id, account)
+        account = _normalise_account(
+            connector_id,
+            account,
+            allow_disabled=True,
+        )
         from openjarvis.connectors.oauth import get_provider_for_connector
 
         provider = get_provider_for_connector(connector_id)
@@ -849,6 +876,8 @@ def create_connectors_router():
                     "indexed content was not purged"
                 ),
             )
+
+        _revoke_oauth_states(tuple(target_ids), account)
 
         # Only revoke/delete credentials after the worker has relinquished
         # the old connection.  A timeout must leave the connector usable and
@@ -1019,7 +1048,10 @@ def create_connectors_router():
 
         _ensure_connectors_registered()
 
-        account_alias = _consume_oauth_state(connector_id, state)
+        account_alias = _normalise_account(
+            connector_id,
+            _consume_oauth_state(connector_id, state),
+        )
         _reject_pending_disconnect(_instance_key(connector_id, account_alias))
 
         if error:

--- a/src/openjarvis/server/connectors_router.py
+++ b/src/openjarvis/server/connectors_router.py
@@ -101,6 +101,8 @@ try:
         host: Optional[str] = None
         port: Optional[int] = None
         security: Optional[str] = None
+        account: Optional[str] = None
+        profile: Optional[str] = None
 
 except ImportError:
     ConnectRequest = None  # type: ignore[assignment,misc]
@@ -131,12 +133,19 @@ def create_connectors_router():
     # Helpers
     # ------------------------------------------------------------------
 
-    def _get_or_create(connector_id: str) -> Any:
+    def _instance_key(connector_id: str, account: str = "") -> str:
+        return f"{connector_id}:{account}" if account else connector_id
+
+    def _get_or_create(connector_id: str, account: str = "") -> Any:
         """Return a cached connector instance, creating it if needed."""
-        if connector_id not in _instances:
+        key = _instance_key(connector_id, account)
+        if key not in _instances:
             cls = ConnectorRegistry.get(connector_id)
-            _instances[connector_id] = cls()
-        return _instances[connector_id]
+            try:
+                _instances[key] = cls(account=account) if account else cls()
+            except TypeError:
+                _instances[key] = cls()
+        return _instances[key]
 
     def _connector_summary(connector_id: str, instance: Any) -> Dict[str, Any]:
         """Build the dict returned by GET /connectors."""
@@ -222,18 +231,28 @@ def create_connectors_router():
                 ),
             )
 
-        save_client_credentials(provider, client_id, client_secret)
+        account = (req.account or req.profile or "").strip()
+        save_client_credentials(
+            provider,
+            client_id,
+            client_secret,
+            account=account,
+        )
         # Cached instances may have resolved a stale credentials path before
         # these client creds existed; drop them so /oauth/callback rebuilds
         # them against the freshly written files.
         for cid in provider.connector_ids:
-            _instances.pop(cid, None)
+            _instances.pop(_instance_key(cid, account), None)
+
+        account_query = f"?account={account}" if account else ""
 
         return {
             "connector_id": connector_id,
             "connected": False,
             "status": "oauth_required",
-            "oauth_start": f"/v1/connectors/{connector_id}/oauth/start",
+            "oauth_start": (
+                f"/v1/connectors/{connector_id}/oauth/start{account_query}"
+            ),
             "sync_status": None,
         }
 
@@ -255,23 +274,23 @@ def create_connectors_router():
     # including ownership checks for sources shared by multiple connectors.
     _lifecycle_lock = threading.RLock()
 
-    def _disconnect_pending(connector_id: str) -> bool:
+    def _disconnect_pending(sync_key: str) -> bool:
         """Whether a prior disconnect is waiting for its worker to stop."""
         with _sync_lock:
-            cancel_event = _sync_cancel_events.get(connector_id)
+            cancel_event = _sync_cancel_events.get(sync_key)
             return (
-                connector_id in _sync_threads
+                sync_key in _sync_threads
                 and cancel_event is not None
                 and cancel_event.is_set()
             )
 
-    def _reject_pending_disconnect(connector_id: str) -> None:
+    def _reject_pending_disconnect(sync_key: str) -> None:
         """Prevent credential/source changes while an old worker still owns them."""
-        if _disconnect_pending(connector_id):
+        if _disconnect_pending(sync_key):
             raise HTTPException(
                 status_code=409,
                 detail=(
-                    f"Sync for '{connector_id}' is still stopping; "
+                    f"Sync for '{sync_key}' is still stopping; "
                     "retry disconnect before reconnecting or syncing"
                 ),
             )
@@ -293,15 +312,15 @@ def create_connectors_router():
         return wrapped
 
     def _publish_sync_state(
-        connector_id: str,
+        sync_key: str,
         generation: int,
         state: Dict[str, Any],
     ) -> bool:
         """Publish worker state only while it still owns this lifecycle."""
         with _sync_lock:
-            if _sync_generations.get(connector_id, 0) != generation:
+            if _sync_generations.get(sync_key, 0) != generation:
                 return False
-            _sync_state[connector_id] = state
+            _sync_state[sync_key] = state
             return True
 
     def _translate_sync_error(raw: str) -> str:
@@ -317,7 +336,7 @@ def create_connectors_router():
         return raw
 
     @_serialized_sync
-    def _start_sync(connector_id: str, instance: Any) -> str:
+    def _start_sync(connector_id: str, instance: Any, account: str = "") -> str:
         """Spawn a background sync; returns ``"started"`` or ``"already_syncing"``.
 
         Records baseline items in ``_sync_state`` so GET /{id}/sync polls
@@ -326,15 +345,16 @@ def create_connectors_router():
         inline. Both POST /connect (auto-ingest) and POST /sync (manual)
         route through here so they share guard, state, and error handling.
         """
+        sync_key = _instance_key(connector_id, account)
         with _sync_lock:
-            existing = _sync_threads.get(connector_id)
+            existing = _sync_threads.get(sync_key)
             if existing and existing.is_alive():
                 return "already_syncing"
             # Detect a disconnect that completes while the checkpoint baseline
             # below is being read, before this start has published its thread.
             # Without a generation token that race can launch a writer after
             # disconnect has already purged the connector's indexed content.
-            start_generation = _sync_generations.get(connector_id, 0)
+            start_generation = _sync_generations.get(sync_key, 0)
 
         # Snapshot the prior checkpoint count so the GET handler can
         # report "X new this run" without each client tracking it.
@@ -348,7 +368,7 @@ def create_connectors_router():
                 with SyncEngine(
                     pipeline=IngestionPipeline(store=store),
                 ) as engine:
-                    cp = engine.get_checkpoint(connector_id)
+                    cp = engine.get_checkpoint(sync_key)
             if cp and cp.get("items_synced") is not None:
                 baseline_items = int(cp["items_synced"])
         except Exception:  # noqa: BLE001
@@ -368,9 +388,9 @@ def create_connectors_router():
                     ) as engine:
                         engine.sync(instance, cancel_event=cancel_event)
                 final_state = "cancelled" if cancel_event.is_set() else "complete"
-                logger.info("Sync %s for %s", final_state, connector_id)
+                logger.info("Sync %s for %s", final_state, sync_key)
                 _publish_sync_state(
-                    connector_id,
+                    sync_key,
                     start_generation,
                     {
                         "state": final_state,
@@ -381,7 +401,7 @@ def create_connectors_router():
             except Exception as exc:
                 if cancel_event.is_set():
                     _publish_sync_state(
-                        connector_id,
+                        sync_key,
                         start_generation,
                         {
                             "state": "cancelled",
@@ -391,9 +411,9 @@ def create_connectors_router():
                     )
                     return
                 error_msg = _translate_sync_error(str(exc))
-                logger.error("Sync failed for %s: %s", connector_id, error_msg)
+                logger.error("Sync failed for %s: %s", sync_key, error_msg)
                 _publish_sync_state(
-                    connector_id,
+                    sync_key,
                     start_generation,
                     {
                         "state": "error",
@@ -402,20 +422,20 @@ def create_connectors_router():
                     },
                 )
 
-        t = threading.Thread(target=_run_sync, daemon=True)
+        t = threading.Thread(target=_run_sync, daemon=True, name=f"sync-{sync_key}")
         with _sync_lock:
-            if _sync_generations.get(connector_id, 0) != start_generation:
+            if _sync_generations.get(sync_key, 0) != start_generation:
                 return "cancelled"
-            existing = _sync_threads.get(connector_id)
+            existing = _sync_threads.get(sync_key)
             if existing and existing.is_alive():
                 return "already_syncing"
-            _sync_state[connector_id] = {
+            _sync_state[sync_key] = {
                 "state": "syncing",
                 "error": None,
                 "baseline_items": baseline_items,
             }
-            _sync_cancel_events[connector_id] = cancel_event
-            _sync_threads[connector_id] = t
+            _sync_cancel_events[sync_key] = cancel_event
+            _sync_threads[sync_key] = t
             t.start()
         return "started"
 
@@ -509,8 +529,9 @@ def create_connectors_router():
                 status_code=404,
                 detail=f"Connector '{connector_id}' not found",
             )
-        _reject_pending_disconnect(connector_id)
-        instance = _get_or_create(connector_id)
+        account = (req.account or req.profile or "").strip()
+        _reject_pending_disconnect(_instance_key(connector_id, account))
+        instance = _get_or_create(connector_id, account)
 
         try:
             auth_type = getattr(instance, "auth_type", "unknown")
@@ -627,10 +648,11 @@ def create_connectors_router():
         # immediately — the user shouldn't have to click "Sync Now".
         sync_status: Optional[str] = None
         if instance.is_connected():
-            sync_status = _start_sync(connector_id, instance)
+            sync_status = _start_sync(connector_id, instance, account)
 
         return {
             "connector_id": connector_id,
+            "account": account or None,
             "connected": instance.is_connected(),
             "status": "connected" if instance.is_connected() else "pending",
             "sync_status": sync_status,
@@ -638,7 +660,7 @@ def create_connectors_router():
 
     @router.post("/{connector_id}/disconnect")
     @_serialized_async
-    async def disconnect_connector(connector_id: str):
+    async def disconnect_connector(connector_id: str, account: str = ""):
         """Disconnect a connector and clear its credentials."""
         _ensure_connectors_registered()
         if not ConnectorRegistry.contains(connector_id):
@@ -646,16 +668,18 @@ def create_connectors_router():
                 status_code=404,
                 detail=f"Connector '{connector_id}' not found",
             )
-        instance = _get_or_create(connector_id)
+        account = account.strip()
+        sync_key = _instance_key(connector_id, account)
+        instance = _get_or_create(connector_id, account)
         with _sync_lock:
-            _sync_generations[connector_id] = _sync_generations.get(connector_id, 0) + 1
-            cancel_event = _sync_cancel_events.get(connector_id)
-            sync_thread = _sync_threads.get(connector_id)
+            _sync_generations[sync_key] = _sync_generations.get(sync_key, 0) + 1
+            cancel_event = _sync_cancel_events.get(sync_key)
+            sync_thread = _sync_threads.get(sync_key)
             if cancel_event is not None:
                 cancel_event.set()
             if sync_thread is not None and sync_thread.is_alive():
-                previous_state = _sync_state.get(connector_id, {})
-                _sync_state[connector_id] = {
+                previous_state = _sync_state.get(sync_key, {})
+                _sync_state[sync_key] = {
                     **previous_state,
                     "state": "stopping",
                     "error": None,
@@ -667,7 +691,7 @@ def create_connectors_router():
             raise HTTPException(
                 status_code=409,
                 detail=(
-                    f"Sync for '{connector_id}' is still stopping; "
+                    f"Sync for '{sync_key}' is still stopping; "
                     "indexed content was not purged"
                 ),
             )
@@ -680,25 +704,27 @@ def create_connectors_router():
             instance.disconnect()
         except Exception as exc:
             raise HTTPException(status_code=500, detail=str(exc))
-
         # A source can be shared by multiple connector implementations
         # (Gmail OAuth and Gmail IMAP both write source='gmail'). Preserve it
         # while another owner is connected; otherwise purge it only after the
         # in-flight writer has stopped.
         purge_sources = set(_knowledge_sources(connector_id, instance))
-        for other_id in ConnectorRegistry.keys():
-            if other_id == connector_id:
-                continue
-            other_cls = ConnectorRegistry.get(other_id)
-            shared = purge_sources.intersection(_knowledge_sources(other_id, other_cls))
-            if not shared:
-                continue
-            try:
-                if _get_or_create(other_id).is_connected():
+        if not account:
+            for other_id in ConnectorRegistry.keys():
+                if other_id == connector_id:
+                    continue
+                other_cls = ConnectorRegistry.get(other_id)
+                shared = purge_sources.intersection(
+                    _knowledge_sources(other_id, other_cls)
+                )
+                if not shared:
+                    continue
+                try:
+                    if _get_or_create(other_id).is_connected():
+                        purge_sources.difference_update(shared)
+                except Exception:
+                    # If ownership cannot be established safely, retain data.
                     purge_sources.difference_update(shared)
-            except Exception:
-                # If ownership cannot be established safely, retain data.
-                purge_sources.difference_update(shared)
 
         try:
             from openjarvis.connectors.pipeline import IngestionPipeline
@@ -709,33 +735,37 @@ def create_connectors_router():
                 with SyncEngine(
                     pipeline=IngestionPipeline(store=store),
                 ) as engine:
-                    old_checkpoint = engine.get_checkpoint(connector_id)
-                    engine.reset_checkpoint(connector_id)
+                    old_checkpoint = engine.get_checkpoint(sync_key)
+                    engine.reset_checkpoint(sync_key)
                     try:
-                        store.delete_by_sources(purge_sources)
+                        store.delete_by_sources(
+                            purge_sources,
+                            account=account or None,
+                        )
                     except Exception:
-                        engine.restore_checkpoint(connector_id, old_checkpoint)
+                        engine.restore_checkpoint(sync_key, old_checkpoint)
                         raise
         except Exception as exc:  # noqa: BLE001
-            logger.exception("Disconnect cleanup failed for %s", connector_id)
+            logger.exception("Disconnect cleanup failed for %s", sync_key)
             raise HTTPException(
                 status_code=500,
                 detail=f"Disconnected, but indexed-data cleanup failed: {exc}",
             )
 
         with _sync_lock:
-            _sync_cancel_events.pop(connector_id, None)
-            _sync_threads.pop(connector_id, None)
-            _sync_state.pop(connector_id, None)
-
+            _sync_cancel_events.pop(sync_key, None)
+            _sync_threads.pop(sync_key, None)
+            _sync_state.pop(sync_key, None)
+        _instances.pop(sync_key, None)
         return {
             "connector_id": connector_id,
+            "account": account or None,
             "connected": False,
             "status": "disconnected",
         }
 
     @router.get("/{connector_id}/oauth/start")
-    async def oauth_start(connector_id: str, request: Request):
+    async def oauth_start(connector_id: str, request: Request, account: str = ""):
         """Redirect to the OAuth provider's consent page.
 
         The callback will come back to /v1/connectors/{id}/oauth/callback.
@@ -755,7 +785,8 @@ def create_connectors_router():
         if not provider:
             raise HTTPException(400, f"No OAuth provider for '{connector_id}'")
 
-        creds = get_client_credentials(provider)
+        account = account.strip()
+        creds = get_client_credentials(provider, account=account)
         if not creds:
             raise HTTPException(
                 400,
@@ -775,6 +806,8 @@ def create_connectors_router():
             "scope": " ".join(provider.scopes),
             **provider.extra_auth_params,
         }
+        if account:
+            params["state"] = account
         auth_url = f"{provider.auth_endpoint}?{urlencode(params)}"
 
         from fastapi.responses import RedirectResponse
@@ -788,12 +821,14 @@ def create_connectors_router():
         request: Request,
         code: str = "",
         error: str = "",
+        state: str = "",
+        account: str = "",
     ):
         """Handle OAuth callback from the provider."""
         from fastapi.responses import HTMLResponse
 
         from openjarvis.connectors.oauth import (
-            _CONNECTORS_DIR,
+            _credential_paths_for_provider,
             _exchange_token,
             get_client_credentials,
             get_provider_for_connector,
@@ -825,7 +860,8 @@ def create_connectors_router():
         if not provider:
             raise HTTPException(400, f"No OAuth provider for '{connector_id}'")
 
-        creds = get_client_credentials(provider)
+        account_alias = (account or state or "").strip()
+        creds = get_client_credentials(provider, account=account_alias)
         if not creds:
             raise HTTPException(400, "No client credentials configured")
 
@@ -859,11 +895,11 @@ def create_connectors_router():
             "client_secret": client_secret,
         }
 
-        for filename in provider.credential_files:
-            save_tokens(str(_CONNECTORS_DIR / filename), payload)
+        for path in _credential_paths_for_provider(provider, account=account_alias):
+            save_tokens(str(path), payload)
 
         # Clear cached instance so it picks up new credentials
-        _instances.pop(connector_id, None)
+        _instances.pop(_instance_key(connector_id, account_alias), None)
 
         _style = "font-family:system-ui;text-align:center;padding:60px"
         return HTMLResponse(
@@ -878,7 +914,7 @@ def create_connectors_router():
 
     @router.post("/{connector_id}/sync")
     @_serialized_sync
-    def trigger_sync(connector_id: str) -> Dict[str, Any]:
+    def trigger_sync(connector_id: str, account: str = "") -> Dict[str, Any]:
         """Trigger a sync in the background and return immediately."""
         _ensure_connectors_registered()
         if not ConnectorRegistry.contains(connector_id):
@@ -886,18 +922,23 @@ def create_connectors_router():
                 status_code=404,
                 detail=f"Connector '{connector_id}' not found",
             )
-        inst = _get_or_create(connector_id)
-        _reject_pending_disconnect(connector_id)
+        account = account.strip()
+        _reject_pending_disconnect(_instance_key(connector_id, account))
+        inst = _get_or_create(connector_id, account)
         if not inst.is_connected():
             raise HTTPException(
                 status_code=400,
                 detail=f"Connector '{connector_id}' is not connected",
             )
-        status = _start_sync(connector_id, inst)
-        return {"connector_id": connector_id, "status": status}
+        status = _start_sync(connector_id, inst, account)
+        return {
+            "connector_id": connector_id,
+            "account": account or None,
+            "status": status,
+        }
 
     @router.get("/{connector_id}/sync")
-    async def sync_status(connector_id: str):
+    async def sync_status(connector_id: str, account: str = ""):
         """Return the current sync status for a connector."""
         _ensure_connectors_registered()
         if not ConnectorRegistry.contains(connector_id):
@@ -905,15 +946,17 @@ def create_connectors_router():
                 status_code=404,
                 detail=f"Connector '{connector_id}' not found",
             )
-        instance = _get_or_create(connector_id)
+        account = account.strip()
+        instance = _get_or_create(connector_id, account)
         try:
             status = instance.sync_status()
         except Exception as exc:
             raise HTTPException(status_code=500, detail=str(exc))
 
         # Override with router-level sync state (background thread tracking)
-        bg = _sync_state.get(connector_id, {})
-        bg_thread = _sync_threads.get(connector_id)
+        sync_key = _instance_key(connector_id, account)
+        bg = _sync_state.get(sync_key, {})
+        bg_thread = _sync_threads.get(sync_key)
         is_bg_running = bg_thread is not None and bg_thread.is_alive()
 
         # Fall back to the SyncEngine's persistent checkpoint for items_synced
@@ -933,16 +976,20 @@ def create_connectors_router():
                 with SyncEngine(
                     pipeline=IngestionPipeline(store=store),
                 ) as engine:
-                    checkpoint = engine.get_checkpoint(connector_id)
+                    checkpoint = engine.get_checkpoint(sync_key)
 
                 sources = _knowledge_sources(connector_id, instance)
                 placeholders = ", ".join("?" for _ in sources)
-                row = store._conn.execute(
+                oldest_sql = (
                     "SELECT MIN(timestamp) FROM knowledge_chunks "
                     f"WHERE source IN ({placeholders}) AND timestamp != '' "
-                    "AND deleted_at IS NULL",
-                    sources,
-                ).fetchone()
+                    "AND deleted_at IS NULL"
+                )
+                oldest_params: tuple[Any, ...] = tuple(sources)
+                if account:
+                    oldest_sql += " AND json_extract(metadata, '$.account') = ?"
+                    oldest_params = (*oldest_params, account)
+                row = store._conn.execute(oldest_sql, oldest_params).fetchone()
                 if row is not None and row[0]:
                     oldest_item_date = str(row[0])
         except Exception:  # noqa: BLE001

--- a/src/openjarvis/server/connectors_router.py
+++ b/src/openjarvis/server/connectors_router.py
@@ -434,7 +434,22 @@ def create_connectors_router():
             while not _lifecycle_lock.acquire(blocking=False):
                 await asyncio.sleep(0.01)
             try:
-                return await func(*args, **kwargs)
+                operation = asyncio.create_task(func(*args, **kwargs))
+                cancelled = False
+                while True:
+                    try:
+                        result = await asyncio.shield(operation)
+                        break
+                    except asyncio.CancelledError:
+                        if operation.done():
+                            raise
+                        # Starlette's threadpool work cannot be cancelled once
+                        # running. Keep the lifecycle lock until it drains so a
+                        # disconnected credential cannot be recreated later.
+                        cancelled = True
+                if cancelled:
+                    raise asyncio.CancelledError
+                return result
             finally:
                 _lifecycle_lock.release()
 
@@ -841,7 +856,7 @@ def create_connectors_router():
         # provider-level lifecycle and clean every primitive atomically.
         target_ids = (
             tuple(provider.connector_ids)
-            if account and provider and provider.name == "google"
+            if provider and provider.name == "google"
             else (connector_id,)
         )
         targets = {
@@ -895,6 +910,10 @@ def create_connectors_router():
         try:
             for instance in targets.values():
                 instance.disconnect()
+            if provider and provider.name == "google":
+                from openjarvis.connectors.oauth import delete_provider_tokens
+
+                delete_provider_tokens(provider, account=account)
         except Exception as exc:
             raise HTTPException(status_code=500, detail=str(exc))
         # A source can be shared by multiple connector implementations

--- a/src/openjarvis/server/connectors_router.py
+++ b/src/openjarvis/server/connectors_router.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import logging
+import secrets
 import threading
+import time
 from functools import wraps
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
@@ -136,6 +138,37 @@ def create_connectors_router():
     def _instance_key(connector_id: str, account: str = "") -> str:
         return f"{connector_id}:{account}" if account else connector_id
 
+    def _normalise_account(connector_id: str, account: str = "") -> str:
+        """Validate account aliases and reject false isolation for other providers."""
+        from openjarvis.connectors.oauth import (
+            get_provider_for_connector,
+            normalize_account_alias,
+        )
+
+        alias = normalize_account_alias(account)
+        provider = get_provider_for_connector(connector_id)
+        if alias and (provider is None or provider.name != "google"):
+            raise HTTPException(
+                400,
+                "Named account profiles are currently supported only for Google "
+                "connectors.",
+            )
+        return alias
+
+    def _normalise_request_account(
+        connector_id: str,
+        req: ConnectRequest,
+    ) -> str:
+        """Resolve account/profile aliases without silently choosing one."""
+        account = _normalise_account(connector_id, req.account or "")
+        profile = _normalise_account(connector_id, req.profile or "")
+        if account and profile and account != profile:
+            raise HTTPException(
+                400,
+                "account and profile must name the same alias",
+            )
+        return account or profile
+
     def _get_or_create(connector_id: str, account: str = "") -> Any:
         """Return a cached connector instance, creating it if needed."""
         key = _instance_key(connector_id, account)
@@ -165,13 +198,25 @@ def create_connectors_router():
         except Exception:
             pass
 
-        return {
+        summary = {
             "connector_id": connector_id,
             "display_name": getattr(instance, "display_name", connector_id),
             "auth_type": getattr(instance, "auth_type", "unknown"),
             "connected": instance.is_connected(),
             "chunks": chunks,
         }
+        try:
+            from openjarvis.connectors.oauth import (
+                get_provider_for_connector,
+                list_google_accounts,
+            )
+
+            provider = get_provider_for_connector(connector_id)
+            if provider and provider.name == "google":
+                summary["accounts"] = list_google_accounts()
+        except Exception:  # noqa: BLE001
+            pass
+        return summary
 
     def _maybe_oauth_client_pair(
         connector_id: str, req: ConnectRequest
@@ -231,7 +276,7 @@ def create_connectors_router():
                 ),
             )
 
-        account = (req.account or req.profile or "").strip()
+        account = _normalise_request_account(connector_id, req)
         save_client_credentials(
             provider,
             client_id,
@@ -273,6 +318,39 @@ def create_connectors_router():
     # globally keeps connect/disconnect/manual-sync decisions atomic,
     # including ownership checks for sources shared by multiple connectors.
     _lifecycle_lock = threading.RLock()
+    _oauth_state_lock = threading.Lock()
+    _oauth_states: Dict[str, tuple[str, str, float]] = {}
+    _OAUTH_STATE_TTL_SECONDS = 600.0
+
+    def _issue_oauth_state(connector_id: str, account: str) -> str:
+        """Issue a one-time state token bound to connector and account alias."""
+        now = time.monotonic()
+        state = secrets.token_urlsafe(32)
+        with _oauth_state_lock:
+            expired = [
+                key
+                for key, (_, _, deadline) in _oauth_states.items()
+                if deadline <= now
+            ]
+            for key in expired:
+                _oauth_states.pop(key, None)
+            _oauth_states[state] = (
+                connector_id,
+                account,
+                now + _OAUTH_STATE_TTL_SECONDS,
+            )
+        return state
+
+    def _consume_oauth_state(connector_id: str, state: str) -> str:
+        """Consume a valid one-time OAuth state and return its account alias."""
+        with _oauth_state_lock:
+            stored = _oauth_states.pop(state, None)
+        if stored is None:
+            raise HTTPException(400, "Invalid or expired OAuth state")
+        stored_connector, account, deadline = stored
+        if stored_connector != connector_id or deadline <= time.monotonic():
+            raise HTTPException(400, "Invalid or expired OAuth state")
+        return account
 
     def _disconnect_pending(sync_key: str) -> bool:
         """Whether a prior disconnect is waiting for its worker to stop."""
@@ -293,6 +371,28 @@ def create_connectors_router():
                     f"Sync for '{sync_key}' is still stopping; "
                     "retry disconnect before reconnecting or syncing"
                 ),
+            )
+
+    def _reject_active_provider_syncs(
+        connector_ids: tuple[str, ...],
+        account: str,
+    ) -> None:
+        """Prevent a shared OAuth grant changing under active sync workers."""
+        with _sync_lock:
+            active = [
+                _instance_key(connector_id, account)
+                for connector_id in connector_ids
+                if (
+                    (thread := _sync_threads.get(_instance_key(connector_id, account)))
+                    is not None
+                    and thread.is_alive()
+                )
+            ]
+        if active:
+            raise HTTPException(
+                409,
+                "OAuth credentials cannot be changed while sync is active for: "
+                + ", ".join(active),
             )
 
     def _serialized_async(func):
@@ -464,7 +564,7 @@ def create_connectors_router():
         return {"connectors": results}
 
     @router.get("/{connector_id}")
-    async def connector_detail(connector_id: str):
+    async def connector_detail(connector_id: str, account: str = ""):
         """Return detail for a single connector."""
         _ensure_connectors_registered()
         if not ConnectorRegistry.contains(connector_id):
@@ -472,7 +572,8 @@ def create_connectors_router():
                 status_code=404,
                 detail=f"Connector '{connector_id}' not found",
             )
-        instance = _get_or_create(connector_id)
+        account = _normalise_account(connector_id, account)
+        instance = _get_or_create(connector_id, account)
 
         # Try to get an OAuth URL if applicable; ignore errors for non-OAuth
         # connectors.
@@ -499,7 +600,9 @@ def create_connectors_router():
 
             provider = get_provider_for_connector(connector_id)
             if provider:
-                has_creds = get_client_credentials(provider) is not None
+                has_creds = (
+                    get_client_credentials(provider, account=account) is not None
+                )
                 oauth_setup = {
                     "provider": provider.name,
                     "setup_url": provider.setup_url,
@@ -511,6 +614,7 @@ def create_connectors_router():
 
         return {
             "connector_id": connector_id,
+            "account": account or None,
             "display_name": getattr(instance, "display_name", connector_id),
             "auth_type": getattr(instance, "auth_type", "unknown"),
             "connected": instance.is_connected(),
@@ -529,7 +633,7 @@ def create_connectors_router():
                 status_code=404,
                 detail=f"Connector '{connector_id}' not found",
             )
-        account = (req.account or req.profile or "").strip()
+        account = _normalise_request_account(connector_id, req)
         _reject_pending_disconnect(_instance_key(connector_id, account))
         instance = _get_or_create(connector_id, account)
 
@@ -668,30 +772,58 @@ def create_connectors_router():
                 status_code=404,
                 detail=f"Connector '{connector_id}' not found",
             )
-        account = account.strip()
-        sync_key = _instance_key(connector_id, account)
-        instance = _get_or_create(connector_id, account)
-        with _sync_lock:
-            _sync_generations[sync_key] = _sync_generations.get(sync_key, 0) + 1
-            cancel_event = _sync_cancel_events.get(sync_key)
-            sync_thread = _sync_threads.get(sync_key)
-            if cancel_event is not None:
-                cancel_event.set()
-            if sync_thread is not None and sync_thread.is_alive():
-                previous_state = _sync_state.get(sync_key, {})
-                _sync_state[sync_key] = {
-                    **previous_state,
-                    "state": "stopping",
-                    "error": None,
-                }
+        account = _normalise_account(connector_id, account)
+        from openjarvis.connectors.oauth import get_provider_for_connector
 
-        if sync_thread is not None and sync_thread.is_alive():
-            sync_thread.join(timeout=_SYNC_STOP_TIMEOUT_SECONDS)
-        if sync_thread is not None and sync_thread.is_alive():
+        provider = get_provider_for_connector(connector_id)
+        # A named Google profile uses one shared grant for Gmail, Drive,
+        # Calendar, Contacts, and Tasks.  Removing that file for only the
+        # initiating primitive would silently disconnect its siblings while
+        # leaving their indexed rows/checkpoints behind.  Treat it as one
+        # provider-level lifecycle and clean every primitive atomically.
+        target_ids = (
+            tuple(provider.connector_ids)
+            if account and provider and provider.name == "google"
+            else (connector_id,)
+        )
+        targets = {
+            target_id: _get_or_create(target_id, account)
+            for target_id in target_ids
+            if ConnectorRegistry.contains(target_id)
+        }
+        sync_keys = {
+            target_id: _instance_key(target_id, account) for target_id in targets
+        }
+        threads: Dict[str, Any] = {}
+        with _sync_lock:
+            for sync_key in sync_keys.values():
+                _sync_generations[sync_key] = _sync_generations.get(sync_key, 0) + 1
+                cancel_event = _sync_cancel_events.get(sync_key)
+                sync_thread = _sync_threads.get(sync_key)
+                threads[sync_key] = sync_thread
+                if cancel_event is not None:
+                    cancel_event.set()
+                if sync_thread is not None and sync_thread.is_alive():
+                    previous_state = _sync_state.get(sync_key, {})
+                    _sync_state[sync_key] = {
+                        **previous_state,
+                        "state": "stopping",
+                        "error": None,
+                    }
+
+        for sync_thread in threads.values():
+            if sync_thread is not None and sync_thread.is_alive():
+                sync_thread.join(timeout=_SYNC_STOP_TIMEOUT_SECONDS)
+        still_running = [
+            key
+            for key, sync_thread in threads.items()
+            if sync_thread is not None and sync_thread.is_alive()
+        ]
+        if still_running:
             raise HTTPException(
                 status_code=409,
                 detail=(
-                    f"Sync for '{sync_key}' is still stopping; "
+                    f"Sync for '{', '.join(still_running)}' is still stopping; "
                     "indexed content was not purged"
                 ),
             )
@@ -701,14 +833,19 @@ def create_connectors_router():
         # reject reconnect attempts, rather than silently switching source
         # state underneath a still-running writer.
         try:
-            instance.disconnect()
+            for instance in targets.values():
+                instance.disconnect()
         except Exception as exc:
             raise HTTPException(status_code=500, detail=str(exc))
         # A source can be shared by multiple connector implementations
         # (Gmail OAuth and Gmail IMAP both write source='gmail'). Preserve it
         # while another owner is connected; otherwise purge it only after the
         # in-flight writer has stopped.
-        purge_sources = set(_knowledge_sources(connector_id, instance))
+        purge_sources = {
+            source
+            for target_id, instance in targets.items()
+            for source in _knowledge_sources(target_id, instance)
+        }
         if not account:
             for other_id in ConnectorRegistry.keys():
                 if other_id == connector_id:
@@ -735,37 +872,52 @@ def create_connectors_router():
                 with SyncEngine(
                     pipeline=IngestionPipeline(store=store),
                 ) as engine:
-                    old_checkpoint = engine.get_checkpoint(sync_key)
-                    engine.reset_checkpoint(sync_key)
+                    old_checkpoints = {
+                        key: engine.get_checkpoint(key) for key in sync_keys.values()
+                    }
+                    for key in sync_keys.values():
+                        engine.reset_checkpoint(key)
                     try:
                         store.delete_by_sources(
                             purge_sources,
                             account=account or None,
                         )
                     except Exception:
-                        engine.restore_checkpoint(sync_key, old_checkpoint)
+                        for key, checkpoint in old_checkpoints.items():
+                            engine.restore_checkpoint(key, checkpoint)
                         raise
         except Exception as exc:  # noqa: BLE001
-            logger.exception("Disconnect cleanup failed for %s", sync_key)
+            logger.exception(
+                "Disconnect cleanup failed for %s",
+                ", ".join(sync_keys.values()),
+            )
             raise HTTPException(
                 status_code=500,
                 detail=f"Disconnected, but indexed-data cleanup failed: {exc}",
             )
 
         with _sync_lock:
-            _sync_cancel_events.pop(sync_key, None)
-            _sync_threads.pop(sync_key, None)
-            _sync_state.pop(sync_key, None)
-        _instances.pop(sync_key, None)
+            for sync_key in sync_keys.values():
+                _sync_cancel_events.pop(sync_key, None)
+                _sync_threads.pop(sync_key, None)
+                _sync_state.pop(sync_key, None)
+        for sync_key in sync_keys.values():
+            _instances.pop(sync_key, None)
         return {
             "connector_id": connector_id,
             "account": account or None,
+            "disconnected_connectors": sorted(targets),
             "connected": False,
             "status": "disconnected",
         }
 
     @router.get("/{connector_id}/oauth/start")
-    async def oauth_start(connector_id: str, request: Request, account: str = ""):
+    async def oauth_start(
+        connector_id: str,
+        request: Request,
+        account: str = "",
+        response_mode: str = "redirect",
+    ):
         """Redirect to the OAuth provider's consent page.
 
         The callback will come back to /v1/connectors/{id}/oauth/callback.
@@ -785,7 +937,8 @@ def create_connectors_router():
         if not provider:
             raise HTTPException(400, f"No OAuth provider for '{connector_id}'")
 
-        account = account.strip()
+        account = _normalise_account(connector_id, account)
+        _reject_active_provider_syncs(tuple(provider.connector_ids), account)
         creds = get_client_credentials(provider, account=account)
         if not creds:
             raise HTTPException(
@@ -806,9 +959,13 @@ def create_connectors_router():
             "scope": " ".join(provider.scopes),
             **provider.extra_auth_params,
         }
-        if account:
-            params["state"] = account
+        params["state"] = _issue_oauth_state(connector_id, account)
         auth_url = f"{provider.auth_endpoint}?{urlencode(params)}"
+
+        if response_mode == "json":
+            return {"authorization_url": auth_url}
+        if response_mode != "redirect":
+            raise HTTPException(400, "response_mode must be 'redirect' or 'json'")
 
         from fastapi.responses import RedirectResponse
 
@@ -822,9 +979,10 @@ def create_connectors_router():
         code: str = "",
         error: str = "",
         state: str = "",
-        account: str = "",
     ):
         """Handle OAuth callback from the provider."""
+        from html import escape
+
         from fastapi.responses import HTMLResponse
 
         from openjarvis.connectors.oauth import (
@@ -832,13 +990,15 @@ def create_connectors_router():
             _exchange_token,
             get_client_credentials,
             get_provider_for_connector,
+            google_source_email_from_tokens,
             require_access_token,
             save_tokens,
         )
 
         _ensure_connectors_registered()
 
-        _reject_pending_disconnect(connector_id)
+        account_alias = _consume_oauth_state(connector_id, state)
+        _reject_pending_disconnect(_instance_key(connector_id, account_alias))
 
         if error:
             _style = "font-family:system-ui;text-align:center;padding:60px"
@@ -846,7 +1006,7 @@ def create_connectors_router():
                 content=(
                     f"<html><body style='{_style}'>"
                     f"<h2 style='color:#ef4444'>Authorization Failed</h2>"
-                    f"<p>{error}</p>"
+                    f"<p>{escape(error)}</p>"
                     "<script>setTimeout(()=>window.close(),3000)</script>"
                     "</body></html>"
                 ),
@@ -860,7 +1020,11 @@ def create_connectors_router():
         if not provider:
             raise HTTPException(400, f"No OAuth provider for '{connector_id}'")
 
-        account_alias = (account or state or "").strip()
+        _reject_active_provider_syncs(
+            tuple(provider.connector_ids),
+            account_alias,
+        )
+
         creds = get_client_credentials(provider, account=account_alias)
         if not creds:
             raise HTTPException(400, "No client credentials configured")
@@ -874,13 +1038,15 @@ def create_connectors_router():
                 provider, code, client_id, client_secret, redirect_uri
             )
             access_token = require_access_token(tokens)
-        except Exception as exc:
+        except Exception:
+            logger.exception("OAuth token exchange failed for %s", connector_id)
             _style = "font-family:system-ui;text-align:center;padding:60px"
             return HTMLResponse(
                 content=(
                     f"<html><body style='{_style}'>"
                     f"<h2 style='color:#ef4444'>Token Exchange Failed</h2>"
-                    f"<p>{exc}</p>"
+                    "<p>The provider rejected the token exchange. "
+                    "Check the server logs for details.</p>"
                     "</body></html>"
                 ),
                 status_code=500,
@@ -893,13 +1059,22 @@ def create_connectors_router():
             "expires_in": tokens.get("expires_in", 3600),
             "client_id": client_id,
             "client_secret": client_secret,
+            "source_email": google_source_email_from_tokens(tokens)
+            if provider.name == "google"
+            else "",
         }
 
         for path in _credential_paths_for_provider(provider, account=account_alias):
             save_tokens(str(path), payload)
 
-        # Clear cached instance so it picks up new credentials
-        _instances.pop(_instance_key(connector_id, account_alias), None)
+        # Every Google primitive shares this account grant.  Rebuild all of
+        # them so instances created before the callback cannot retain a stale
+        # credentials path or connection status.
+        for provider_connector_id in provider.connector_ids:
+            _instances.pop(
+                _instance_key(provider_connector_id, account_alias),
+                None,
+            )
 
         _style = "font-family:system-ui;text-align:center;padding:60px"
         return HTMLResponse(
@@ -922,7 +1097,7 @@ def create_connectors_router():
                 status_code=404,
                 detail=f"Connector '{connector_id}' not found",
             )
-        account = account.strip()
+        account = _normalise_account(connector_id, account)
         _reject_pending_disconnect(_instance_key(connector_id, account))
         inst = _get_or_create(connector_id, account)
         if not inst.is_connected():
@@ -946,7 +1121,7 @@ def create_connectors_router():
                 status_code=404,
                 detail=f"Connector '{connector_id}' not found",
             )
-        account = account.strip()
+        account = _normalise_account(connector_id, account)
         instance = _get_or_create(connector_id, account)
         try:
             status = instance.sync_status()
@@ -1046,6 +1221,7 @@ def create_connectors_router():
 
         return {
             "connector_id": connector_id,
+            "account": account or None,
             "state": effective_state,
             "items_synced": items_synced,
             "items_total": items_total,

--- a/src/openjarvis/server/connectors_router.py
+++ b/src/openjarvis/server/connectors_router.py
@@ -958,7 +958,7 @@ def create_connectors_router():
                     for key in sync_keys.values():
                         engine.reset_checkpoint(key)
                     try:
-                        if not account and attributed_shared_sources:
+                        if not account and provider and provider.name == "google":
                             store.delete_unscoped_sources_with_attribution(
                                 purge_sources,
                                 attributed_shared_sources,

--- a/src/openjarvis/server/connectors_router.py
+++ b/src/openjarvis/server/connectors_router.py
@@ -277,6 +277,7 @@ def create_connectors_router():
             )
 
         account = _normalise_request_account(connector_id, req)
+        _reject_active_provider_syncs(tuple(provider.connector_ids), account)
         save_client_credentials(
             provider,
             client_id,
@@ -635,6 +636,20 @@ def create_connectors_router():
             )
         account = _normalise_request_account(connector_id, req)
         _reject_pending_disconnect(_instance_key(connector_id, account))
+
+        # Client registration changes a provider-wide credential grant.  Run
+        # that preflight before constructing or invalidating any connector
+        # instance so a sibling Google sync rejects the request atomically:
+        # neither credential files nor the instance cache may change.
+        try:
+            directive = _maybe_oauth_client_pair(connector_id, req)
+        except HTTPException:
+            raise
+        except Exception as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        if directive is not None:
+            return directive
+
         instance = _get_or_create(connector_id, account)
 
         try:
@@ -659,9 +674,6 @@ def create_connectors_router():
                 # localhost:8789 callback server; that thread fails silently in
                 # the bundled desktop context, so the connector never became
                 # connected and never appeared in Data Sources (issue #512).
-                directive = _maybe_oauth_client_pair(connector_id, req)
-                if directive is not None:
-                    return directive
                 if (
                     req.email
                     and req.password
@@ -743,8 +755,10 @@ def create_connectors_router():
                 if req.password and hasattr(instance, "_password"):
                     instance._password = req.password
 
+        except HTTPException:
+            raise
         except Exception as exc:
-            raise HTTPException(status_code=400, detail=str(exc))
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
 
         # Auto-trigger a full backfill on a successful connect. Routed
         # through the same _start_sync helper that POST /sync uses so the

--- a/src/openjarvis/server/connectors_router.py
+++ b/src/openjarvis/server/connectors_router.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import secrets
 import threading
@@ -332,6 +333,7 @@ def create_connectors_router():
     # globally keeps connect/disconnect/manual-sync decisions atomic,
     # including ownership checks for sources shared by multiple connectors.
     _lifecycle_lock = threading.RLock()
+    _lifecycle_async_lock = asyncio.Lock()
     _oauth_state_lock = threading.Lock()
     _oauth_states: Dict[str, tuple[str, str, float]] = {}
     _OAUTH_STATE_TTL_SECONDS = 600.0
@@ -424,7 +426,7 @@ def create_connectors_router():
     def _serialized_async(func):
         @wraps(func)
         async def wrapped(*args, **kwargs):
-            with _lifecycle_lock:
+            async with _lifecycle_async_lock:
                 return await func(*args, **kwargs)
 
         return wrapped
@@ -963,6 +965,7 @@ def create_connectors_router():
         }
 
     @router.get("/{connector_id}/oauth/start")
+    @_serialized_async
     async def oauth_start(
         connector_id: str,
         request: Request,

--- a/src/openjarvis/server/connectors_router.py
+++ b/src/openjarvis/server/connectors_router.py
@@ -913,6 +913,13 @@ def create_connectors_router():
             for source in _knowledge_sources(target_id, instance)
         }
         attributed_shared_sources: Dict[str, str] = {}
+        if connector_id == "gmail_imap" and "gmail" in purge_sources:
+            # Gmail IMAP shares ``source='gmail'`` with every Google OAuth
+            # profile.  Its own rows are positively identifiable by connector
+            # provenance or the historical IMAP UID marker, so never make
+            # cleanup depend on which OAuth profile happens to be cached.
+            purge_sources.remove("gmail")
+            attributed_shared_sources["gmail"] = "gmail_imap"
         if not account:
             for other_id in ConnectorRegistry.keys():
                 if other_id in target_ids:
@@ -958,7 +965,10 @@ def create_connectors_router():
                     try:
                         for key in sync_keys.values():
                             engine.reset_checkpoint(key)
-                        if not account and provider and provider.name == "google":
+                        if not account and (
+                            attributed_shared_sources
+                            or (provider and provider.name == "google")
+                        ):
                             store.delete_unscoped_sources_with_attribution(
                                 purge_sources,
                                 attributed_shared_sources,

--- a/src/openjarvis/server/research_router.py
+++ b/src/openjarvis/server/research_router.py
@@ -427,6 +427,7 @@ async def _stream_research(
             model=model,
             clarify_handler=lambda question: _WEB_CLARIFY_RESPONSE,
             on_event=on_event,
+            default_accounts=config.agent.default_accounts,
         )
     except Exception as exc:  # noqa: BLE001
         logger.exception("research: setup failed before agent could run: %s", exc)

--- a/src/openjarvis/server/research_router.py
+++ b/src/openjarvis/server/research_router.py
@@ -421,13 +421,17 @@ async def _stream_research(
             )
             embedder = None
 
+        configured_defaults = config.agent.default_accounts
+        default_account_scope = config.connectors.google.account_scope(
+            configured_defaults
+        )
         agent = ResearchAgent(
             engine=engine,
             search=HybridSearch(store, embedder),
             model=model,
             clarify_handler=lambda question: _WEB_CLARIFY_RESPONSE,
             on_event=on_event,
-            default_accounts=config.agent.default_accounts,
+            default_accounts=default_account_scope,
         )
     except Exception as exc:  # noqa: BLE001
         logger.exception("research: setup failed before agent could run: %s", exc)

--- a/src/openjarvis/system/orchestrator.py
+++ b/src/openjarvis/system/orchestrator.py
@@ -180,9 +180,14 @@ class QueryOrchestrator:
                         expand_account_sources,
                     )
 
+                    configured_accounts = dc.accounts
+                    enabled_accounts = s.config.connectors.google.account_scope(
+                        configured_accounts
+                    )
                     section_sources[sec] = expand_account_sources(
                         sc.sources,
-                        s.config.connectors.google.enabled_aliases(dc.accounts),
+                        enabled_accounts,
+                        is_account_enabled=s.config.connectors.google.is_enabled,
                     )
             agent_kwargs.update(
                 {

--- a/src/openjarvis/system/orchestrator.py
+++ b/src/openjarvis/system/orchestrator.py
@@ -176,7 +176,14 @@ class QueryOrchestrator:
             for sec in dc.sections:
                 sc = getattr(dc, sec, None)
                 if sc and hasattr(sc, "sources"):
-                    section_sources[sec] = sc.sources
+                    from openjarvis.agents.morning_digest import (
+                        expand_account_sources,
+                    )
+
+                    section_sources[sec] = expand_account_sources(
+                        sc.sources,
+                        dc.accounts,
+                    )
             agent_kwargs.update(
                 {
                     "persona": dc.persona,

--- a/src/openjarvis/system/orchestrator.py
+++ b/src/openjarvis/system/orchestrator.py
@@ -182,7 +182,7 @@ class QueryOrchestrator:
 
                     section_sources[sec] = expand_account_sources(
                         sc.sources,
-                        dc.accounts,
+                        s.config.connectors.google.enabled_aliases(dc.accounts),
                     )
             agent_kwargs.update(
                 {

--- a/src/openjarvis/tools/digest_collect.py
+++ b/src/openjarvis/tools/digest_collect.py
@@ -523,6 +523,12 @@ class DigestCollectTool(BaseTool):
                             "named digest profiles are supported only for Google "
                             "connectors"
                         )
+                    from openjarvis.core.config import load_config
+
+                    if not load_config().connectors.google.is_enabled(account):
+                        raise ValueError(
+                            f"Google account profile '{account}' is disabled"
+                        )
                 except ValueError as exc:
                     errors.append(f"Invalid source '{requested_source}': {exc}")
                     continue

--- a/src/openjarvis/tools/digest_collect.py
+++ b/src/openjarvis/tools/digest_collect.py
@@ -168,7 +168,13 @@ def _format_gmail(doc: Document) -> str:
     subject = doc.title or "(no subject)"
     ago = _time_ago(doc.timestamp)
     body = doc.content.replace("\n", " ").strip()[:150] if doc.content else ""
-    line = f'[gmail id={doc.doc_id}] From: {sender} — "{subject}" ({ago})'
+    account = str(doc.metadata.get("account", "") or "")
+    message_id = str(doc.metadata.get("message_id", "") or doc.source_id)
+    scope = f" account={account}" if account else ""
+    native = f" message_id={message_id}" if message_id else ""
+    line = (
+        f'[gmail id={doc.doc_id}{scope}{native}] From: {sender} — "{subject}" ({ago})'
+    )
     if body:
         line += f"\n  Preview: {body}"
     return line
@@ -276,7 +282,13 @@ def _format_gcalendar(doc: Document) -> str:
                 time_range = f" ({duration})"
             except (ValueError, TypeError):
                 pass
-    return f"[gcalendar id={doc.doc_id}] {time_str} — {title}{time_range}"
+    account = str(doc.metadata.get("account", "") or "")
+    event_id = str(doc.metadata.get("event_id", "") or doc.source_id)
+    scope = f" account={account}" if account else ""
+    native = f" event_id={event_id}" if event_id else ""
+    return (
+        f"[gcalendar id={doc.doc_id}{scope}{native}] {time_str} — {title}{time_range}"
+    )
 
 
 def _format_spotify(doc: Document) -> str:

--- a/src/openjarvis/tools/digest_collect.py
+++ b/src/openjarvis/tools/digest_collect.py
@@ -358,10 +358,18 @@ _FORMATTERS: Dict[str, Any] = {
 
 def _format_doc(source: str, doc: Document) -> str:
     """Format a document using the source-specific formatter, with fallback."""
-    formatter = _FORMATTERS.get(source)
+    base_source, _, account = source.partition(":")
+    formatter = _FORMATTERS.get(base_source)
     if formatter:
         try:
-            return formatter(doc)
+            formatted = formatter(doc)
+            if account and formatted.startswith(f"[{base_source}"):
+                return formatted.replace(
+                    f"[{base_source}",
+                    f"[{base_source}:{account}",
+                    1,
+                )
+            return formatted
         except Exception:  # noqa: BLE001
             pass
     # Fallback: connector name + title
@@ -444,7 +452,9 @@ class DigestCollectTool(BaseTool):
                         "items": {"type": "string"},
                         "description": (
                             "List of connector IDs to fetch from "
-                            "(e.g., ['gmail', 'oura', 'gcalendar'])."
+                            "(e.g., ['gmail', 'oura', 'gcalendar']). Named Google "
+                            "profiles use connector:account syntax, such as "
+                            "['gmail:work', 'gcalendar:personal']."
                         ),
                     },
                     "hours_back": {
@@ -474,7 +484,8 @@ class DigestCollectTool(BaseTool):
         # Ensure connectors are registered
         import openjarvis.connectors  # noqa: F401
 
-        sources: List[str] = params.get("sources", [])
+        requested_sources: List[str] = params.get("sources", [])
+        sources: List[str] = []
         hours_back: float = params.get("hours_back", 24)
         unacted_only: bool = bool(params.get("unacted_only", False))
         seen_ids: set = set(params.get("seen_ids", []))
@@ -484,14 +495,36 @@ class DigestCollectTool(BaseTool):
         collected_docs: Dict[str, List[Document]] = {}
         errors: List[str] = []
 
-        for source in sources:
-            if not ConnectorRegistry.contains(source):
+        for requested_source in requested_sources:
+            connector_id, separator, account = requested_source.partition(":")
+            if separator:
+                try:
+                    from openjarvis.connectors.oauth import (
+                        get_provider_for_connector,
+                        normalize_account_alias,
+                    )
+
+                    account = normalize_account_alias(account)
+                    provider = get_provider_for_connector(connector_id)
+                    if not account or provider is None or provider.name != "google":
+                        raise ValueError(
+                            "named digest profiles are supported only for Google "
+                            "connectors"
+                        )
+                except ValueError as exc:
+                    errors.append(f"Invalid source '{requested_source}': {exc}")
+                    continue
+            source = f"{connector_id}:{account}" if account else connector_id
+            sources.append(source)
+            if not ConnectorRegistry.contains(connector_id):
                 errors.append(f"Connector '{source}' not available")
                 continue
 
             try:
-                connector_cls = ConnectorRegistry.get(source)
-                connector = connector_cls()
+                connector_cls = ConnectorRegistry.get(connector_id)
+                connector = (
+                    connector_cls(account=account) if account else connector_cls()
+                )
 
                 if not connector.is_connected():
                     errors.append(
@@ -504,7 +537,7 @@ class DigestCollectTool(BaseTool):
                 docs: List[Document] = []
 
                 sync_kwargs: Dict[str, Any] = {"since": since}
-                if unacted_only and source == "gmail":
+                if unacted_only and connector_id == "gmail":
                     sync_kwargs["query_extra"] = "is:unread"
 
                 for d in connector.sync(**sync_kwargs):
@@ -513,10 +546,10 @@ class DigestCollectTool(BaseTool):
                     if len(docs) >= max_per_source:
                         break
 
-                if unacted_only and source == "imessage":
+                if unacted_only and connector_id == "imessage":
                     docs = _filter_unanswered_threads(docs)
 
-                if unacted_only and source == "gcalendar":
+                if unacted_only and connector_id == "gcalendar":
                     docs = _filter_pending_invites(docs)
 
                 collected_docs[source] = docs
@@ -528,7 +561,9 @@ class DigestCollectTool(BaseTool):
         for section_name, section_connectors in _SECTION_ORDER:
             # Gather all sources that belong to this section and have data
             section_sources = [
-                s for s in sources if s in section_connectors and s in collected_docs
+                s
+                for s in sources
+                if s.partition(":")[0] in section_connectors and s in collected_docs
             ]
             if not section_sources:
                 continue
@@ -556,7 +591,9 @@ class DigestCollectTool(BaseTool):
             known_connectors |= cids
 
         uncategorized_sources = [
-            s for s in sources if s not in known_connectors and s in collected_docs
+            s
+            for s in sources
+            if s.partition(":")[0] not in known_connectors and s in collected_docs
         ]
         if uncategorized_sources:
             summary_parts.append("=== OTHER ===")

--- a/src/openjarvis/tools/knowledge_search.py
+++ b/src/openjarvis/tools/knowledge_search.py
@@ -57,7 +57,15 @@ class KnowledgeSearchTool(BaseTool):
                         "type": "string",
                         "description": (
                             "Filter by source connector"
-                            " (e.g. 'gmail', 'slack', 'obsidian')."
+                            " (e.g. 'gmail', 'slack', 'obsidian', or"
+                            " 'gmail:work' for a named account alias)."
+                        ),
+                    },
+                    "account": {
+                        "type": "string",
+                        "description": (
+                            "Optional named connector account alias "
+                            "(e.g. 'personal' or 'work')."
                         ),
                     },
                     "doc_type": {
@@ -111,6 +119,7 @@ class KnowledgeSearchTool(BaseTool):
 
         top_k: int = int(params.get("top_k", 10))
         source: Optional[str] = params.get("source")
+        account: Optional[str] = params.get("account")
         doc_type: Optional[str] = params.get("doc_type")
         author: Optional[str] = params.get("author")
         since: Optional[str] = params.get("since")
@@ -121,6 +130,7 @@ class KnowledgeSearchTool(BaseTool):
                 query,
                 top_k=top_k,
                 source=source or "",
+                account=account or "",
                 doc_type=doc_type or "",
                 author=author or "",
                 since=since or "",
@@ -131,6 +141,7 @@ class KnowledgeSearchTool(BaseTool):
                 query,
                 top_k=top_k,
                 source=source,
+                account=account,
                 doc_type=doc_type,
                 author=author,
                 since=since,

--- a/src/openjarvis/tools/knowledge_search.py
+++ b/src/openjarvis/tools/knowledge_search.py
@@ -126,61 +126,40 @@ class KnowledgeSearchTool(BaseTool):
         until: Optional[str] = params.get("until")
 
         try:
-            source, query_accounts = self._account_scope(source, account)
+            source, strict_account, default_accounts = self._account_scope(
+                source,
+                account,
+            )
         except ValueError as exc:
             return ToolResult(
                 tool_name="knowledge_search",
                 content=str(exc),
                 success=False,
             )
-        if query_accounts == []:
-            return ToolResult(
-                tool_name="knowledge_search",
-                content="No relevant results found.",
-                success=True,
-                metadata={"num_results": 0},
+        if self._retriever is not None:
+            results = self._retriever.retrieve(
+                query,
+                top_k=top_k,
+                source=source or "",
+                account=strict_account or "",
+                accounts=default_accounts,
+                doc_type=doc_type or "",
+                author=author or "",
+                since=since or "",
+                until=until or "",
             )
-
-        def retrieve_one(query_account: Optional[str]):
-            if self._retriever is not None:
-                return self._retriever.retrieve(
-                    query,
-                    top_k=top_k,
-                    source=source or "",
-                    account=query_account or "",
-                    doc_type=doc_type or "",
-                    author=author or "",
-                    since=since or "",
-                    until=until or "",
-                )
-            return self._store.retrieve(  # type: ignore[union-attr]
+        else:
+            results = self._store.retrieve(  # type: ignore[union-attr]
                 query,
                 top_k=top_k,
                 source=source,
-                account=query_account,
+                account=strict_account,
+                accounts=default_accounts,
                 doc_type=doc_type,
                 author=author,
                 since=since,
                 until=until,
             )
-
-        if query_accounts is None:
-            results = retrieve_one(None)
-        else:
-            by_chunk: dict[str, Any] = {}
-            for query_account in query_accounts:
-                for result in retrieve_one(query_account):
-                    chunk_id = str(result.metadata.get("chunk_id", "")) or str(
-                        id(result)
-                    )
-                    previous = by_chunk.get(chunk_id)
-                    if previous is None or result.score > previous.score:
-                        by_chunk[chunk_id] = result
-            results = sorted(
-                by_chunk.values(),
-                key=lambda result: result.score,
-                reverse=True,
-            )[:top_k]
 
         if not results:
             return ToolResult(
@@ -248,7 +227,7 @@ class KnowledgeSearchTool(BaseTool):
     def _account_scope(
         source: Optional[str],
         account: Optional[str],
-    ) -> tuple[Optional[str], Optional[list[str]]]:
+    ) -> tuple[Optional[str], Optional[str], Optional[list[str]]]:
         """Resolve requested filters within configured Google boundaries."""
         from openjarvis.connectors.oauth import (
             get_provider_for_connector,
@@ -282,19 +261,15 @@ class KnowledgeSearchTool(BaseTool):
 
         configured_scope = google_config.account_scope(config.agent.default_accounts)
         if configured_scope is None:
-            return normalized_source, (
-                [requested_account] if requested_account else None
-            )
-        if not configured_scope:
-            return normalized_source, []
+            return normalized_source, requested_account or None, None
         if requested_account:
             if requested_account not in configured_scope:
                 raise ValueError(
                     f"Google account profile '{requested_account}' is outside "
                     "the configured agent account boundary"
                 )
-            return normalized_source, [requested_account]
-        return normalized_source, configured_scope
+            return normalized_source, requested_account, None
+        return normalized_source, None, configured_scope
 
 
 __all__ = ["KnowledgeSearchTool"]

--- a/src/openjarvis/tools/knowledge_search.py
+++ b/src/openjarvis/tools/knowledge_search.py
@@ -161,6 +161,7 @@ class KnowledgeSearchTool(BaseTool):
             meta = result.metadata
             src_label = result.source or meta.get("source", "")
             result_account = str(meta.get("account", "") or "")
+            source_email = str(meta.get("source_email", "") or "")
             if src_label and result_account:
                 src_label = f"{src_label}:{result_account}"
             title = meta.get("title", "")
@@ -175,6 +176,8 @@ class KnowledgeSearchTool(BaseTool):
                 header_parts.append(title)
             if result_author:
                 header_parts.append(f"by {result_author}")
+            if source_email:
+                header_parts.append(f"account {source_email}")
             if url:
                 header_parts.append(f"({url})")
 
@@ -189,7 +192,22 @@ class KnowledgeSearchTool(BaseTool):
             tool_name="knowledge_search",
             content=formatted,
             success=True,
-            metadata={"num_results": len(results)},
+            metadata={
+                "num_results": len(results),
+                "sources": [
+                    {
+                        "source": result.source,
+                        "account": str(result.metadata.get("account", "") or ""),
+                        "source_profile": str(
+                            result.metadata.get("source_profile", "") or ""
+                        ),
+                        "source_email": str(
+                            result.metadata.get("source_email", "") or ""
+                        ),
+                    }
+                    for result in results
+                ],
+            },
         )
 
 

--- a/src/openjarvis/tools/knowledge_search.py
+++ b/src/openjarvis/tools/knowledge_search.py
@@ -160,6 +160,9 @@ class KnowledgeSearchTool(BaseTool):
         for i, result in enumerate(results, start=1):
             meta = result.metadata
             src_label = result.source or meta.get("source", "")
+            result_account = str(meta.get("account", "") or "")
+            if src_label and result_account:
+                src_label = f"{src_label}:{result_account}"
             title = meta.get("title", "")
             result_author = meta.get("author", "")
             url = meta.get("url", "")

--- a/src/openjarvis/tools/knowledge_search.py
+++ b/src/openjarvis/tools/knowledge_search.py
@@ -125,28 +125,62 @@ class KnowledgeSearchTool(BaseTool):
         since: Optional[str] = params.get("since")
         until: Optional[str] = params.get("until")
 
-        if self._retriever is not None:
-            results = self._retriever.retrieve(
-                query,
-                top_k=top_k,
-                source=source or "",
-                account=account or "",
-                doc_type=doc_type or "",
-                author=author or "",
-                since=since or "",
-                until=until or "",
+        try:
+            source, query_accounts = self._account_scope(source, account)
+        except ValueError as exc:
+            return ToolResult(
+                tool_name="knowledge_search",
+                content=str(exc),
+                success=False,
             )
-        else:
-            results = self._store.retrieve(  # type: ignore[union-attr]
+        if query_accounts == []:
+            return ToolResult(
+                tool_name="knowledge_search",
+                content="No relevant results found.",
+                success=True,
+                metadata={"num_results": 0},
+            )
+
+        def retrieve_one(query_account: Optional[str]):
+            if self._retriever is not None:
+                return self._retriever.retrieve(
+                    query,
+                    top_k=top_k,
+                    source=source or "",
+                    account=query_account or "",
+                    doc_type=doc_type or "",
+                    author=author or "",
+                    since=since or "",
+                    until=until or "",
+                )
+            return self._store.retrieve(  # type: ignore[union-attr]
                 query,
                 top_k=top_k,
                 source=source,
-                account=account,
+                account=query_account,
                 doc_type=doc_type,
                 author=author,
                 since=since,
                 until=until,
             )
+
+        if query_accounts is None:
+            results = retrieve_one(None)
+        else:
+            by_chunk: dict[str, Any] = {}
+            for query_account in query_accounts:
+                for result in retrieve_one(query_account):
+                    chunk_id = str(result.metadata.get("chunk_id", "")) or str(
+                        id(result)
+                    )
+                    previous = by_chunk.get(chunk_id)
+                    if previous is None or result.score > previous.score:
+                        by_chunk[chunk_id] = result
+            results = sorted(
+                by_chunk.values(),
+                key=lambda result: result.score,
+                reverse=True,
+            )[:top_k]
 
         if not results:
             return ToolResult(
@@ -209,6 +243,58 @@ class KnowledgeSearchTool(BaseTool):
                 ],
             },
         )
+
+    @staticmethod
+    def _account_scope(
+        source: Optional[str],
+        account: Optional[str],
+    ) -> tuple[Optional[str], Optional[list[str]]]:
+        """Resolve requested filters within configured Google boundaries."""
+        from openjarvis.connectors.oauth import (
+            get_provider_for_connector,
+            normalize_account_alias,
+        )
+        from openjarvis.core.config import load_config
+
+        config = load_config()
+        google_config = config.connectors.google
+        requested_account = ""
+        if account:
+            requested_account = normalize_account_alias(str(account))
+
+        normalized_source = str(source).strip() if source else None
+        if normalized_source and ":" in normalized_source:
+            connector_id, raw_source_account = normalized_source.split(":", 1)
+            provider = get_provider_for_connector(connector_id)
+            if provider is not None and provider.name == "google":
+                source_account = normalize_account_alias(raw_source_account)
+                if requested_account and requested_account != source_account:
+                    raise ValueError(
+                        "Conflicting account filters: source and account must match"
+                    )
+                requested_account = source_account
+                normalized_source = f"{connector_id}:{source_account}"
+
+        if requested_account and not google_config.is_enabled(requested_account):
+            raise ValueError(
+                f"Google account profile '{requested_account}' is disabled"
+            )
+
+        configured_scope = google_config.account_scope(config.agent.default_accounts)
+        if configured_scope is None:
+            return normalized_source, (
+                [requested_account] if requested_account else None
+            )
+        if not configured_scope:
+            return normalized_source, []
+        if requested_account:
+            if requested_account not in configured_scope:
+                raise ValueError(
+                    f"Google account profile '{requested_account}' is outside "
+                    "the configured agent account boundary"
+                )
+            return normalized_source, [requested_account]
+        return normalized_source, configured_scope
 
 
 __all__ = ["KnowledgeSearchTool"]

--- a/src/openjarvis/tools/knowledge_sql.py
+++ b/src/openjarvis/tools/knowledge_sql.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import re
 import sqlite3
-from typing import Any, Optional
+from typing import Any, Optional, Sequence
 
 from openjarvis.connectors.store import KnowledgeStore
 from openjarvis.core.registry import ToolRegistry
@@ -45,8 +45,13 @@ class KnowledgeSQLTool(BaseTool):
 
     tool_id = "knowledge_sql"
 
-    def __init__(self, store: Optional[KnowledgeStore] = None) -> None:
+    def __init__(
+        self,
+        store: Optional[KnowledgeStore] = None,
+        accounts: Optional[Sequence[str]] = None,
+    ) -> None:
         self._store = store
+        self._accounts = None if accounts is None else tuple(accounts)
 
     @property
     def spec(self) -> ToolSpec:
@@ -81,6 +86,15 @@ class KnowledgeSQLTool(BaseTool):
             return ToolResult(
                 tool_name="knowledge_sql",
                 content="No knowledge store configured.",
+                success=False,
+            )
+        if self._accounts is not None:
+            return ToolResult(
+                tool_name="knowledge_sql",
+                content=(
+                    "Raw SQL is unavailable while a named Google account "
+                    "boundary is configured; use knowledge_search instead."
+                ),
                 success=False,
             )
 

--- a/src/openjarvis/tools/proactive_tools.py
+++ b/src/openjarvis/tools/proactive_tools.py
@@ -461,16 +461,21 @@ def _google_action_scope(
         if possible_account and (not account or possible_account == account):
             account = account or possible_account
             raw_id = native_id
+    if account:
+        from openjarvis.core.config import load_config
+
+        if not load_config().connectors.google.is_enabled(account):
+            raise ValueError(f"Google account profile '{account}' is disabled")
     return account, raw_id
 
 
 def _exec_email_delete(payload: Dict[str, Any]) -> Tuple[bool, str]:
-    account, msg_id = _google_action_scope(
-        payload, connector_id="gmail", id_field="message_id"
-    )
-    if not msg_id:
-        return False, "Missing message_id in payload"
     try:
+        account, msg_id = _google_action_scope(
+            payload, connector_id="gmail", id_field="message_id"
+        )
+        if not msg_id:
+            return False, "Missing message_id in payload"
         from openjarvis.connectors.gmail import GmailConnector
 
         conn = GmailConnector(account=account)
@@ -481,12 +486,12 @@ def _exec_email_delete(payload: Dict[str, Any]) -> Tuple[bool, str]:
 
 
 def _exec_email_archive(payload: Dict[str, Any]) -> Tuple[bool, str]:
-    account, msg_id = _google_action_scope(
-        payload, connector_id="gmail", id_field="message_id"
-    )
-    if not msg_id:
-        return False, "Missing message_id in payload"
     try:
+        account, msg_id = _google_action_scope(
+            payload, connector_id="gmail", id_field="message_id"
+        )
+        if not msg_id:
+            return False, "Missing message_id in payload"
         from openjarvis.connectors.gmail import GmailConnector
 
         conn = GmailConnector(account=account)
@@ -511,13 +516,13 @@ def _exec_sms_send(payload: Dict[str, Any]) -> Tuple[bool, str]:
 
 
 def _exec_calendar_decline(payload: Dict[str, Any]) -> Tuple[bool, str]:
-    account, event_id = _google_action_scope(
-        payload, connector_id="gcalendar", id_field="event_id"
-    )
-    calendar_id = payload.get("calendar_id", "primary")
-    if not event_id:
-        return False, "Missing event_id in payload"
     try:
+        account, event_id = _google_action_scope(
+            payload, connector_id="gcalendar", id_field="event_id"
+        )
+        calendar_id = payload.get("calendar_id", "primary")
+        if not event_id:
+            return False, "Missing event_id in payload"
         from openjarvis.connectors.gcalendar import GCalendarConnector
 
         conn = GCalendarConnector(account=account)
@@ -528,13 +533,13 @@ def _exec_calendar_decline(payload: Dict[str, Any]) -> Tuple[bool, str]:
 
 
 def _exec_calendar_accept(payload: Dict[str, Any]) -> Tuple[bool, str]:
-    account, event_id = _google_action_scope(
-        payload, connector_id="gcalendar", id_field="event_id"
-    )
-    calendar_id = payload.get("calendar_id", "primary")
-    if not event_id:
-        return False, "Missing event_id in payload"
     try:
+        account, event_id = _google_action_scope(
+            payload, connector_id="gcalendar", id_field="event_id"
+        )
+        calendar_id = payload.get("calendar_id", "primary")
+        if not event_id:
+            return False, "Missing event_id in payload"
         from openjarvis.connectors.gcalendar import GCalendarConnector
 
         conn = GCalendarConnector(account=account)

--- a/src/openjarvis/tools/proactive_tools.py
+++ b/src/openjarvis/tools/proactive_tools.py
@@ -431,14 +431,49 @@ class ExecutePendingActionsTool(BaseTool):
 # ---------------------------------------------------------------------------
 
 
+def _google_action_scope(
+    payload: Dict[str, Any],
+    *,
+    connector_id: str,
+    id_field: str,
+) -> Tuple[str, str]:
+    """Return normalized account and provider-native action ID.
+
+    New proposals carry explicit ``account`` plus the native ID.  The parser
+    also accepts legacy/account-prefixed document IDs so already queued
+    actions remain executable after named profiles are enabled.
+    """
+    from openjarvis.connectors.oauth import normalize_account_alias
+
+    raw_id = str(payload.get(id_field, "") or "").strip()
+    prefix = f"{connector_id}:"
+    if raw_id.startswith(prefix):
+        raw_id = raw_id[len(prefix) :]
+
+    raw_account = str(payload.get("account", "") or "").strip()
+    account = normalize_account_alias(raw_account) if raw_account else ""
+    if ":" in raw_id:
+        possible_account, native_id = raw_id.split(":", 1)
+        try:
+            possible_account = normalize_account_alias(possible_account)
+        except ValueError:
+            possible_account = ""
+        if possible_account and (not account or possible_account == account):
+            account = account or possible_account
+            raw_id = native_id
+    return account, raw_id
+
+
 def _exec_email_delete(payload: Dict[str, Any]) -> Tuple[bool, str]:
-    msg_id = payload.get("message_id", "")
+    account, msg_id = _google_action_scope(
+        payload, connector_id="gmail", id_field="message_id"
+    )
     if not msg_id:
         return False, "Missing message_id in payload"
     try:
         from openjarvis.connectors.gmail import GmailConnector
 
-        conn = GmailConnector()
+        conn = GmailConnector(account=account)
         conn.delete_message(msg_id)
         return True, f"Deleted email {msg_id}"
     except Exception as exc:
@@ -446,13 +481,15 @@ def _exec_email_delete(payload: Dict[str, Any]) -> Tuple[bool, str]:
 
 
 def _exec_email_archive(payload: Dict[str, Any]) -> Tuple[bool, str]:
-    msg_id = payload.get("message_id", "")
+    account, msg_id = _google_action_scope(
+        payload, connector_id="gmail", id_field="message_id"
+    )
     if not msg_id:
         return False, "Missing message_id in payload"
     try:
         from openjarvis.connectors.gmail import GmailConnector
 
-        conn = GmailConnector()
+        conn = GmailConnector(account=account)
         conn.archive_message(msg_id)
         return True, f"Archived email {msg_id}"
     except Exception as exc:
@@ -474,14 +511,16 @@ def _exec_sms_send(payload: Dict[str, Any]) -> Tuple[bool, str]:
 
 
 def _exec_calendar_decline(payload: Dict[str, Any]) -> Tuple[bool, str]:
-    event_id = payload.get("event_id", "")
+    account, event_id = _google_action_scope(
+        payload, connector_id="gcalendar", id_field="event_id"
+    )
     calendar_id = payload.get("calendar_id", "primary")
     if not event_id:
         return False, "Missing event_id in payload"
     try:
         from openjarvis.connectors.gcalendar import GCalendarConnector
 
-        conn = GCalendarConnector()
+        conn = GCalendarConnector(account=account)
         conn.decline_event(event_id, calendar_id=calendar_id)
         return True, f"Declined calendar event {event_id}"
     except Exception as exc:
@@ -489,14 +528,16 @@ def _exec_calendar_decline(payload: Dict[str, Any]) -> Tuple[bool, str]:
 
 
 def _exec_calendar_accept(payload: Dict[str, Any]) -> Tuple[bool, str]:
-    event_id = payload.get("event_id", "")
+    account, event_id = _google_action_scope(
+        payload, connector_id="gcalendar", id_field="event_id"
+    )
     calendar_id = payload.get("calendar_id", "primary")
     if not event_id:
         return False, "Missing event_id in payload"
     try:
         from openjarvis.connectors.gcalendar import GCalendarConnector
 
-        conn = GCalendarConnector()
+        conn = GCalendarConnector(account=account)
         conn.accept_event(event_id, calendar_id=calendar_id)
         return True, f"Accepted calendar event {event_id}"
     except Exception as exc:

--- a/src/openjarvis/tools/scan_chunks.py
+++ b/src/openjarvis/tools/scan_chunks.py
@@ -7,7 +7,7 @@ that keyword-based BM25 search misses.
 
 from __future__ import annotations
 
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Sequence
 
 from openjarvis.connectors.store import KnowledgeStore
 from openjarvis.core.registry import ToolRegistry
@@ -30,10 +30,12 @@ class ScanChunksTool(BaseTool):
         store: Optional[KnowledgeStore] = None,
         engine: Optional[InferenceEngine] = None,
         model: str = "",
+        accounts: Optional[Sequence[str]] = None,
     ) -> None:
         self._store = store
         self._engine = engine
         self._model = model
+        self._accounts = None if accounts is None else tuple(accounts)
 
     @property
     def spec(self) -> ToolSpec:
@@ -105,8 +107,15 @@ class ScanChunksTool(BaseTool):
         max_chunks: int = int(params.get("max_chunks", _DEFAULT_MAX_CHUNKS))
         batch_size: int = _DEFAULT_BATCH_SIZE
 
-        where_clauses: List[str] = []
+        where_clauses: List[str] = ["deleted_at IS NULL"]
         sql_params: List[Any] = []
+
+        if self._accounts is not None:
+            from openjarvis.connectors.store import google_account_scope_sql
+
+            account_clause, account_params = google_account_scope_sql(self._accounts)
+            where_clauses.append(account_clause)
+            sql_params.extend(account_params)
 
         if source:
             where_clauses.append("source = ?")

--- a/src/openjarvis/tools/scan_chunks.py
+++ b/src/openjarvis/tools/scan_chunks.py
@@ -58,7 +58,14 @@ class ScanChunksTool(BaseTool):
                     },
                     "source": {
                         "type": "string",
-                        "description": "Filter by source (e.g. 'granola', 'gmail').",
+                        "description": (
+                            "Filter by source (e.g. 'granola', 'gmail', or "
+                            "'gmail:work' for a named Google profile)."
+                        ),
+                    },
+                    "account": {
+                        "type": "string",
+                        "description": "Narrow the scan to one Google profile alias.",
                     },
                     "doc_type": {
                         "type": "string",
@@ -101,6 +108,7 @@ class ScanChunksTool(BaseTool):
             )
 
         source: str = params.get("source", "")
+        account: str = params.get("account", "")
         doc_type: str = params.get("doc_type", "")
         since: str = params.get("since", "")
         until: str = params.get("until", "")
@@ -110,7 +118,22 @@ class ScanChunksTool(BaseTool):
         where_clauses: List[str] = ["deleted_at IS NULL"]
         sql_params: List[Any] = []
 
-        if self._accounts is not None:
+        try:
+            source, requested_account = self._resolve_account_filter(source, account)
+        except ValueError as exc:
+            return ToolResult(
+                tool_name="scan_chunks",
+                content=str(exc),
+                success=False,
+            )
+
+        if requested_account:
+            where_clauses.append(
+                "CASE WHEN json_valid(metadata) "
+                "THEN json_extract(metadata, '$.account') END = ?"
+            )
+            sql_params.append(requested_account)
+        elif self._accounts is not None:
             from openjarvis.connectors.store import google_account_scope_sql
 
             account_clause, account_params = google_account_scope_sql(self._accounts)
@@ -195,6 +218,38 @@ class ScanChunksTool(BaseTool):
                 "batches_with_findings": len(findings),
             },
         )
+
+    def _resolve_account_filter(self, source: str, account: str) -> tuple[str, str]:
+        """Normalize and intersect a per-call profile with the hard boundary."""
+        from openjarvis.connectors.oauth import (
+            get_provider_for_connector,
+            normalize_account_alias,
+        )
+        from openjarvis.core.config import load_config
+
+        requested = normalize_account_alias(account) if account else ""
+        normalized_source = source.strip()
+        if ":" in normalized_source:
+            connector_id, raw_account = normalized_source.split(":", 1)
+            provider = get_provider_for_connector(connector_id)
+            if provider is not None and provider.name == "google":
+                source_account = normalize_account_alias(raw_account)
+                if requested and requested != source_account:
+                    raise ValueError(
+                        "Conflicting account filters: source and account must match"
+                    )
+                requested = source_account
+                normalized_source = connector_id
+
+        if requested:
+            if not load_config().connectors.google.is_enabled(requested):
+                raise ValueError(f"Google account profile '{requested}' is disabled")
+            if self._accounts is not None and requested not in self._accounts:
+                raise ValueError(
+                    f"Google account profile '{requested}' is outside the "
+                    "configured agent account boundary"
+                )
+        return normalized_source, requested
 
 
 __all__ = ["ScanChunksTool"]

--- a/tests/agents/test_morning_digest.py
+++ b/tests/agents/test_morning_digest.py
@@ -30,6 +30,22 @@ def test_expand_account_sources_scopes_only_google_connectors() -> None:
     ]
 
 
+def test_expand_account_sources_fails_closed_when_profiles_are_disabled() -> None:
+    from openjarvis.agents.morning_digest import expand_account_sources
+
+    assert expand_account_sources(
+        ["gmail", "gcalendar:disabled", "slack"],
+        [],
+        is_account_enabled=lambda account: account != "disabled",
+    ) == ["slack"]
+
+
+def test_expand_account_sources_keeps_unconfigured_legacy_google_source() -> None:
+    from openjarvis.agents.morning_digest import expand_account_sources
+
+    assert expand_account_sources(["gmail", "slack"], None) == ["gmail", "slack"]
+
+
 def test_morning_digest_run(tmp_path):
     from openjarvis.agents.morning_digest import MorningDigestAgent
 

--- a/tests/agents/test_morning_digest.py
+++ b/tests/agents/test_morning_digest.py
@@ -16,6 +16,20 @@ def test_morning_digest_registered():
     assert AgentRegistry.contains("morning_digest")
 
 
+def test_expand_account_sources_scopes_only_google_connectors() -> None:
+    from openjarvis.agents.morning_digest import expand_account_sources
+
+    assert expand_account_sources(
+        ["gmail", "gcalendar:family", "slack"],
+        [" Work ", "personal"],
+    ) == [
+        "gmail:work",
+        "gmail:personal",
+        "gcalendar:family",
+        "slack",
+    ]
+
+
 def test_morning_digest_run(tmp_path):
     from openjarvis.agents.morning_digest import MorningDigestAgent
 

--- a/tests/agents/test_research_loop.py
+++ b/tests/agents/test_research_loop.py
@@ -289,6 +289,37 @@ def test_build_sources_includes_account_metadata() -> None:
     assert sources[0]["source_profile"] == "work"
 
 
+def test_named_gmail_citation_never_falls_back_to_default_browser_account() -> None:
+    [without_email] = build_sources_for_client(
+        [
+            _mk_hit(
+                source="gmail",
+                document_id="gmail:work:18f9abc",
+                account="work",
+                source_profile="work",
+            )
+        ]
+    )
+    assert without_email["source_id"] == "18f9abc"
+    assert without_email["url"] == ""
+
+    [with_email] = build_sources_for_client(
+        [
+            _mk_hit(
+                source="gmail",
+                document_id="gmail:work:18f9abc",
+                account="work",
+                source_profile="work",
+                source_email="user+work@company.example",
+            )
+        ]
+    )
+    assert with_email["url"] == (
+        "https://mail.google.com/mail/?authuser="
+        "user%2Bwork%40company.example#all/18f9abc"
+    )
+
+
 def test_build_sources_falls_back_to_reconstruction_when_url_missing() -> None:
     """Slack/Gmail still work without a stored URL — reconstructed from doc_id."""
     sources = build_sources_for_client(
@@ -451,6 +482,41 @@ def test_search_account_scalar_is_coerced_to_list(stub_search: MagicMock) -> Non
 
     kwargs = stub_search.search.call_args.kwargs
     assert kwargs.get("accounts") == ["personal"]
+
+
+def test_empty_enforced_account_scope_matches_nothing(
+    stub_search: MagicMock,
+) -> None:
+    """All-disabled configured defaults must not widen back to every account."""
+    engine = _MockEngine(
+        responses=[_search_call("s1"), _text_response("No enabled accounts.")]
+    )
+    agent = ResearchAgent(
+        engine,
+        stub_search,
+        model="mock",
+        max_iterations=2,
+        default_accounts=[],
+    )
+
+    agent.run("search my mail")
+
+    assert stub_search.search.call_args.kwargs["accounts"] == [
+        "__openjarvis_no_matching_account__"
+    ]
+
+
+def test_unconfigured_account_scope_remains_unfiltered(
+    stub_search: MagicMock,
+) -> None:
+    engine = _MockEngine(
+        responses=[_search_call("s1"), _text_response("Unscoped result.")]
+    )
+    agent = ResearchAgent(engine, stub_search, model="mock", max_iterations=2)
+
+    agent.run("search my mail")
+
+    assert stub_search.search.call_args.kwargs["accounts"] is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agents/test_research_loop.py
+++ b/tests/agents/test_research_loop.py
@@ -233,6 +233,8 @@ def _mk_hit(
     document_id: str = "granola:not_abc12345678901",
     url: str = "",
     title: str = "Sprint Planning",
+    account: str = "",
+    source_profile: str = "",
 ) -> SearchHit:
     """Tiny SearchHit factory for URL-routing tests."""
     return SearchHit(
@@ -247,6 +249,8 @@ def _mk_hit(
         score=0.5,
         bm25_score=0.5,
         vector_score=0.5,
+        account=account,
+        source_profile=source_profile,
         url=url,
     )
 
@@ -260,6 +264,27 @@ def test_build_sources_prefers_stored_url_over_reconstruction() -> None:
     stored = "https://notes.granola.ai/d/e98b5d85-ff57-46ac-a0ce-849fc68d086f"
     sources = build_sources_for_client([_mk_hit(url=stored)])
     assert sources[0]["url"] == stored
+
+
+def test_build_sources_includes_account_metadata() -> None:
+    """Citation payloads include the Google profile alias for UI chips.
+
+    The frontend can show "Gmail / work" and follow-up queries can preserve
+    the same scope instead of silently falling back to all Gmail accounts.
+    """
+    sources = build_sources_for_client(
+        [
+            _mk_hit(
+                source="gmail",
+                document_id="gmail:work:msg-1",
+                account="work",
+                source_profile="work",
+            )
+        ]
+    )
+
+    assert sources[0]["account"] == "work"
+    assert sources[0]["source_profile"] == "work"
 
 
 def test_build_sources_falls_back_to_reconstruction_when_url_missing() -> None:
@@ -362,6 +387,70 @@ def test_search_sources_coerces_scalar_to_list(stub_search: MagicMock) -> None:
     assert kwargs.get("sources") == ["slack"]
 
 
+def test_search_with_accounts_filter_is_passed_through(
+    stub_search: MagicMock,
+) -> None:
+    """A planner-selected account alias reaches HybridSearch.search."""
+    engine = _MockEngine(
+        responses=[
+            {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "s1",
+                        "name": "search",
+                        "arguments": json.dumps(
+                            {
+                                "query": "subscription renewals",
+                                "sources": ["gmail"],
+                                "accounts": ["work"],
+                            }
+                        ),
+                    }
+                ],
+                "usage": {},
+            },
+            _text_response("Found work subscription renewals."),
+        ]
+    )
+
+    agent = ResearchAgent(engine, stub_search, model="mock", max_iterations=2)
+    result = agent.run("summarize subscription renewals in work Gmail")
+
+    stub_search.search.assert_called_once()
+    kwargs = stub_search.search.call_args.kwargs
+    assert kwargs.get("sources") == ["gmail"]
+    assert kwargs.get("accounts") == ["work"]
+    assert result.tool_calls[0].arguments["accounts"] == ["work"]
+
+
+def test_search_account_scalar_is_coerced_to_list(stub_search: MagicMock) -> None:
+    """If the model sends ``account='personal'``, wrap it as ``['personal']``."""
+    engine = _MockEngine(
+        responses=[
+            {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "s1",
+                        "name": "search",
+                        "arguments": json.dumps(
+                            {"query": "anything", "account": "personal"}
+                        ),
+                    }
+                ],
+                "usage": {},
+            },
+            _text_response("done"),
+        ]
+    )
+    agent = ResearchAgent(engine, stub_search, model="mock", max_iterations=2)
+    agent.run("anything from my personal profile")
+
+    kwargs = stub_search.search.call_args.kwargs
+    assert kwargs.get("accounts") == ["personal"]
+
+
 # ---------------------------------------------------------------------------
 # Prompt + tool schema — the planner must see the sources directive
 # ---------------------------------------------------------------------------
@@ -376,8 +465,21 @@ def test_tool_schema_sources_lists_known_connectors() -> None:
     """
     sources_prop = SEARCH_TOOL_SPEC["function"]["parameters"]["properties"]["sources"]
     desc = sources_prop["description"]
-    for connector_id in ("granola", "slack", "gmail", "notion"):
+    for connector_id in ("granola", "slack", "gmail", "gdrive"):
         assert connector_id in desc
+    assert "connector:account" in desc
+    assert "gmail:work" in desc
+
+
+def test_tool_schema_includes_accounts_filter() -> None:
+    """The planner has an explicit account/persona filter parameter."""
+    accounts_prop = (
+        SEARCH_TOOL_SPEC["function"]["parameters"]["properties"]["accounts"]
+    )
+    desc = accounts_prop["description"]
+    assert accounts_prop["type"] == "array"
+    assert "account aliases" in desc
+    assert "work" in desc
 
 
 def test_system_prompt_mandates_sources_extraction() -> None:
@@ -391,6 +493,9 @@ def test_system_prompt_mandates_sources_extraction() -> None:
     # Synonym mapping for the most-common alias.
     assert "granola" in SYSTEM_PROMPT.lower()
     assert "meeting notes" in SYSTEM_PROMPT.lower()
+    assert "accounts=" in SYSTEM_PROMPT
+    assert "gmail:work" in SYSTEM_PROMPT
+    assert "account/profile/persona" in SYSTEM_PROMPT
     # The dynamic placeholder is what's interpolated per-run.
     assert "{available_sources}" in SYSTEM_PROMPT
 
@@ -435,7 +540,6 @@ def test_available_sources_override_appears_in_prompt(
     # unconnected source, which is intentional.)
     assert "obsidian" not in sys_content.lower()
     assert "apple_notes" not in sys_content.lower()
-    assert "gdrive" not in sys_content.lower()
 
 
 def test_available_sources_fall_back_to_store(stub_search: MagicMock) -> None:

--- a/tests/agents/test_research_loop.py
+++ b/tests/agents/test_research_loop.py
@@ -235,6 +235,7 @@ def _mk_hit(
     title: str = "Sprint Planning",
     account: str = "",
     source_profile: str = "",
+    source_email: str = "",
 ) -> SearchHit:
     """Tiny SearchHit factory for URL-routing tests."""
     return SearchHit(
@@ -251,6 +252,7 @@ def _mk_hit(
         vector_score=0.5,
         account=account,
         source_profile=source_profile,
+        source_email=source_email,
         url=url,
     )
 
@@ -599,6 +601,25 @@ def test_shape_results_for_model_respects_ref_offset() -> None:
     shaped = shape_results_for_model(hits, ref_offset=20)
     refs = [h["ref"] for h in shaped["hits"]]
     assert refs == [21, 22, 23]
+
+
+def test_shape_results_for_model_exposes_account_provenance() -> None:
+    """The synthesis model can distinguish identically named account hits."""
+    hits = [
+        _mk_hit(
+            title="Quarterly plan",
+            document_id="gmail:work:42",
+            account="work",
+            source_profile="work",
+            source_email="user@company.example",
+        )
+    ]
+
+    shaped = shape_results_for_model(hits)
+
+    assert shaped["hits"][0]["account"] == "work"
+    assert shaped["hits"][0]["source_profile"] == "work"
+    assert shaped["hits"][0]["source_email"] == "user@company.example"
 
 
 def test_build_sources_for_client_respects_ref_offset() -> None:

--- a/tests/agents/test_research_loop.py
+++ b/tests/agents/test_research_loop.py
@@ -473,9 +473,7 @@ def test_tool_schema_sources_lists_known_connectors() -> None:
 
 def test_tool_schema_includes_accounts_filter() -> None:
     """The planner has an explicit account/persona filter parameter."""
-    accounts_prop = (
-        SEARCH_TOOL_SPEC["function"]["parameters"]["properties"]["accounts"]
-    )
+    accounts_prop = SEARCH_TOOL_SPEC["function"]["parameters"]["properties"]["accounts"]
     desc = accounts_prop["description"]
     assert accounts_prop["type"] == "array"
     assert "account aliases" in desc

--- a/tests/agents/test_research_loop.py
+++ b/tests/agents/test_research_loop.py
@@ -622,9 +622,50 @@ def test_available_sources_fall_back_to_store(stub_search: MagicMock) -> None:
     agent = ResearchAgent(engine, stub_search, model="mock", max_iterations=1)
     agent.run("hi")
 
-    fake_store.distinct_sources.assert_called_once()
+    fake_store.distinct_sources.assert_called_once_with(accounts=None)
     sys_content = engine.calls[0]["messages"][0].content
     assert "granola, slack" in sys_content
+
+
+def test_available_sources_respect_account_boundary(
+    stub_search: MagicMock,
+    tmp_path,
+) -> None:
+    """The planner must not learn that another named profile is indexed."""
+    from openjarvis.connectors.store import KnowledgeStore
+
+    store = KnowledgeStore(tmp_path / "account-sources.db")
+    store.store(
+        "work data",
+        source="gmail",
+        source_id="work:message",
+        metadata={"account": "work"},
+    )
+    store.store(
+        "personal data",
+        source="gdrive",
+        source_id="personal:file",
+        metadata={"account": "personal"},
+    )
+    store.store("shared data", source="slack", source_id="shared")
+    stub_search._store = store
+    engine = _MockEngine(responses=[_text_response("ok")])
+    agent = ResearchAgent(
+        engine,
+        stub_search,
+        model="mock",
+        max_iterations=1,
+        default_accounts=["work"],
+    )
+
+    try:
+        agent.run("hi")
+    finally:
+        store.close()
+
+    sys_content = engine.calls[0]["messages"][0].content
+    assert "gmail, gmail:work, slack" in sys_content
+    assert "gdrive:personal" not in sys_content
 
 
 def test_available_sources_empty_message_when_nothing_connected(

--- a/tests/agents/test_tool_resolver.py
+++ b/tests/agents/test_tool_resolver.py
@@ -126,6 +126,32 @@ def test_deep_research_grants_are_live_deduplicated_and_use_selected_model(
         resolved.by_name["knowledge_sql"]._store.close()
 
 
+def test_scoped_deep_research_disables_raw_sql_and_scopes_scan(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    """Every granted reader must respect the configured account boundary."""
+    from openjarvis.core.config import JarvisConfig
+
+    db_path = tmp_path / "knowledge.db"
+    with KnowledgeStore(db_path=db_path) as store:
+        store.store("seed", source="slack")
+    config = JarvisConfig()
+    config.agent.default_accounts = ["work"]
+    monkeypatch.setattr("openjarvis.core.config.load_config", lambda: config)
+
+    tools = tool_resolver.build_deep_research_tools(object(), "test", db_path)
+    by_name = {tool.tool_id: tool for tool in tools}
+
+    sql_result = by_name["knowledge_sql"].execute(
+        query="SELECT content FROM knowledge_chunks"
+    )
+    assert sql_result.success is False
+    assert "unavailable" in sql_result.content
+    assert by_name["scan_chunks"]._accounts == ("work",)
+    by_name["knowledge_sql"]._store.close()
+
+
 @pytest.mark.parametrize(
     "tool_config",
     [

--- a/tests/cli/test_ask_accounts.py
+++ b/tests/cli/test_ask_accounts.py
@@ -1,0 +1,47 @@
+"""Account-scoped ``jarvis ask`` CLI regressions."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from openjarvis.cli.ask import _normalise_account_filters, ask
+from openjarvis.core.config import JarvisConfig
+
+
+def test_normalise_account_filters_deduplicates_aliases() -> None:
+    assert _normalise_account_filters((" Work ", "personal"), "work,research") == [
+        "work",
+        "personal",
+        "research",
+    ]
+
+
+def test_account_filters_imply_research_and_reach_agent() -> None:
+    config = JarvisConfig()
+    with (
+        patch("openjarvis.cli.ask.print_banner"),
+        patch("openjarvis.cli.ask.load_config", return_value=config),
+        patch("openjarvis.cli.ask.register_builtin_models"),
+        patch(
+            "openjarvis.cli.ask.get_engine",
+            return_value=("fake", MagicMock()),
+        ),
+        patch("openjarvis.cli.ask._run_research") as run_research,
+    ):
+        result = CliRunner().invoke(
+            ask,
+            ["--account", "Work", "--accounts", "personal,work", "updates"],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert run_research.call_args.kwargs["accounts"] == ["work", "personal"]
+
+
+def test_invalid_account_filter_fails_before_engine_discovery() -> None:
+    with patch("openjarvis.cli.ask.load_config", return_value=JarvisConfig()):
+        result = CliRunner().invoke(ask, ["--account", "../work", "updates"])
+
+    assert result.exit_code == 2
+    assert "Account aliases must" in result.output

--- a/tests/cli/test_connect.py
+++ b/tests/cli/test_connect.py
@@ -108,3 +108,25 @@ def test_connect_disconnect() -> None:
 
     assert result.exit_code == 0
     mock_instance.disconnect.assert_called_once()
+
+
+def test_connect_google_with_account_runs_segmented_oauth() -> None:
+    """connect google --account work routes OAuth through the account alias."""
+    runner = CliRunner()
+
+    with (
+        mock.patch(
+            "openjarvis.connectors.oauth.get_client_credentials",
+            return_value=("client.apps.googleusercontent.com", "secret"),
+        ),
+        mock.patch("openjarvis.connectors.oauth.run_connector_oauth") as mock_run,
+    ):
+        result = runner.invoke(cli, ["connect", "--account", "work", "google"])
+
+    assert result.exit_code == 0
+    mock_run.assert_called_once_with(
+        "gmail",
+        "client.apps.googleusercontent.com",
+        "secret",
+        account="work",
+    )

--- a/tests/cli/test_connect.py
+++ b/tests/cli/test_connect.py
@@ -130,3 +130,78 @@ def test_connect_google_with_account_runs_segmented_oauth() -> None:
         "secret",
         account="work",
     )
+
+
+def test_connect_rejects_conflicting_account_and_profile_aliases() -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli,
+        ["connect", "--account", "work", "--profile", "personal", "google"],
+    )
+
+    assert result.exit_code == 2
+    assert "must name the same alias" in result.output
+
+
+def test_connect_accepts_equivalent_canonical_account_and_profile() -> None:
+    runner = CliRunner()
+
+    with (
+        mock.patch(
+            "openjarvis.connectors.oauth.get_client_credentials",
+            return_value=("client.apps.googleusercontent.com", "secret"),
+        ),
+        mock.patch("openjarvis.connectors.oauth.run_connector_oauth") as mock_run,
+    ):
+        result = runner.invoke(
+            cli,
+            ["connect", "--account", " Work ", "--profile", "work", "google"],
+        )
+
+    assert result.exit_code == 0
+    mock_run.assert_called_once_with(
+        "gmail",
+        "client.apps.googleusercontent.com",
+        "secret",
+        account="work",
+    )
+
+
+def test_disconnect_named_google_account_purges_index_before_token() -> None:
+    runner = CliRunner()
+
+    with (
+        mock.patch("openjarvis.cli.connect_cmd._purge_google_account_index") as purge,
+        mock.patch("openjarvis.connectors.oauth.delete_tokens") as delete,
+        mock.patch(
+            "openjarvis.connectors.oauth.google_account_credentials_path",
+            return_value="/tmp/work.json",
+        ),
+    ):
+        result = runner.invoke(
+            cli,
+            ["connect", "--account", "work", "--disconnect", "gmail"],
+        )
+
+    assert result.exit_code == 0
+    purge.assert_called_once_with("work")
+    delete.assert_called_once_with("/tmp/work.json")
+
+
+def test_connect_rejects_named_account_for_non_google_source() -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["connect", "--account", "work", "obsidian"])
+
+    assert result.exit_code == 2
+    assert "supported only for Google connectors" in result.output
+
+
+def test_connect_rejects_unsafe_account_alias() -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["connect", "--account", "../work", "google"])
+
+    assert result.exit_code == 2
+    assert "Account aliases must be" in result.output

--- a/tests/cli/test_connect.py
+++ b/tests/cli/test_connect.py
@@ -205,3 +205,73 @@ def test_connect_rejects_unsafe_account_alias() -> None:
 
     assert result.exit_code == 2
     assert "Account aliases must be" in result.output
+
+
+def test_connect_google_account_can_sync_after_oauth() -> None:
+    runner = CliRunner()
+
+    with (
+        mock.patch("openjarvis.cli.connect_cmd._connect_source") as connect_source,
+        mock.patch("openjarvis.cli.connect_cmd._sync_sources") as sync_sources,
+    ):
+        result = runner.invoke(
+            cli,
+            ["connect", "--account", "work", "--sync", "google"],
+        )
+
+    assert result.exit_code == 0
+    connect_source.assert_called_once()
+    sync_sources.assert_called_once()
+    assert sync_sources.call_args.kwargs == {"source": "google", "account": "work"}
+
+
+def test_legacy_migration_is_explicit_and_precedes_named_sync() -> None:
+    runner = CliRunner()
+    calls: list[str] = []
+
+    with (
+        mock.patch(
+            "openjarvis.cli.connect_cmd._migrate_legacy_google_index",
+            side_effect=lambda account: calls.append(f"migrate:{account}"),
+        ),
+        mock.patch(
+            "openjarvis.cli.connect_cmd._connect_source",
+            side_effect=lambda *args, **kwargs: calls.append("connect"),
+        ),
+        mock.patch(
+            "openjarvis.cli.connect_cmd._sync_sources",
+            side_effect=lambda *args, **kwargs: calls.append("sync"),
+        ),
+    ):
+        result = runner.invoke(
+            cli,
+            [
+                "connect",
+                "--account",
+                "work",
+                "--migrate-legacy-google",
+                "--sync",
+                "google",
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert calls == ["migrate:work", "connect", "sync"]
+
+
+def test_disabled_configured_google_account_is_rejected(monkeypatch) -> None:
+    from openjarvis.core.config import (
+        GoogleAccountProfileConfig,
+        JarvisConfig,
+    )
+
+    config = JarvisConfig()
+    config.connectors.google.accounts["work"] = GoogleAccountProfileConfig(
+        enabled=False
+    )
+    monkeypatch.setattr("openjarvis.core.config.load_config", lambda: config)
+
+    result = CliRunner().invoke(cli, ["connect", "--account", "work", "google"])
+
+    assert result.exit_code == 2
+    assert "disabled in config.toml" in result.output

--- a/tests/cli/test_connect.py
+++ b/tests/cli/test_connect.py
@@ -336,14 +336,10 @@ def test_legacy_migration_preserves_ambiguous_gmail_rows() -> None:
     ):
         _migrate_legacy_google_index("work")
 
-    calls = store.delete_by_sources.call_args_list
-    assert calls[-2].kwargs == {"unscoped_only": True}
-    assert "gmail" not in calls[-2].args[0]
-    assert calls[-1].args == (("gmail",),)
-    assert calls[-1].kwargs == {
-        "unscoped_only": True,
-        "metadata_connector": "gmail",
-    }
+    store.delete_unscoped_sources_with_attribution.assert_called_once()
+    sources, attribution = store.delete_unscoped_sources_with_attribution.call_args.args
+    assert "gmail" not in sources
+    assert attribution == {"gmail": "gmail"}
 
 
 def test_disabled_configured_google_account_is_rejected(monkeypatch) -> None:

--- a/tests/cli/test_connect.py
+++ b/tests/cli/test_connect.py
@@ -236,7 +236,7 @@ def test_legacy_migration_is_explicit_and_precedes_named_sync() -> None:
         ),
         mock.patch(
             "openjarvis.cli.connect_cmd._connect_source",
-            side_effect=lambda *args, **kwargs: calls.append("connect"),
+            side_effect=lambda *args, **kwargs: calls.append("connect") or True,
         ),
         mock.patch(
             "openjarvis.cli.connect_cmd._sync_sources",
@@ -263,6 +263,89 @@ def test_legacy_migration_is_explicit_and_precedes_named_sync() -> None:
     assert calls == ["connect", "migrate:work", "sync"]
 
 
+def test_failed_google_oauth_does_not_migrate_existing_legacy_rows() -> None:
+    runner = CliRunner()
+
+    with (
+        mock.patch(
+            "openjarvis.connectors.gmail.GmailConnector.is_connected",
+            return_value=False,
+        ),
+        mock.patch(
+            "openjarvis.connectors.oauth.get_client_credentials",
+            return_value=("client.apps.googleusercontent.com", "secret"),
+        ),
+        mock.patch(
+            "openjarvis.connectors.oauth.run_connector_oauth",
+            side_effect=RuntimeError("provider rejected reauth"),
+        ),
+        mock.patch(
+            "openjarvis.cli.connect_cmd._migrate_legacy_google_index"
+        ) as migrate,
+    ):
+        result = runner.invoke(
+            cli,
+            ["connect", "--account", "work", "--migrate-legacy-google", "google"],
+        )
+
+    assert result.exit_code == 1
+    assert "legacy data was not changed" in result.output
+    migrate.assert_not_called()
+
+
+def test_copied_named_token_can_migrate_without_reauthentication() -> None:
+    runner = CliRunner()
+
+    with (
+        mock.patch(
+            "openjarvis.connectors.gmail.GmailConnector.is_connected",
+            return_value=True,
+        ),
+        mock.patch("openjarvis.connectors.oauth.run_connector_oauth") as oauth,
+        mock.patch(
+            "openjarvis.cli.connect_cmd._migrate_legacy_google_index"
+        ) as migrate,
+    ):
+        result = runner.invoke(
+            cli,
+            ["connect", "--account", "work", "--migrate-legacy-google", "google"],
+        )
+
+    assert result.exit_code == 0, result.output
+    oauth.assert_not_called()
+    migrate.assert_called_once_with("work")
+
+
+def test_legacy_migration_preserves_ambiguous_gmail_rows() -> None:
+    from openjarvis.cli.connect_cmd import _migrate_legacy_google_index
+
+    store = mock.MagicMock()
+    store.__enter__.return_value = store
+    engine = mock.MagicMock()
+    engine.__enter__.return_value = engine
+
+    with (
+        mock.patch(
+            "openjarvis.connectors.store.KnowledgeStore",
+            return_value=store,
+        ),
+        mock.patch(
+            "openjarvis.connectors.sync_engine.SyncEngine",
+            return_value=engine,
+        ),
+    ):
+        _migrate_legacy_google_index("work")
+
+    calls = store.delete_by_sources.call_args_list
+    assert calls[-2].kwargs == {"unscoped_only": True}
+    assert "gmail" not in calls[-2].args[0]
+    assert calls[-1].args == (("gmail",),)
+    assert calls[-1].kwargs == {
+        "unscoped_only": True,
+        "metadata_connector": "gmail",
+    }
+
+
 def test_disabled_configured_google_account_is_rejected(monkeypatch) -> None:
     from openjarvis.core.config import (
         GoogleAccountProfileConfig,
@@ -279,3 +362,22 @@ def test_disabled_configured_google_account_is_rejected(monkeypatch) -> None:
 
     assert result.exit_code == 2
     assert "disabled in config.toml" in result.output
+
+
+def test_disabled_google_account_can_still_be_disconnected(monkeypatch) -> None:
+    from openjarvis.core.config import GoogleAccountProfileConfig, JarvisConfig
+
+    config = JarvisConfig()
+    config.connectors.google.accounts["work"] = GoogleAccountProfileConfig(
+        enabled=False
+    )
+    monkeypatch.setattr("openjarvis.core.config.load_config", lambda: config)
+
+    with mock.patch("openjarvis.cli.connect_cmd._purge_google_account_index") as purge:
+        result = CliRunner().invoke(
+            cli,
+            ["connect", "--account", "work", "--disconnect", "google"],
+        )
+
+    assert result.exit_code == 0, result.output
+    purge.assert_called_once_with("work")

--- a/tests/cli/test_connect.py
+++ b/tests/cli/test_connect.py
@@ -87,7 +87,7 @@ def test_connect_specific_source(tmp_path: object) -> None:
 
 
 def test_connect_disconnect() -> None:
-    """--disconnect gmail exits 0."""
+    """A non-provider --disconnect invokes the connector directly."""
     runner = CliRunner()
 
     mock_cls = mock.MagicMock()
@@ -104,7 +104,7 @@ def test_connect_disconnect() -> None:
             return_value=mock_cls,
         ),
     ):
-        result = runner.invoke(cli, ["connect", "--disconnect", "gmail"])
+        result = runner.invoke(cli, ["connect", "--disconnect", "obsidian"])
 
     assert result.exit_code == 0
     mock_instance.disconnect.assert_called_once()
@@ -173,11 +173,7 @@ def test_disconnect_named_google_account_purges_index_before_token() -> None:
 
     with (
         mock.patch("openjarvis.cli.connect_cmd._purge_google_account_index") as purge,
-        mock.patch("openjarvis.connectors.oauth.delete_tokens") as delete,
-        mock.patch(
-            "openjarvis.connectors.oauth.google_account_credentials_path",
-            return_value="/tmp/work.json",
-        ),
+        mock.patch("openjarvis.connectors.oauth.delete_provider_tokens") as delete,
     ):
         result = runner.invoke(
             cli,
@@ -186,7 +182,23 @@ def test_disconnect_named_google_account_purges_index_before_token() -> None:
 
     assert result.exit_code == 0
     purge.assert_called_once_with("work")
-    delete.assert_called_once_with("/tmp/work.json")
+    delete.assert_called_once()
+    assert delete.call_args.kwargs == {"account": "work"}
+
+
+def test_disconnect_default_google_is_provider_wide() -> None:
+    runner = CliRunner()
+
+    with (
+        mock.patch("openjarvis.cli.connect_cmd._migrate_legacy_google_index") as purge,
+        mock.patch("openjarvis.connectors.oauth.delete_provider_tokens") as delete,
+    ):
+        result = runner.invoke(cli, ["connect", "--disconnect", "gdrive"])
+
+    assert result.exit_code == 0, result.output
+    purge.assert_called_once_with("")
+    delete.assert_called_once()
+    assert delete.call_args.kwargs == {"account": ""}
 
 
 def test_connect_rejects_named_account_for_non_google_source() -> None:

--- a/tests/cli/test_connect.py
+++ b/tests/cli/test_connect.py
@@ -242,6 +242,10 @@ def test_legacy_migration_is_explicit_and_precedes_named_sync() -> None:
             "openjarvis.cli.connect_cmd._sync_sources",
             side_effect=lambda *args, **kwargs: calls.append("sync"),
         ),
+        mock.patch(
+            "openjarvis.connectors.gmail.GmailConnector.is_connected",
+            return_value=True,
+        ),
     ):
         result = runner.invoke(
             cli,
@@ -256,7 +260,7 @@ def test_legacy_migration_is_explicit_and_precedes_named_sync() -> None:
         )
 
     assert result.exit_code == 0
-    assert calls == ["migrate:work", "connect", "sync"]
+    assert calls == ["connect", "migrate:work", "sync"]
 
 
 def test_disabled_configured_google_account_is_rejected(monkeypatch) -> None:

--- a/tests/connectors/test_account_scoped_retrieval.py
+++ b/tests/connectors/test_account_scoped_retrieval.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Iterator
+
+from openjarvis.connectors._stubs import BaseConnector, Document, SyncStatus
+from openjarvis.connectors.hybrid_search import HybridSearch
+from openjarvis.connectors.pipeline import IngestionPipeline
+from openjarvis.connectors.store import KnowledgeStore
+from openjarvis.connectors.sync_engine import SyncEngine
+
+MARKER = "OPENJARVIS_PERSONAL_MAIN_MARKER_001"
+
+
+def test_hybrid_search_does_not_fallback_to_recent_rows_for_nonempty_query(tmp_path):
+    store = KnowledgeStore(tmp_path / "knowledge.db")
+    store.store(
+        MARKER,
+        source="gmail",
+        source_id="personal-main:msg-1",
+        doc_type="email",
+        doc_id="gmail:personal-main:msg-1",
+        title="test",
+        author="Nirav <nirav@example.com>",
+        metadata={"account": "personal-main", "source_profile": "personal-main"},
+        timestamp="2026-06-05T14:28:51-04:00",
+    )
+    store.store(
+        "An unrelated work email",
+        source="gmail",
+        source_id="work-credain:msg-1",
+        doc_type="email",
+        doc_id="gmail:work-credain:msg-1",
+        title="unrelated",
+        author="Work <work@example.com>",
+        metadata={"account": "work-credain", "source_profile": "work-credain"},
+        timestamp="2026-06-05T14:29:00-04:00",
+    )
+
+    search = HybridSearch(store, embedder=None)
+
+    personal_hits = search.search(MARKER, sources=["gmail:personal-main"])
+    work_hits = search.search(MARKER, sources=["gmail:work-credain"])
+
+    assert len(personal_hits) == 1
+    assert personal_hits[0].account == "personal-main"
+    assert MARKER in personal_hits[0].content_snippet
+    assert work_hits == []
+
+
+def test_research_agent_strips_account_alias_person_filter():
+    from openjarvis.agents.research_loop import ResearchAgent
+
+    class _FakeSearch:
+        def __init__(self):
+            self.calls = []
+
+        def search(
+            self,
+            query,
+            *,
+            person=None,
+            time_range=None,
+            sources=None,
+            accounts=None,
+            limit=20,
+        ):
+            self.calls.append(
+                {
+                    "query": query,
+                    "person": person,
+                    "time_range": time_range,
+                    "sources": sources,
+                    "accounts": accounts,
+                    "limit": limit,
+                }
+            )
+            return []
+
+    fake_search = _FakeSearch()
+    agent = ResearchAgent(engine=None, search=fake_search)  # type: ignore[arg-type]
+
+    agent._execute_search(
+        {
+            "query": MARKER,
+            "person": "Personal Main",
+            "sources": ["gmail:personal-main"],
+        }
+    )
+    agent._execute_search(
+        {
+            "query": MARKER,
+            "person": "work-credain",
+            "sources": ["gmail"],
+            "accounts": ["work-credain"],
+        }
+    )
+
+    agent._execute_search(
+        {
+            "query": MARKER,
+            "person": "OpenJarvis",
+            "sources": ["gmail:personal-main"],
+        }
+    )
+
+    assert fake_search.calls[0]["person"] is None
+    assert fake_search.calls[1]["person"] is None
+    assert fake_search.calls[2]["person"] is None
+
+
+class _AccountConnector(BaseConnector):
+    connector_id = "gmail"
+    display_name = "Gmail"
+    auth_type = "oauth"
+
+    def __init__(self, account: str, marker: str):
+        self._account = account
+        self._marker = marker
+
+    def is_connected(self) -> bool:
+        return True
+
+    def disconnect(self) -> None:
+        return None
+
+    def sync(self, *, since=None, cursor=None) -> Iterator[Document]:
+        # If sync state is incorrectly shared across accounts, the second
+        # account receives since from the first account and emits nothing.
+        if since is not None:
+            return iter(())
+        return iter(
+            [
+                Document(
+                    doc_id=f"gmail:{self._account}:msg-1",
+                    source="gmail",
+                    doc_type="email",
+                    content=self._marker,
+                    title=self._marker,
+                    author=f"{self._account}@example.com",
+                    timestamp=datetime(2026, 6, 5, tzinfo=timezone.utc),
+                    metadata={
+                        "account": self._account,
+                        "source_profile": self._account,
+                    },
+                    source_id=f"{self._account}:msg-1",
+                )
+            ]
+        )
+
+    def sync_status(self) -> SyncStatus:
+        return SyncStatus()
+
+
+def test_sync_engine_checkpoints_are_account_scoped(tmp_path):
+    store = KnowledgeStore(tmp_path / "knowledge.db")
+    engine = SyncEngine(
+        IngestionPipeline(store=store),
+        state_db=str(tmp_path / "sync_state.db"),
+    )
+
+    assert engine.sync(_AccountConnector("personal-main", "personal marker")) == 1
+    assert engine.sync(_AccountConnector("work-credain", "work marker")) == 1
+
+    assert engine.get_checkpoint("gmail:personal-main")["items_synced"] == 1
+    assert engine.get_checkpoint("gmail:work-credain")["items_synced"] == 1
+    assert engine.get_checkpoint("gmail") is None
+
+    rows = store._conn.execute(
+        """
+        SELECT json_extract(metadata, '$.account') AS account, COUNT(*) AS count
+        FROM knowledge_chunks
+        WHERE source='gmail'
+        GROUP BY json_extract(metadata, '$.account')
+        ORDER BY account
+        """
+    ).fetchall()
+    assert [(row["account"], row["count"]) for row in rows] == [
+        ("personal-main", 1),
+        ("work-credain", 1),
+    ]
+
+
+def test_sync_engine_applies_checkpoint_lookback(monkeypatch, tmp_path):
+    seen_since = []
+
+    class _RecordingConnector(_AccountConnector):
+        def sync(self, *, since=None, cursor=None):
+            seen_since.append(since)
+            return iter(())
+
+    monkeypatch.setenv("OPENJARVIS_SYNC_LOOKBACK_SECONDS", "3600")
+    store = KnowledgeStore(tmp_path / "knowledge.db")
+    engine = SyncEngine(
+        IngestionPipeline(store=store),
+        state_db=str(tmp_path / "sync_state.db"),
+    )
+    engine._conn.execute(
+        """
+        INSERT INTO sync_state (connector_id, items_synced, cursor, last_sync, error)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        ("gmail:personal-main", 1, None, "2026-06-05T20:00:00+00:00", None),
+    )
+    engine._conn.commit()
+
+    engine.sync(_RecordingConnector("personal-main", "marker"))
+
+    assert seen_since[0].isoformat() == "2026-06-05T19:00:00+00:00"

--- a/tests/connectors/test_account_scoped_retrieval.py
+++ b/tests/connectors/test_account_scoped_retrieval.py
@@ -163,6 +163,15 @@ def test_hybrid_account_scope_keeps_non_google_and_hides_other_profiles(
     assert "work" in snippets
     assert "shared" in snippets
     assert "personal" not in snippets
+
+    disabled_hits = HybridSearch(store, embedder=None).search(
+        "BOUNDARY_MARKER",
+        accounts=[],
+    )
+    disabled_snippets = "\n".join(hit.content_snippet for hit in disabled_hits)
+    assert "shared" in disabled_snippets
+    assert "work" not in disabled_snippets
+    assert "personal" not in disabled_snippets
     store.close()
 
 

--- a/tests/connectors/test_account_scoped_retrieval.py
+++ b/tests/connectors/test_account_scoped_retrieval.py
@@ -96,17 +96,33 @@ def test_research_agent_strips_account_alias_person_filter():
         }
     )
 
-    agent._execute_search(
-        {
-            "query": MARKER,
-            "person": "OpenJarvis",
-            "sources": ["gmail:personal-main"],
-        }
-    )
-
     assert fake_search.calls[0]["person"] is None
     assert fake_search.calls[1]["person"] is None
-    assert fake_search.calls[2]["person"] is None
+
+
+def test_research_agent_applies_configured_default_accounts() -> None:
+    from openjarvis.agents.research_loop import ResearchAgent
+
+    class _FakeSearch:
+        def __init__(self):
+            self.calls = []
+
+        def search(self, query, **kwargs):
+            self.calls.append({"query": query, **kwargs})
+            return []
+
+    fake_search = _FakeSearch()
+    agent = ResearchAgent(  # type: ignore[arg-type]
+        engine=None,
+        search=fake_search,
+        default_accounts=[" Work "],
+    )
+
+    agent._execute_search({"query": "renewals", "sources": ["gmail"]})
+    agent._execute_search({"query": "family", "sources": ["gmail:personal"]})
+
+    assert fake_search.calls[0]["accounts"] == ["work"]
+    assert fake_search.calls[1]["accounts"] is None
 
 
 class _AccountConnector(BaseConnector):
@@ -179,31 +195,3 @@ def test_sync_engine_checkpoints_are_account_scoped(tmp_path):
         ("personal-main", 1),
         ("work-credain", 1),
     ]
-
-
-def test_sync_engine_applies_checkpoint_lookback(monkeypatch, tmp_path):
-    seen_since = []
-
-    class _RecordingConnector(_AccountConnector):
-        def sync(self, *, since=None, cursor=None):
-            seen_since.append(since)
-            return iter(())
-
-    monkeypatch.setenv("OPENJARVIS_SYNC_LOOKBACK_SECONDS", "3600")
-    store = KnowledgeStore(tmp_path / "knowledge.db")
-    engine = SyncEngine(
-        IngestionPipeline(store=store),
-        state_db=str(tmp_path / "sync_state.db"),
-    )
-    engine._conn.execute(
-        """
-        INSERT INTO sync_state (connector_id, items_synced, cursor, last_sync, error)
-        VALUES (?, ?, ?, ?, ?)
-        """,
-        ("gmail:personal-main", 1, None, "2026-06-05T20:00:00+00:00", None),
-    )
-    engine._conn.commit()
-
-    engine.sync(_RecordingConnector("personal-main", "marker"))
-
-    assert seen_since[0].isoformat() == "2026-06-05T19:00:00+00:00"

--- a/tests/connectors/test_account_scoped_retrieval.py
+++ b/tests/connectors/test_account_scoped_retrieval.py
@@ -120,9 +120,16 @@ def test_research_agent_applies_configured_default_accounts() -> None:
 
     agent._execute_search({"query": "renewals", "sources": ["gmail"]})
     agent._execute_search({"query": "family", "sources": ["gmail:personal"]})
+    agent._execute_search(
+        {"query": "family", "sources": ["gmail"], "accounts": ["Personal"]}
+    )
+    agent._execute_search({"query": "renewals", "sources": ["gmail:Work"]})
 
     assert fake_search.calls[0]["accounts"] == ["work"]
-    assert fake_search.calls[1]["accounts"] is None
+    assert fake_search.calls[1]["accounts"] == ["work"]
+    assert fake_search.calls[2]["accounts"] == ["__openjarvis_no_matching_account__"]
+    assert fake_search.calls[3]["sources"] == ["gmail:work"]
+    assert fake_search.calls[3]["accounts"] == ["work"]
 
 
 class _AccountConnector(BaseConnector):

--- a/tests/connectors/test_account_scoped_retrieval.py
+++ b/tests/connectors/test_account_scoped_retrieval.py
@@ -132,6 +132,40 @@ def test_research_agent_applies_configured_default_accounts() -> None:
     assert fake_search.calls[3]["accounts"] == ["work"]
 
 
+def test_hybrid_account_scope_keeps_non_google_and_hides_other_profiles(
+    tmp_path,
+) -> None:
+    store = KnowledgeStore(tmp_path / "account-boundary.db")
+    store.store(
+        "BOUNDARY_MARKER work",
+        source="gmail",
+        source_id="work:message",
+        metadata={"account": "work"},
+    )
+    store.store(
+        "BOUNDARY_MARKER personal",
+        source="gdrive",
+        source_id="personal:file",
+        metadata={"account": "personal"},
+    )
+    store.store(
+        "BOUNDARY_MARKER shared",
+        source="slack",
+        source_id="shared:message",
+    )
+
+    hits = HybridSearch(store, embedder=None).search(
+        "BOUNDARY_MARKER",
+        accounts=["work"],
+    )
+
+    snippets = "\n".join(hit.content_snippet for hit in hits)
+    assert "work" in snippets
+    assert "shared" in snippets
+    assert "personal" not in snippets
+    store.close()
+
+
 class _AccountConnector(BaseConnector):
     connector_id = "gmail"
     display_name = "Gmail"

--- a/tests/connectors/test_connectors_router_oauth.py
+++ b/tests/connectors/test_connectors_router_oauth.py
@@ -485,7 +485,12 @@ def test_named_account_oauth_state_binds_segmented_token(
     listing = client.get("/v1/connectors").json()["connectors"]
     gdrive = next(item for item in listing if item["connector_id"] == "gdrive")
     assert gdrive["accounts"] == [
-        {"account": "work", "connected": True, "source_email": ""}
+        {
+            "account": "work",
+            "enabled": True,
+            "connected": True,
+            "source_email": "",
+        }
     ]
 
     disconnected = client.post(
@@ -525,6 +530,24 @@ def test_connect_rejects_conflicting_account_and_profile(client: TestClient) -> 
 
     assert response.status_code == 400
     assert "must name the same alias" in response.json()["detail"]
+
+
+def test_disabled_google_account_is_rejected_by_server(client: TestClient) -> None:
+    from openjarvis.core.config import GoogleAccountProfileConfig, JarvisConfig
+
+    config = JarvisConfig()
+    config.connectors.google.accounts["work"] = GoogleAccountProfileConfig(
+        enabled=False
+    )
+
+    with patch("openjarvis.core.config.load_config", return_value=config):
+        response = client.post(
+            "/v1/connectors/gdrive/connect",
+            json={"code": _CLIENT_PAIR, "account": "work"},
+        )
+
+    assert response.status_code == 403
+    assert "disabled in config.toml" in response.json()["detail"]
 
 
 def test_reauth_rejected_while_sibling_account_sync_is_active(

--- a/tests/connectors/test_connectors_router_oauth.py
+++ b/tests/connectors/test_connectors_router_oauth.py
@@ -578,6 +578,71 @@ def test_reauth_rejected_while_sibling_account_sync_is_active(
         release.set()
 
 
+def test_client_pair_rejected_before_mutating_credentials_or_instances(
+    client: TestClient,
+    hermetic_connectors: Path,
+) -> None:
+    """A sibling sync makes client-registration POST an atomic 409."""
+    import openjarvis.server.connectors_router as router_mod
+
+    initial = client.post(
+        "/v1/connectors/gdrive/connect",
+        json={"code": _CLIENT_PAIR, "account": "work"},
+    )
+    assert initial.status_code == 200
+    account_file = hermetic_connectors / "google" / "accounts" / "work.json"
+    original_credentials = account_file.read_bytes()
+
+    started = threading.Event()
+    release = threading.Event()
+
+    class _BlockingGmail:
+        connector_id = "gmail"
+        _account = "work"
+
+        @staticmethod
+        def is_connected() -> bool:
+            return True
+
+        @staticmethod
+        def sync(*, since=None, cursor=None):
+            del since, cursor
+            started.set()
+            release.wait(timeout=5)
+            if False:
+                yield None
+
+    blocker = _BlockingGmail()
+    router_mod._instances["gmail:work"] = blocker
+    try:
+        sync_response = client.post(
+            "/v1/connectors/gmail/sync",
+            params={"account": "work"},
+        )
+        assert sync_response.status_code == 200
+        assert started.wait(timeout=2)
+        original_instances = dict(router_mod._instances)
+
+        response = client.post(
+            "/v1/connectors/gdrive/connect",
+            json={
+                "code": ("replacement.apps.googleusercontent.com:replacement-secret"),
+                "account": "work",
+            },
+        )
+
+        assert response.status_code == 409
+        assert "sync is active" in response.json()["detail"]
+        assert account_file.read_bytes() == original_credentials
+        assert router_mod._instances.keys() == original_instances.keys()
+        assert all(
+            router_mod._instances[key] is value
+            for key, value in original_instances.items()
+        )
+    finally:
+        release.set()
+
+
 def test_oauth_state_is_required_and_single_use(
     client: TestClient,
 ) -> None:

--- a/tests/connectors/test_connectors_router_oauth.py
+++ b/tests/connectors/test_connectors_router_oauth.py
@@ -515,6 +515,59 @@ def test_named_account_oauth_state_binds_segmented_token(
         assert response.json()["connected"] is False
 
 
+def test_disconnect_revokes_pending_named_oauth_state(
+    client: TestClient,
+    hermetic_connectors: Path,
+) -> None:
+    import openjarvis.connectors.oauth as oauth_mod
+
+    client.post(
+        "/v1/connectors/gdrive/connect",
+        json={"code": _CLIENT_PAIR, "account": "work"},
+    )
+    state = _start_state(client, "gdrive", account="work")
+
+    disconnected = client.post(
+        "/v1/connectors/gdrive/disconnect",
+        params={"account": "work"},
+    )
+    assert disconnected.status_code == 200
+
+    with patch.object(oauth_mod, "_exchange_token") as exchange:
+        callback = client.get(
+            "/v1/connectors/gdrive/oauth/callback",
+            params={"code": "late-code", "state": state},
+        )
+
+    assert callback.status_code == 400
+    exchange.assert_not_called()
+    assert not (hermetic_connectors / "google" / "accounts" / "work.json").exists()
+
+
+def test_callback_rechecks_disabled_profile_after_state_was_issued(
+    client: TestClient,
+) -> None:
+    from openjarvis.core.config import GoogleAccountProfileConfig, JarvisConfig
+
+    client.post(
+        "/v1/connectors/gdrive/connect",
+        json={"code": _CLIENT_PAIR, "account": "work"},
+    )
+    state = _start_state(client, "gdrive", account="work")
+    config = JarvisConfig()
+    config.connectors.google.accounts["work"] = GoogleAccountProfileConfig(
+        enabled=False
+    )
+
+    with patch("openjarvis.core.config.load_config", return_value=config):
+        callback = client.get(
+            "/v1/connectors/gdrive/oauth/callback",
+            params={"code": "late-code", "state": state},
+        )
+
+    assert callback.status_code == 403
+
+
 def test_named_account_rejected_for_non_google_connector(client: TestClient) -> None:
     response = client.get("/v1/connectors/spotify", params={"account": "work"})
 
@@ -548,6 +601,30 @@ def test_disabled_google_account_is_rejected_by_server(client: TestClient) -> No
 
     assert response.status_code == 403
     assert "disabled in config.toml" in response.json()["detail"]
+
+
+def test_disabled_google_account_can_still_be_disconnected(
+    client: TestClient,
+) -> None:
+    from openjarvis.core.config import GoogleAccountProfileConfig, JarvisConfig
+
+    client.post(
+        "/v1/connectors/gdrive/connect",
+        json={"code": _CLIENT_PAIR, "account": "work"},
+    )
+    config = JarvisConfig()
+    config.connectors.google.accounts["work"] = GoogleAccountProfileConfig(
+        enabled=False
+    )
+
+    with patch("openjarvis.core.config.load_config", return_value=config):
+        response = client.post(
+            "/v1/connectors/gdrive/disconnect",
+            params={"account": "work"},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "disconnected"
 
 
 def test_reauth_rejected_while_sibling_account_sync_is_active(
@@ -662,6 +739,61 @@ def test_client_pair_rejected_before_mutating_credentials_or_instances(
             router_mod._instances[key] is value
             for key, value in original_instances.items()
         )
+    finally:
+        release.set()
+
+
+def test_raw_google_token_rejected_while_sibling_sync_is_active(
+    client: TestClient,
+    hermetic_connectors: Path,
+) -> None:
+    import openjarvis.server.connectors_router as router_mod
+
+    initial = client.post(
+        "/v1/connectors/gdrive/connect",
+        json={"code": _CLIENT_PAIR, "account": "work"},
+    )
+    assert initial.status_code == 200
+    account_file = hermetic_connectors / "google" / "accounts" / "work.json"
+    original_credentials = account_file.read_bytes()
+    started = threading.Event()
+    release = threading.Event()
+
+    class _BlockingCalendar:
+        connector_id = "gcalendar"
+        _account = "work"
+
+        @staticmethod
+        def is_connected() -> bool:
+            return True
+
+        @staticmethod
+        def sync(*, since=None, cursor=None):
+            del since, cursor
+            started.set()
+            release.wait(timeout=5)
+            if False:
+                yield None
+
+    router_mod._instances["gcalendar:work"] = _BlockingCalendar()
+    try:
+        assert (
+            client.post(
+                "/v1/connectors/gcalendar/sync",
+                params={"account": "work"},
+            ).status_code
+            == 200
+        )
+        assert started.wait(timeout=2)
+
+        response = client.post(
+            "/v1/connectors/gmail/connect",
+            json={"token": "ya29.replacement", "account": "work"},
+        )
+
+        assert response.status_code == 409
+        assert "sync is active" in response.json()["detail"]
+        assert account_file.read_bytes() == original_credentials
     finally:
         release.set()
 

--- a/tests/connectors/test_connectors_router_oauth.py
+++ b/tests/connectors/test_connectors_router_oauth.py
@@ -628,6 +628,27 @@ def test_disabled_google_account_can_still_be_disconnected(
     assert response.json()["status"] == "disconnected"
 
 
+def test_default_google_disconnect_removes_shared_fallback(
+    client: TestClient,
+    hermetic_connectors: Path,
+) -> None:
+    from openjarvis.connectors.oauth import save_tokens
+
+    payload = {"access_token": "ya29.default"}
+    save_tokens(str(hermetic_connectors / "google.json"), payload)
+    save_tokens(str(hermetic_connectors / "gdrive.json"), payload)
+
+    assert client.get("/v1/connectors/gdrive").json()["connected"] is True
+    response = client.post("/v1/connectors/gdrive/disconnect")
+
+    assert response.status_code == 200, response.text
+    assert response.json()["status"] == "disconnected"
+    assert client.get("/v1/connectors/gdrive").json()["connected"] is False
+    assert not any(
+        (hermetic_connectors / filename).exists() for filename in _ALL_GOOGLE_FILES
+    )
+
+
 def test_reauth_rejected_while_sibling_account_sync_is_active(
     client: TestClient,
 ) -> None:
@@ -849,6 +870,64 @@ def test_connect_and_disconnect_are_serialized_on_one_event_loop(
         connected, disconnected, credential_exists = asyncio.run(run_race())
 
     assert connected.status_code == 200
+    assert disconnected.status_code == 200
+    assert credential_exists is False
+
+
+def test_cancelled_connect_drains_before_disconnect_releases_lifecycle(
+    client: TestClient,
+    hermetic_connectors: Path,
+) -> None:
+    """Cancelling the request cannot orphan its running credential writer."""
+    httpx = pytest.importorskip("httpx")
+    import contextlib
+
+    import openjarvis.connectors.oauth as oauth_mod
+    from openjarvis.connectors.gdrive import GDriveConnector
+
+    started = threading.Event()
+    release = threading.Event()
+
+    def blocking_callback(instance: Any, code: str) -> None:
+        started.set()
+        release.wait(timeout=5)
+        oauth_mod.save_tokens(instance._credentials_path, {"token": code})
+
+    async def run_race() -> tuple[bool, Any, bool]:
+        transport = httpx.ASGITransport(app=client.app)
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://testserver",
+        ) as async_client:
+            connect_task = asyncio.create_task(
+                async_client.post(
+                    "/v1/connectors/gdrive/connect",
+                    json={"code": "raw-code", "account": "work"},
+                )
+            )
+            assert await asyncio.to_thread(started.wait, 2)
+            connect_task.cancel()
+            disconnect_task = asyncio.create_task(
+                async_client.post(
+                    "/v1/connectors/gdrive/disconnect",
+                    params={"account": "work"},
+                )
+            )
+            await asyncio.sleep(0.05)
+            pending_before_release = (
+                not connect_task.done() and not disconnect_task.done()
+            )
+            release.set()
+            with contextlib.suppress(asyncio.CancelledError):
+                await connect_task
+            disconnect_response = await disconnect_task
+        account_file = hermetic_connectors / "google" / "accounts" / "work.json"
+        return pending_before_release, disconnect_response, account_file.exists()
+
+    with patch.object(GDriveConnector, "handle_callback", blocking_callback):
+        pending, disconnected, credential_exists = asyncio.run(run_race())
+
+    assert pending is True
     assert disconnected.status_code == 200
     assert credential_exists is False
 

--- a/tests/connectors/test_connectors_router_oauth.py
+++ b/tests/connectors/test_connectors_router_oauth.py
@@ -28,9 +28,11 @@ shared file when the caller-supplied path does not yet exist on disk).
 from __future__ import annotations
 
 import json
+import threading
 from pathlib import Path
 from typing import Any, Iterator
 from unittest.mock import patch
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 
@@ -83,6 +85,11 @@ def hermetic_connectors(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path
     monkeypatch.setattr(config_mod, "DEFAULT_CONFIG_DIR", tmp_path)
     monkeypatch.setattr(oauth_mod, "_CONNECTORS_DIR", conn_dir)
     monkeypatch.setattr(
+        oauth_mod,
+        "_GOOGLE_ACCOUNTS_DIR",
+        conn_dir / "google" / "accounts",
+    )
+    monkeypatch.setattr(
         oauth_mod, "_SHARED_GOOGLE_CREDENTIALS_PATH", str(conn_dir / "google.json")
     )
 
@@ -101,6 +108,7 @@ def hermetic_connectors(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path
         "openjarvis.connectors.spotify",
         "openjarvis.connectors.strava",
     ]
+    ConnectorRegistry.clear()
     for name in google_mods:
         module = importlib.import_module(name)
         # Always execute each decorator under the patched config root. Merely
@@ -130,6 +138,24 @@ def client(hermetic_connectors: Path) -> Iterator[TestClient]:
     app.include_router(create_connectors_router())
     with TestClient(app) as c:
         yield c
+
+
+def _start_state(
+    client: TestClient,
+    connector_id: str,
+    *,
+    account: str = "",
+) -> str:
+    """Start OAuth and return the one-time state from its provider URL."""
+    suffix = f"?account={account}" if account else ""
+    response = client.get(
+        f"/v1/connectors/{connector_id}/oauth/start{suffix}",
+        follow_redirects=False,
+    )
+    assert response.status_code in (302, 307), response.text
+    state = parse_qs(urlparse(response.headers["location"]).query).get("state")
+    assert state and len(state) == 1
+    return state[0]
 
 
 # ---------------------------------------------------------------------------
@@ -276,6 +302,22 @@ def test_oauth_start_redirects_to_consent(
     assert "oauth%2Fcallback" in location or "oauth/callback" in location
 
 
+def test_oauth_start_can_return_provider_url_for_authenticated_frontend(
+    client: TestClient,
+) -> None:
+    client.post("/v1/connectors/gdrive/connect", json={"code": _CLIENT_PAIR})
+
+    response = client.get(
+        "/v1/connectors/gdrive/oauth/start",
+        params={"response_mode": "json"},
+    )
+
+    assert response.status_code == 200
+    authorization_url = response.json()["authorization_url"]
+    assert authorization_url.startswith("https://accounts.google.com/o/oauth2/v2/auth")
+    assert parse_qs(urlparse(authorization_url).query)["state"][0]
+
+
 def test_oauth_start_without_creds_returns_400(client: TestClient) -> None:
     resp = client.get("/v1/connectors/gdrive/oauth/start", follow_redirects=False)
     assert resp.status_code == 400
@@ -293,6 +335,7 @@ def test_oauth_callback_exchanges_and_connects(
     import openjarvis.connectors.oauth as oauth_mod
 
     client.post("/v1/connectors/gdrive/connect", json={"code": _CLIENT_PAIR})
+    state = _start_state(client, "gdrive")
 
     fake_tokens = {
         "access_token": "ya29.REAL",
@@ -301,7 +344,10 @@ def test_oauth_callback_exchanges_and_connects(
         "expires_in": 3600,
     }
     with patch.object(oauth_mod, "_exchange_token", return_value=fake_tokens) as ex:
-        resp = client.get("/v1/connectors/gdrive/oauth/callback?code=authcode123")
+        resp = client.get(
+            "/v1/connectors/gdrive/oauth/callback",
+            params={"code": "authcode123", "state": state},
+        )
 
     assert resp.status_code == 200, resp.text
     assert "Connected!" in resp.text
@@ -324,7 +370,12 @@ def test_oauth_callback_exchanges_and_connects(
 
 
 def test_oauth_callback_error_param_renders_failure(client: TestClient) -> None:
-    resp = client.get("/v1/connectors/gdrive/oauth/callback?error=access_denied")
+    client.post("/v1/connectors/gdrive/connect", json={"code": _CLIENT_PAIR})
+    state = _start_state(client, "gdrive")
+    resp = client.get(
+        "/v1/connectors/gdrive/oauth/callback",
+        params={"error": "access_denied", "state": state},
+    )
     assert resp.status_code == 400
     assert "access_denied" in resp.text
 
@@ -335,12 +386,16 @@ def test_oauth_callback_exchange_failure_renders_error(
     import openjarvis.connectors.oauth as oauth_mod
 
     client.post("/v1/connectors/gdrive/connect", json={"code": _CLIENT_PAIR})
+    state = _start_state(client, "gdrive")
 
     def _boom(*_a: Any, **_k: Any) -> dict[str, Any]:
         raise RuntimeError("token endpoint 400")
 
     with patch.object(oauth_mod, "_exchange_token", side_effect=_boom):
-        resp = client.get("/v1/connectors/gdrive/oauth/callback?code=bad")
+        resp = client.get(
+            "/v1/connectors/gdrive/oauth/callback",
+            params={"code": "bad", "state": state},
+        )
 
     assert resp.status_code == 500
     assert "Token Exchange Failed" in resp.text
@@ -354,12 +409,16 @@ def test_oauth_callback_rejects_missing_access_token_without_false_success(
     import openjarvis.connectors.oauth as oauth_mod
 
     client.post("/v1/connectors/spotify/connect", json={"code": "id:secret"})
+    state = _start_state(client, "spotify")
     with patch.object(
         oauth_mod,
         "_exchange_token",
         return_value={"refresh_token": "refresh-only"},
     ):
-        resp = client.get("/v1/connectors/spotify/oauth/callback?code=bad-payload")
+        resp = client.get(
+            "/v1/connectors/spotify/oauth/callback",
+            params={"code": "bad-payload", "state": state},
+        )
 
     assert resp.status_code == 500
     assert "Token Exchange Failed" in resp.text
@@ -370,3 +429,203 @@ def test_oauth_callback_rejects_missing_access_token_without_false_success(
     from openjarvis.connectors.spotify import SpotifyConnector
 
     assert SpotifyConnector().is_connected() is False
+
+
+def test_named_account_oauth_state_binds_segmented_token(
+    client: TestClient,
+    hermetic_connectors: Path,
+) -> None:
+    """The callback account comes from one-time state, not caller input."""
+    import openjarvis.connectors.oauth as oauth_mod
+
+    response = client.post(
+        "/v1/connectors/gdrive/connect",
+        json={"code": _CLIENT_PAIR, "account": "work"},
+    )
+    assert response.status_code == 200
+    assert response.json()["oauth_start"].endswith("?account=work")
+    # Cache a sibling before tokens exist. The callback must invalidate every
+    # Google primitive that shares this named grant, not only gdrive.
+    assert (
+        client.get("/v1/connectors/gmail", params={"account": "work"}).json()[
+            "connected"
+        ]
+        is False
+    )
+    state = _start_state(client, "gdrive", account="work")
+
+    with patch.object(
+        oauth_mod,
+        "_exchange_token",
+        return_value={"access_token": "ya29.WORK", "refresh_token": "refresh"},
+    ):
+        callback = client.get(
+            "/v1/connectors/gdrive/oauth/callback",
+            params={"code": "work-code", "state": state, "account": "personal"},
+        )
+
+    assert callback.status_code == 200
+    account_file = hermetic_connectors / "google" / "accounts" / "work.json"
+    assert json.loads(account_file.read_text(encoding="utf-8"))["access_token"] == (
+        "ya29.WORK"
+    )
+    assert not (hermetic_connectors / "google" / "accounts" / "personal.json").exists()
+
+    detail = client.get("/v1/connectors/gdrive", params={"account": "work"})
+    assert detail.status_code == 200
+    assert detail.json()["account"] == "work"
+    assert detail.json()["connected"] is True
+    assert (
+        client.get("/v1/connectors/gmail", params={"account": "work"}).json()[
+            "connected"
+        ]
+        is True
+    )
+
+    listing = client.get("/v1/connectors").json()["connectors"]
+    gdrive = next(item for item in listing if item["connector_id"] == "gdrive")
+    assert gdrive["accounts"] == [
+        {"account": "work", "connected": True, "source_email": ""}
+    ]
+
+    disconnected = client.post(
+        "/v1/connectors/gdrive/disconnect",
+        params={"account": "work"},
+    )
+    assert disconnected.status_code == 200, disconnected.text
+    assert set(disconnected.json()["disconnected_connectors"]) == {
+        "gcalendar",
+        "gcontacts",
+        "gdrive",
+        "gmail",
+        "google_tasks",
+    }
+    assert not account_file.exists()
+    for connector_id in ("gdrive", "gmail", "gcalendar"):
+        response = client.get(
+            f"/v1/connectors/{connector_id}",
+            params={"account": "work"},
+        )
+        assert response.status_code == 200
+        assert response.json()["connected"] is False
+
+
+def test_named_account_rejected_for_non_google_connector(client: TestClient) -> None:
+    response = client.get("/v1/connectors/spotify", params={"account": "work"})
+
+    assert response.status_code == 400
+    assert "supported only for Google connectors" in response.json()["detail"]
+
+
+def test_connect_rejects_conflicting_account_and_profile(client: TestClient) -> None:
+    response = client.post(
+        "/v1/connectors/gdrive/connect",
+        json={"code": _CLIENT_PAIR, "account": "work", "profile": "personal"},
+    )
+
+    assert response.status_code == 400
+    assert "must name the same alias" in response.json()["detail"]
+
+
+def test_reauth_rejected_while_sibling_account_sync_is_active(
+    client: TestClient,
+) -> None:
+    import openjarvis.connectors.oauth as oauth_mod
+    import openjarvis.server.connectors_router as router_mod
+
+    client.post(
+        "/v1/connectors/gdrive/connect",
+        json={"code": _CLIENT_PAIR, "account": "work"},
+    )
+    state = _start_state(client, "gdrive", account="work")
+    started = threading.Event()
+    release = threading.Event()
+
+    class _BlockingGmail:
+        connector_id = "gmail"
+        _account = "work"
+
+        @staticmethod
+        def is_connected() -> bool:
+            return True
+
+        @staticmethod
+        def sync(*, since=None, cursor=None):
+            del since, cursor
+            started.set()
+            release.wait(timeout=5)
+            if False:
+                yield None
+
+    router_mod._instances["gmail:work"] = _BlockingGmail()
+    try:
+        sync_response = client.post(
+            "/v1/connectors/gmail/sync", params={"account": "work"}
+        )
+        assert sync_response.status_code == 200
+        assert started.wait(timeout=2)
+
+        with patch.object(oauth_mod, "_exchange_token") as exchange:
+            callback = client.get(
+                "/v1/connectors/gdrive/oauth/callback",
+                params={"code": "new-identity", "state": state},
+            )
+
+        assert callback.status_code == 409
+        assert "sync is active" in callback.json()["detail"]
+        exchange.assert_not_called()
+    finally:
+        release.set()
+
+
+def test_oauth_state_is_required_and_single_use(
+    client: TestClient,
+) -> None:
+    """Missing, forged, or replayed state never reaches token exchange."""
+    import openjarvis.connectors.oauth as oauth_mod
+
+    client.post("/v1/connectors/gdrive/connect", json={"code": _CLIENT_PAIR})
+    state = _start_state(client, "gdrive")
+
+    with patch.object(
+        oauth_mod,
+        "_exchange_token",
+        return_value={"access_token": "ya29.ONCE"},
+    ) as exchange:
+        missing = client.get(
+            "/v1/connectors/gdrive/oauth/callback",
+            params={"code": "missing"},
+        )
+        forged = client.get(
+            "/v1/connectors/gdrive/oauth/callback",
+            params={"code": "forged", "state": "not-issued"},
+        )
+        first = client.get(
+            "/v1/connectors/gdrive/oauth/callback",
+            params={"code": "valid", "state": state},
+        )
+        replay = client.get(
+            "/v1/connectors/gdrive/oauth/callback",
+            params={"code": "again", "state": state},
+        )
+
+    assert missing.status_code == 400
+    assert forged.status_code == 400
+    assert first.status_code == 200
+    assert replay.status_code == 400
+    exchange.assert_called_once()
+
+
+def test_oauth_error_is_html_escaped(client: TestClient) -> None:
+    """Provider error text cannot inject markup into the callback page."""
+    client.post("/v1/connectors/gdrive/connect", json={"code": _CLIENT_PAIR})
+    state = _start_state(client, "gdrive")
+
+    response = client.get(
+        "/v1/connectors/gdrive/oauth/callback",
+        params={"error": "<script>alert(1)</script>", "state": state},
+    )
+
+    assert response.status_code == 400
+    assert "<script>alert(1)</script>" not in response.text
+    assert "&lt;script&gt;" in response.text

--- a/tests/connectors/test_connectors_router_oauth.py
+++ b/tests/connectors/test_connectors_router_oauth.py
@@ -27,6 +27,7 @@ shared file when the caller-supplied path does not yet exist on disk).
 
 from __future__ import annotations
 
+import asyncio
 import json
 import threading
 from pathlib import Path
@@ -796,6 +797,60 @@ def test_raw_google_token_rejected_while_sibling_sync_is_active(
         assert account_file.read_bytes() == original_credentials
     finally:
         release.set()
+
+
+def test_connect_and_disconnect_are_serialized_on_one_event_loop(
+    client: TestClient,
+    hermetic_connectors: Path,
+) -> None:
+    """An earlier in-flight connect cannot recreate a disconnected profile."""
+    httpx = pytest.importorskip("httpx")
+    import openjarvis.connectors.oauth as oauth_mod
+    from openjarvis.connectors.gdrive import GDriveConnector
+
+    started = threading.Event()
+    release = threading.Event()
+
+    def blocking_callback(instance: Any, code: str) -> None:
+        started.set()
+        release.wait(timeout=5)
+        oauth_mod.save_tokens(instance._credentials_path, {"client_id": code})
+
+    async def run_race() -> tuple[Any, Any, bool]:
+        transport = httpx.ASGITransport(app=client.app)
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://testserver",
+        ) as async_client:
+            connect_task = asyncio.create_task(
+                async_client.post(
+                    "/v1/connectors/gdrive/connect",
+                    json={"code": "raw-code", "account": "work"},
+                )
+            )
+            assert await asyncio.to_thread(started.wait, 2)
+            disconnect_task = asyncio.create_task(
+                async_client.post(
+                    "/v1/connectors/gdrive/disconnect",
+                    params={"account": "work"},
+                )
+            )
+            await asyncio.sleep(0.05)
+            assert not disconnect_task.done()
+            release.set()
+            connect_response, disconnect_response = await asyncio.gather(
+                connect_task,
+                disconnect_task,
+            )
+        account_file = hermetic_connectors / "google" / "accounts" / "work.json"
+        return connect_response, disconnect_response, account_file.exists()
+
+    with patch.object(GDriveConnector, "handle_callback", blocking_callback):
+        connected, disconnected, credential_exists = asyncio.run(run_race())
+
+    assert connected.status_code == 200
+    assert disconnected.status_code == 200
+    assert credential_exists is False
 
 
 def test_oauth_state_is_required_and_single_use(

--- a/tests/connectors/test_gcalendar.py
+++ b/tests/connectors/test_gcalendar.py
@@ -135,6 +135,34 @@ def test_sync_yields_events(
     mock_events.assert_called_once()
 
 
+@patch("openjarvis.connectors.gcalendar._gcal_api_calendars_list")
+@patch("openjarvis.connectors.gcalendar._gcal_api_events_list")
+def test_named_account_sync_emits_scoped_provenance(
+    mock_events,
+    mock_calendars,
+    tmp_path: Path,
+) -> None:
+    from openjarvis.connectors.gcalendar import GCalendarConnector
+
+    creds = tmp_path / "work.json"
+    creds.write_text(
+        json.dumps({"token": "fake-access-token", "source_email": "work@example.com"}),
+        encoding="utf-8",
+    )
+    connector = GCalendarConnector(credentials_path=str(creds), account="work")
+    mock_calendars.return_value = _CALENDARS_RESPONSE
+    mock_events.return_value = _EVENTS_RESPONSE
+
+    doc = next(connector.sync())
+
+    assert doc.doc_id == "gcalendar:work:evt1"
+    assert doc.source_id == "work:evt1"
+    assert doc.metadata["account"] == "work"
+    assert doc.metadata["source_profile"] == "work"
+    assert doc.metadata["connector"] == "gcalendar"
+    assert doc.metadata["source_email"] == "work@example.com"
+
+
 def test_parse_event_timestamp_handles_all_day_events() -> None:
     """All-day events use their calendar date, not the current wall clock."""
     from openjarvis.connectors.gcalendar import _parse_event_timestamp  # noqa: PLC0415

--- a/tests/connectors/test_gcontacts.py
+++ b/tests/connectors/test_gcontacts.py
@@ -128,6 +128,34 @@ def test_sync_yields_contacts(
     mock_list.assert_called_once()
 
 
+@patch("openjarvis.connectors.gcontacts._gcontacts_api_list")
+def test_named_account_sync_emits_scoped_provenance(
+    mock_list,
+    tmp_path: Path,
+) -> None:
+    from openjarvis.connectors.gcontacts import GContactsConnector
+
+    creds = tmp_path / "work.json"
+    creds.write_text(
+        json.dumps({"token": "fake-access-token", "source_email": "work@example.com"}),
+        encoding="utf-8",
+    )
+    connector = GContactsConnector(credentials_path=str(creds), account="work")
+    mock_list.return_value = {
+        "connections": [_CONNECTIONS_RESPONSE["connections"][0]],
+        "nextPageToken": None,
+    }
+
+    doc = next(connector.sync())
+
+    assert doc.doc_id == "gcontacts:work:people/c1"
+    assert doc.source_id == "work:people/c1"
+    assert doc.metadata["account"] == "work"
+    assert doc.metadata["source_profile"] == "work"
+    assert doc.metadata["connector"] == "gcontacts"
+    assert doc.metadata["source_email"] == "work@example.com"
+
+
 # ---------------------------------------------------------------------------
 # Test 4 — disconnect removes the credentials file
 # ---------------------------------------------------------------------------

--- a/tests/connectors/test_gdrive.py
+++ b/tests/connectors/test_gdrive.py
@@ -133,6 +133,37 @@ def test_sync_yields_documents(
     assert mock_export.call_count == 2
 
 
+@patch("openjarvis.connectors.gdrive._gdrive_api_list_files")
+@patch("openjarvis.connectors.gdrive._gdrive_api_export")
+def test_named_account_sync_emits_scoped_provenance(
+    mock_export,
+    mock_list,
+    tmp_path: Path,
+) -> None:
+    from openjarvis.connectors.gdrive import GDriveConnector
+
+    creds = tmp_path / "work.json"
+    creds.write_text(
+        json.dumps({"token": "fake-access-token", "source_email": "work@example.com"}),
+        encoding="utf-8",
+    )
+    connector = GDriveConnector(credentials_path=str(creds), account="work")
+    mock_list.return_value = {
+        "files": [_FILES_LIST_RESPONSE["files"][0]],
+        "nextPageToken": None,
+    }
+    mock_export.return_value = _EXPORT_RESPONSE
+
+    doc = next(connector.sync())
+
+    assert doc.doc_id == "gdrive:work:doc1"
+    assert doc.source_id == "work:doc1"
+    assert doc.metadata["account"] == "work"
+    assert doc.metadata["source_profile"] == "work"
+    assert doc.metadata["connector"] == "gdrive"
+    assert doc.metadata["source_email"] == "work@example.com"
+
+
 # ---------------------------------------------------------------------------
 # Test 4 — disconnect removes the credentials file
 # ---------------------------------------------------------------------------

--- a/tests/connectors/test_gmail.py
+++ b/tests/connectors/test_gmail.py
@@ -167,6 +167,37 @@ def test_sync_yields_documents(
     assert mock_get.call_count == 2
 
 
+@patch("openjarvis.connectors.gmail._gmail_api_list_messages")
+@patch("openjarvis.connectors.gmail._gmail_api_get_message")
+def test_sync_with_account_namespaces_ids_and_metadata(
+    mock_get,
+    mock_list,
+    tmp_path: Path,
+) -> None:
+    """Named Google accounts get collision-safe IDs and provenance metadata."""
+    from openjarvis.connectors import oauth  # noqa: PLC0415
+    from openjarvis.connectors.gmail import GmailConnector  # noqa: PLC0415
+
+    with patch.object(oauth, "_GOOGLE_ACCOUNTS_DIR", tmp_path / "google" / "accounts"):
+        conn = GmailConnector(account="work")
+
+    creds_path = Path(conn._credentials_path)
+    creds_path.parent.mkdir(parents=True, exist_ok=True)
+    creds_path.write_text(json.dumps({"token": "fake-access-token"}), encoding="utf-8")
+
+    mock_list.return_value = {"messages": [{"id": "msg1"}]}
+    mock_get.return_value = _MSG1
+
+    docs: List[Document] = list(conn.sync())
+
+    assert len(docs) == 1
+    assert docs[0].doc_id == "gmail:work:msg1"
+    assert docs[0].source_id == "work:msg1"
+    assert docs[0].metadata["account"] == "work"
+    assert docs[0].metadata["source_profile"] == "work"
+    assert docs[0].metadata["connector_instance"] == "gmail:work"
+
+
 # ---------------------------------------------------------------------------
 # Test 5 — disconnect removes the credentials file
 # ---------------------------------------------------------------------------

--- a/tests/connectors/test_gmail.py
+++ b/tests/connectors/test_gmail.py
@@ -205,6 +205,32 @@ def test_sync_with_account_namespaces_ids_and_metadata(
     assert docs[0].metadata["source_profile"] == "work"
     assert docs[0].metadata["connector_instance"] == "gmail:work"
     assert docs[0].metadata["source_email"] == "work@example.com"
+    assert docs[0].url == (
+        "https://mail.google.com/mail/?authuser=work%40example.com#all/msg1"
+    )
+
+
+@patch("openjarvis.connectors.gmail._gmail_api_list_messages")
+@patch("openjarvis.connectors.gmail._gmail_api_get_message")
+def test_named_sync_omits_ambiguous_link_without_source_email(
+    mock_get,
+    mock_list,
+    tmp_path: Path,
+) -> None:
+    from openjarvis.connectors import oauth  # noqa: PLC0415
+    from openjarvis.connectors.gmail import GmailConnector  # noqa: PLC0415
+
+    with patch.object(oauth, "_GOOGLE_ACCOUNTS_DIR", tmp_path / "google" / "accounts"):
+        conn = GmailConnector(account="work")
+    creds_path = Path(conn._credentials_path)
+    creds_path.parent.mkdir(parents=True, exist_ok=True)
+    creds_path.write_text(json.dumps({"token": "fake-access-token"}), encoding="utf-8")
+    mock_list.return_value = {"messages": [{"id": "msg1"}]}
+    mock_get.return_value = _MSG1
+
+    [doc] = list(conn.sync())
+
+    assert doc.url == ""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/connectors/test_gmail.py
+++ b/tests/connectors/test_gmail.py
@@ -183,7 +183,15 @@ def test_sync_with_account_namespaces_ids_and_metadata(
 
     creds_path = Path(conn._credentials_path)
     creds_path.parent.mkdir(parents=True, exist_ok=True)
-    creds_path.write_text(json.dumps({"token": "fake-access-token"}), encoding="utf-8")
+    creds_path.write_text(
+        json.dumps(
+            {
+                "token": "fake-access-token",
+                "source_email": "work@example.com",
+            }
+        ),
+        encoding="utf-8",
+    )
 
     mock_list.return_value = {"messages": [{"id": "msg1"}]}
     mock_get.return_value = _MSG1
@@ -196,6 +204,7 @@ def test_sync_with_account_namespaces_ids_and_metadata(
     assert docs[0].metadata["account"] == "work"
     assert docs[0].metadata["source_profile"] == "work"
     assert docs[0].metadata["connector_instance"] == "gmail:work"
+    assert docs[0].metadata["source_email"] == "work@example.com"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/connectors/test_google_tasks.py
+++ b/tests/connectors/test_google_tasks.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import json
 from datetime import datetime
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -70,3 +72,26 @@ def test_sync_yields_tasks(connector):
     assert docs[0].title == "Review PR #42"
     assert docs[0].metadata["status"] == "needsAction"
     assert docs[1].metadata["status"] == "completed"
+
+
+def test_named_account_sync_emits_scoped_provenance(tmp_path: Path) -> None:
+    from openjarvis.connectors.google_tasks import GoogleTasksConnector
+
+    creds = tmp_path / "work.json"
+    creds.write_text(
+        json.dumps({"token": "fake-access-token", "source_email": "work@example.com"}),
+        encoding="utf-8",
+    )
+    connector = GoogleTasksConnector(credentials_path=str(creds), account="work")
+    with patch(
+        "openjarvis.connectors.google_tasks._tasks_api_get",
+        side_effect=[_TASK_LISTS_RESPONSE, {"items": [_TASKS_RESPONSE["items"][0]]}],
+    ):
+        doc = next(connector.sync())
+
+    assert doc.doc_id == "google_tasks:work:task1"
+    assert doc.source_id == "work:task1"
+    assert doc.metadata["account"] == "work"
+    assert doc.metadata["source_profile"] == "work"
+    assert doc.metadata["connector"] == "google_tasks"
+    assert doc.metadata["source_email"] == "work@example.com"

--- a/tests/connectors/test_hybrid_search.py
+++ b/tests/connectors/test_hybrid_search.py
@@ -270,3 +270,37 @@ def test_hybrid_search_intersects_sources_and_accounts(tmp_path: Path) -> None:
     assert {h.title for h in hits} == {"Work Drive roadmap"}
     assert all(h.source == "gdrive" for h in hits)
     assert all(h.account == "work" for h in hits)
+
+
+def test_account_scoped_hit_never_enriches_from_sibling_account_thread(
+    tmp_path: Path,
+) -> None:
+    ks = KnowledgeStore(db_path=tmp_path / "knowledge.db")
+    _store(
+        ks,
+        content="project alpha work update",
+        source="gmail",
+        title="Work update",
+        doc_id="gmail:work:1",
+        thread_id="provider-thread-123",
+        metadata={"account": "work", "source_profile": "work"},
+    )
+    _store(
+        ks,
+        content="PERSONAL SECRET project alpha",
+        source="gmail",
+        title="Personal update",
+        doc_id="gmail:personal:1",
+        thread_id="provider-thread-123",
+        metadata={"account": "personal", "source_profile": "personal"},
+        chunk_index=1,
+    )
+
+    hits = HybridSearch(ks).search("project alpha", accounts=["work"])
+
+    assert len(hits) == 1
+    assert hits[0].account == "work"
+    assert all(
+        "PERSONAL SECRET" not in context["snippet"]
+        for context in hits[0].thread_context
+    )

--- a/tests/connectors/test_hybrid_search.py
+++ b/tests/connectors/test_hybrid_search.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 
 from openjarvis.connectors.hybrid_search import HybridSearch
 from openjarvis.connectors.store import KnowledgeStore
@@ -179,3 +180,93 @@ def test_upcoming_calendar_includes_today_all_day_events() -> None:
         "All Day Today",
         "Morning Tomorrow",
     ]
+
+
+def _store(ks: KnowledgeStore, **kwargs) -> str:  # type: ignore[type-arg]
+    defaults = {
+        "content": "project alpha update",
+        "source": "gmail",
+        "doc_type": "email",
+        "doc_id": None,
+        "title": "",
+        "author": "",
+        "participants": None,
+        "timestamp": "2026-01-01T00:00:00",
+        "thread_id": None,
+        "url": None,
+        "metadata": None,
+        "chunk_index": 0,
+    }
+    defaults.update(kwargs)
+    return ks.store(**defaults)  # type: ignore[call-arg]
+
+
+def test_hybrid_search_filters_by_account_alias(tmp_path: Path) -> None:
+    """accounts=['work'] narrows all matching connectors to that profile."""
+    ks = KnowledgeStore(db_path=tmp_path / "knowledge.db")
+    _store(
+        ks,
+        content="project alpha renewal from work inbox",
+        title="Work renewal",
+        doc_id="gmail:work:1",
+        metadata={"account": "work", "source_profile": "work"},
+    )
+    _store(
+        ks,
+        content="project alpha renewal from personal inbox",
+        title="Personal renewal",
+        doc_id="gmail:personal:1",
+        metadata={"account": "personal", "source_profile": "personal"},
+        chunk_index=1,
+    )
+
+    hits = HybridSearch(ks).search("project alpha renewal", accounts=["work"])
+
+    assert hits
+    assert {h.title for h in hits} == {"Work renewal"}
+    assert all(h.account == "work" for h in hits)
+    assert all(h.source_profile == "work" for h in hits)
+
+
+def test_hybrid_search_intersects_sources_and_accounts(tmp_path: Path) -> None:
+    """Connector and account filters combine for precise persona-scoped queries."""
+    ks = KnowledgeStore(db_path=tmp_path / "knowledge.db")
+    _store(
+        ks,
+        content="project alpha roadmap in work Gmail",
+        source="gmail",
+        title="Work Gmail roadmap",
+        doc_id="gmail:work:1",
+        metadata={"account": "work", "source_profile": "work"},
+    )
+    _store(
+        ks,
+        content="project alpha roadmap in work Drive",
+        source="gdrive",
+        doc_type="file",
+        title="Work Drive roadmap",
+        doc_id="gdrive:work:1",
+        metadata={"account": "work", "source_profile": "work"},
+        chunk_index=1,
+    )
+    _store(
+        ks,
+        content="project alpha roadmap in personal Drive",
+        source="gdrive",
+        doc_type="file",
+        title="Personal Drive roadmap",
+        doc_id="gdrive:personal:1",
+        metadata={"account": "personal", "source_profile": "personal"},
+        chunk_index=2,
+    )
+
+    hits = HybridSearch(ks).search(
+        "project alpha roadmap",
+        sources=["gdrive"],
+        accounts=["work"],
+    )
+
+    assert hits
+    assert {h.title for h in hits} == {"Work Drive roadmap"}
+    assert all(h.source == "gdrive" for h in hits)
+    assert all(h.account == "work" for h in hits)

--- a/tests/connectors/test_oauth_flow.py
+++ b/tests/connectors/test_oauth_flow.py
@@ -7,6 +7,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from openjarvis.connectors.gcalendar import GCalendarConnector
+from openjarvis.connectors.gcontacts import GContactsConnector
+from openjarvis.connectors.gdrive import GDriveConnector
+from openjarvis.connectors.gmail import GmailConnector
+from openjarvis.connectors.google_tasks import GoogleTasksConnector
+
 
 def test_exchange_google_token_calls_endpoint() -> None:
     from openjarvis.connectors.oauth import exchange_google_token
@@ -190,6 +196,122 @@ def test_google_account_credentials_path_is_segmented(tmp_path: Path) -> None:
         path = oauth.google_account_credentials_path("work")
 
     assert path == str(tmp_path / "google" / "accounts" / "work.json")
+
+
+def test_resolve_google_credentials_keeps_explicit_path_isolated(
+    tmp_path: Path,
+) -> None:
+    """An explicit temp credentials path must not fall back to shared Google auth."""
+    from openjarvis.connectors import oauth
+
+    shared = tmp_path / "google.json"
+    oauth.save_tokens(
+        str(shared),
+        {
+            "access_token": "ya29.shared",
+            "client_id": "shared-id",
+            "client_secret": "shared-secret",
+        },
+    )
+
+    explicit = str(tmp_path / "gdrive.json")
+    with patch.object(oauth, "_SHARED_GOOGLE_CREDENTIALS_PATH", str(shared)):
+        resolved = oauth.resolve_google_credentials(
+            explicit,
+            allow_shared_fallback=False,
+        )
+
+    assert resolved == explicit
+
+
+def test_resolve_google_credentials_still_falls_back_for_implicit_default(
+    tmp_path: Path,
+) -> None:
+    """The legacy implicit default path still resolves to shared Google auth."""
+    from openjarvis.connectors import oauth
+
+    shared = tmp_path / "google.json"
+    oauth.save_tokens(
+        str(shared),
+        {
+            "access_token": "ya29.shared",
+            "client_id": "shared-id",
+            "client_secret": "shared-secret",
+        },
+    )
+
+    default_path = str(tmp_path / "gdrive.json")
+    with patch.object(oauth, "_SHARED_GOOGLE_CREDENTIALS_PATH", str(shared)):
+        resolved = oauth.resolve_google_credentials(
+            default_path,
+            allow_shared_fallback=True,
+        )
+
+    assert resolved == str(shared)
+
+
+@pytest.mark.parametrize(
+    ("connector_cls", "credentials_name"),
+    [
+        (GDriveConnector, "gdrive"),
+        (GCalendarConnector, "gcalendar"),
+        (GContactsConnector, "gcontacts"),
+        (GmailConnector, "gmail"),
+        (GoogleTasksConnector, "google_tasks"),
+    ],
+)
+def test_google_connectors_keep_explicit_temp_paths_isolated(
+    connector_cls,
+    credentials_name: str,
+    tmp_path: Path,
+) -> None:
+    """Explicit temp credentials never read real host Google auth state."""
+    from openjarvis.connectors import oauth
+
+    shared = tmp_path / "google.json"
+    oauth.save_tokens(
+        str(shared),
+        {
+            "access_token": "ya29.shared",
+            "client_id": "shared-id",
+            "client_secret": "shared-secret",
+        },
+    )
+
+    explicit = str(tmp_path / f"{credentials_name}.json")
+    with patch.object(oauth, "_SHARED_GOOGLE_CREDENTIALS_PATH", str(shared)):
+        connector = connector_cls(credentials_path=explicit)
+
+    assert str(connector._credentials_path) == explicit
+    assert connector.is_connected() is False
+
+
+def test_persist_google_oauth_tokens_keeps_explicit_path_isolated(
+    tmp_path: Path,
+) -> None:
+    """Explicit temp OAuth paths stay isolated from the shared legacy file."""
+    from openjarvis.connectors import oauth
+
+    shared = tmp_path / "google.json"
+    explicit = tmp_path / "gdrive.json"
+    token_payload = {
+        "access_token": "ya29.work",
+        "refresh_token": "1//work",
+        "token_type": "Bearer",
+        "expires_in": 3600,
+        "client_id": "client.apps.googleusercontent.com",
+        "client_secret": "secret",
+    }
+
+    with patch.object(oauth, "_SHARED_GOOGLE_CREDENTIALS_PATH", str(shared)):
+        oauth._persist_google_oauth_tokens(
+            str(explicit),
+            token_payload,
+            mirror_shared_credentials=False,
+        )
+
+    assert explicit.exists()
+    assert not shared.exists()
 
 
 def test_run_connector_oauth_saves_named_google_account_only(tmp_path: Path) -> None:

--- a/tests/connectors/test_oauth_flow.py
+++ b/tests/connectors/test_oauth_flow.py
@@ -201,10 +201,11 @@ def test_google_account_credentials_path_is_segmented(tmp_path: Path) -> None:
 def test_resolve_google_credentials_keeps_explicit_path_isolated(
     tmp_path: Path,
 ) -> None:
-    """An explicit temp credentials path must not fall back to shared Google auth."""
+    """An explicit temp credentials path must not fall back or segment."""
     from openjarvis.connectors import oauth
 
     shared = tmp_path / "google.json"
+    account_dir = tmp_path / "google" / "accounts"
     oauth.save_tokens(
         str(shared),
         {
@@ -215,9 +216,13 @@ def test_resolve_google_credentials_keeps_explicit_path_isolated(
     )
 
     explicit = str(tmp_path / "gdrive.json")
-    with patch.object(oauth, "_SHARED_GOOGLE_CREDENTIALS_PATH", str(shared)):
+    with (
+        patch.object(oauth, "_SHARED_GOOGLE_CREDENTIALS_PATH", str(shared)),
+        patch.object(oauth, "_GOOGLE_ACCOUNTS_DIR", account_dir),
+    ):
         resolved = oauth.resolve_google_credentials(
             explicit,
+            account="work",
             allow_shared_fallback=False,
         )
 
@@ -284,6 +289,34 @@ def test_google_connectors_keep_explicit_temp_paths_isolated(
 
     assert str(connector._credentials_path) == explicit
     assert connector.is_connected() is False
+
+
+@pytest.mark.parametrize(
+    ("connector_cls", "credentials_name"),
+    [
+        (GDriveConnector, "gdrive"),
+        (GCalendarConnector, "gcalendar"),
+        (GContactsConnector, "gcontacts"),
+        (GmailConnector, "gmail"),
+        (GoogleTasksConnector, "google_tasks"),
+    ],
+)
+def test_google_connectors_prefer_explicit_path_over_account_alias(
+    connector_cls,
+    credentials_name: str,
+    tmp_path: Path,
+) -> None:
+    """credentials_path wins even when account is supplied."""
+    from openjarvis.connectors import oauth
+
+    account_dir = tmp_path / "google" / "accounts"
+    explicit = str(tmp_path / f"{credentials_name}.json")
+
+    with patch.object(oauth, "_GOOGLE_ACCOUNTS_DIR", account_dir):
+        connector = connector_cls(credentials_path=explicit, account="work")
+
+    assert str(connector._credentials_path) == explicit
+    assert str(connector._credentials_path) != str(account_dir / "work.json")
 
 
 def test_persist_google_oauth_tokens_keeps_explicit_path_isolated(

--- a/tests/connectors/test_oauth_flow.py
+++ b/tests/connectors/test_oauth_flow.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import base64
+import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 
@@ -198,6 +201,74 @@ def test_google_account_credentials_path_is_segmented(tmp_path: Path) -> None:
     assert path == str(tmp_path / "google" / "accounts" / "work.json")
 
 
+def test_google_account_aliases_are_case_normalized_and_portable(
+    tmp_path: Path,
+) -> None:
+    from openjarvis.connectors import oauth
+
+    with patch.object(oauth, "_GOOGLE_ACCOUNTS_DIR", tmp_path):
+        assert oauth.google_account_credentials_path(" Work ") == str(
+            tmp_path / "work.json"
+        )
+        with pytest.raises(ValueError, match="Account aliases"):
+            oauth.google_account_credentials_path("CON")
+        with pytest.raises(ValueError, match="Account aliases"):
+            oauth.google_account_credentials_path("work.")
+
+
+def test_list_google_accounts_reports_aliases_without_secrets(tmp_path: Path) -> None:
+    from openjarvis.connectors import oauth
+
+    account_dir = tmp_path / "google" / "accounts"
+    with patch.object(oauth, "_GOOGLE_ACCOUNTS_DIR", account_dir):
+        oauth.save_tokens(
+            oauth.google_account_credentials_path("work"),
+            {"access_token": "ya29.secret", "refresh_token": "1//secret"},
+        )
+        oauth.save_tokens(
+            oauth.google_account_credentials_path("personal"),
+            {"client_id": "configured-but-not-authorized"},
+        )
+        profiles = oauth.list_google_accounts()
+
+    assert profiles == [
+        {"account": "personal", "connected": False, "source_email": ""},
+        {"account": "work", "connected": True, "source_email": ""},
+    ]
+    assert "ya29.secret" not in repr(profiles)
+    assert "1//secret" not in repr(profiles)
+
+
+def test_google_source_email_requires_verified_id_token_claim() -> None:
+    from openjarvis.connectors.oauth import google_source_email_from_tokens
+
+    def _id_token(payload: dict) -> str:
+        encoded = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode()
+        return f"header.{encoded.rstrip('=')}.signature"
+
+    assert (
+        google_source_email_from_tokens(
+            {
+                "id_token": _id_token(
+                    {"email": "person@example.com", "email_verified": True}
+                )
+            }
+        )
+        == "person@example.com"
+    )
+    assert (
+        google_source_email_from_tokens(
+            {
+                "id_token": _id_token(
+                    {"email": "spoof@example.com", "email_verified": False}
+                )
+            }
+        )
+        == ""
+    )
+    assert google_source_email_from_tokens({"id_token": "invalid"}) == ""
+
+
 def test_resolve_google_credentials_keeps_explicit_path_isolated(
     tmp_path: Path,
 ) -> None:
@@ -356,8 +427,10 @@ def test_run_connector_oauth_saves_named_google_account_only(tmp_path: Path) -> 
     with (
         patch.object(oauth, "_GOOGLE_ACCOUNTS_DIR", account_dir),
         patch.object(oauth, "_CONNECTORS_DIR", legacy_dir),
-        patch("openjarvis.connectors.oauth.open_browser"),
-        patch("openjarvis.connectors.oauth._wait_for_callback_code", return_value="c"),
+        patch("openjarvis.connectors.oauth.open_browser") as mock_browser,
+        patch(
+            "openjarvis.connectors.oauth._wait_for_callback_code", return_value="c"
+        ) as wait_for_callback,
         patch(
             "openjarvis.connectors.oauth._exchange_token",
             return_value={
@@ -377,3 +450,12 @@ def test_run_connector_oauth_saves_named_google_account_only(tmp_path: Path) -> 
 
     assert (account_dir / "work.json").exists()
     assert not (legacy_dir / "gmail.json").exists()
+    auth_url = mock_browser.call_args.args[0]
+    state = parse_qs(urlparse(auth_url).query)["state"][0]
+    assert state
+    wait_for_callback.assert_called_once_with(
+        host="127.0.0.1",
+        port=8789,
+        path="/callback",
+        expected_state=state,
+    )

--- a/tests/connectors/test_oauth_flow.py
+++ b/tests/connectors/test_oauth_flow.py
@@ -181,3 +181,44 @@ def test_gdrive_auth_url_returns_consent_url_with_client_id(
     url = conn.auth_url()
     assert "accounts.google.com" in url
     assert "test-id.apps.googleusercontent.com" in url
+
+
+def test_google_account_credentials_path_is_segmented(tmp_path: Path) -> None:
+    from openjarvis.connectors import oauth
+
+    with patch.object(oauth, "_GOOGLE_ACCOUNTS_DIR", tmp_path / "google" / "accounts"):
+        path = oauth.google_account_credentials_path("work")
+
+    assert path == str(tmp_path / "google" / "accounts" / "work.json")
+
+
+def test_run_connector_oauth_saves_named_google_account_only(tmp_path: Path) -> None:
+    from openjarvis.connectors import oauth
+
+    account_dir = tmp_path / "google" / "accounts"
+    legacy_dir = tmp_path / "legacy"
+
+    with (
+        patch.object(oauth, "_GOOGLE_ACCOUNTS_DIR", account_dir),
+        patch.object(oauth, "_CONNECTORS_DIR", legacy_dir),
+        patch("openjarvis.connectors.oauth.open_browser"),
+        patch("openjarvis.connectors.oauth._wait_for_callback_code", return_value="c"),
+        patch(
+            "openjarvis.connectors.oauth._exchange_token",
+            return_value={
+                "access_token": "ya29.work",
+                "refresh_token": "1//work",
+                "token_type": "Bearer",
+                "expires_in": 3600,
+            },
+        ),
+    ):
+        oauth.run_connector_oauth(
+            "gmail",
+            "client.apps.googleusercontent.com",
+            "secret",
+            account="work",
+        )
+
+    assert (account_dir / "work.json").exists()
+    assert not (legacy_dir / "gmail.json").exists()

--- a/tests/connectors/test_oauth_flow.py
+++ b/tests/connectors/test_oauth_flow.py
@@ -232,14 +232,51 @@ def test_list_google_accounts_reports_aliases_without_secrets(tmp_path: Path) ->
         profiles = oauth.list_google_accounts()
 
     assert profiles == [
-        {"account": "personal", "connected": False, "source_email": ""},
-        {"account": "work", "connected": True, "source_email": ""},
+        {
+            "account": "personal",
+            "enabled": True,
+            "connected": False,
+            "source_email": "",
+        },
+        {
+            "account": "work",
+            "enabled": True,
+            "connected": True,
+            "source_email": "",
+        },
     ]
     assert "ya29.secret" not in repr(profiles)
     assert "1//secret" not in repr(profiles)
 
 
-def test_google_source_email_requires_verified_id_token_claim() -> None:
+def test_list_google_accounts_includes_disabled_declared_profile(
+    tmp_path: Path,
+) -> None:
+    from openjarvis.connectors import oauth
+    from openjarvis.core.config import GoogleAccountProfileConfig, JarvisConfig
+
+    config = JarvisConfig()
+    config.connectors.google.accounts["Work"] = GoogleAccountProfileConfig(
+        enabled=False
+    )
+
+    with (
+        patch.object(oauth, "_GOOGLE_ACCOUNTS_DIR", tmp_path / "accounts"),
+        patch("openjarvis.core.config.load_config", return_value=config),
+    ):
+        profiles = oauth.list_google_accounts()
+
+    assert profiles == [
+        {
+            "account": "work",
+            "enabled": False,
+            "connected": False,
+            "source_email": "",
+        }
+    ]
+
+
+def test_google_source_email_requires_provider_asserted_verified_email() -> None:
     from openjarvis.connectors.oauth import google_source_email_from_tokens
 
     def _id_token(payload: dict) -> str:

--- a/tests/connectors/test_store.py
+++ b/tests/connectors/test_store.py
@@ -86,6 +86,31 @@ def test_retrieve_filter_by_source(ks: KnowledgeStore) -> None:
     assert len(obsidian_results) >= 1
 
 
+def test_retrieve_filter_by_source_account_alias(ks: KnowledgeStore) -> None:
+    """source='gmail:work' filters to Gmail chunks from that account alias."""
+    _store(
+        ks,
+        content="Email about project alpha",
+        source="gmail",
+        doc_type="email",
+        metadata={"account": "work"},
+    )
+    _store(
+        ks,
+        content="Email about project alpha",
+        source="gmail",
+        doc_type="email",
+        metadata={"account": "personal"},
+        chunk_index=1,
+    )
+
+    work_results = ks.retrieve("project alpha", top_k=10, source="gmail:work")
+
+    assert len(work_results) >= 1
+    assert all(r.metadata.get("account") == "work" for r in work_results)
+    assert "gmail:work" in ks.distinct_sources()
+
+
 def test_retrieve_filter_by_doc_type(ks: KnowledgeStore) -> None:
     """retrieve() with doc_type= filters correctly."""
     _store(

--- a/tests/connectors/test_store.py
+++ b/tests/connectors/test_store.py
@@ -359,6 +359,35 @@ def test_delete_by_sources_can_purge_one_account_only(ks: KnowledgeStore) -> Non
     ]
 
 
+def test_delete_by_sources_account_filter_tolerates_malformed_metadata(
+    ks: KnowledgeStore,
+) -> None:
+    """A corrupt legacy/IMAP row must not abort named-account cleanup."""
+    _store(
+        ks,
+        content="work inbox document",
+        source="gmail",
+        doc_id="gmail:work:1",
+        metadata={"account": "work"},
+    )
+    _store(
+        ks,
+        content="legacy IMAP document",
+        source="gmail",
+        doc_id="gmail:imap:1",
+    )
+    ks._conn.execute(
+        "UPDATE knowledge_chunks SET metadata = 'not-json' WHERE doc_id = ?",
+        ("gmail:imap:1",),
+    )
+    ks._conn.commit()
+
+    assert ks.delete_by_sources(("gmail",), account="work") == 1
+
+    remaining = ks._conn.execute("SELECT doc_id FROM knowledge_chunks").fetchall()
+    assert [row["doc_id"] for row in remaining] == ["gmail:imap:1"]
+
+
 def test_delete_by_sources_can_purge_only_legacy_unscoped_rows(
     ks: KnowledgeStore,
 ) -> None:

--- a/tests/connectors/test_store.py
+++ b/tests/connectors/test_store.py
@@ -505,6 +505,35 @@ def test_legacy_attributed_delete_handles_malformed_metadata_atomically(
     assert [row["doc_id"] for row in remaining] == ["gmail:ambiguous:1"]
 
 
+def test_attributed_delete_recognizes_legacy_gmail_imap_uid(
+    ks: KnowledgeStore,
+) -> None:
+    _store(
+        ks,
+        content="named Google OAuth mail",
+        source="gmail",
+        doc_id="gmail:work:1",
+        metadata={"account": "work", "connector": "gmail"},
+    )
+    _store(
+        ks,
+        content="legacy IMAP mail",
+        source="gmail",
+        doc_id="gmail:imap:1",
+        metadata={"imap_uid": "41", "imap_uidvalidity": "777"},
+    )
+
+    assert (
+        ks.delete_unscoped_sources_with_attribution(
+            (),
+            {"gmail": "gmail_imap"},
+        )
+        == 1
+    )
+    remaining = ks._conn.execute("SELECT doc_id FROM knowledge_chunks").fetchall()
+    assert [row["doc_id"] for row in remaining] == ["gmail:work:1"]
+
+
 def test_legacy_attributed_delete_rolls_back_whole_statement_on_error(
     ks: KnowledgeStore,
 ) -> None:

--- a/tests/connectors/test_store.py
+++ b/tests/connectors/test_store.py
@@ -111,6 +111,25 @@ def test_retrieve_filter_by_source_account_alias(ks: KnowledgeStore) -> None:
     assert "gmail:work" in ks.distinct_sources()
 
 
+def test_retrieve_rejects_conflicting_scoped_and_explicit_accounts(
+    ks: KnowledgeStore,
+) -> None:
+    _store(
+        ks,
+        content="project alpha from personal",
+        source="gmail",
+        doc_type="email",
+        metadata={"account": "personal"},
+    )
+
+    with pytest.raises(ValueError, match="Conflicting account filters"):
+        ks.retrieve(
+            "project alpha",
+            source="gmail:work",
+            account="personal",
+        )
+
+
 def test_retrieve_filter_by_doc_type(ks: KnowledgeStore) -> None:
     """retrieve() with doc_type= filters correctly."""
     _store(
@@ -277,6 +296,40 @@ def test_delete_by_sources_removes_all_owned_sources_atomically(
 
     assert ks.delete_by_sources(("owned_a", "owned_b")) == 2
     assert ks.distinct_sources() == ["other"]
+
+
+def test_delete_by_sources_can_purge_one_account_only(ks: KnowledgeStore) -> None:
+    """Disconnecting one Google profile preserves sibling-profile chunks."""
+    _store(
+        ks,
+        content="work inbox document",
+        source="gmail",
+        doc_id="gmail:work:1",
+        metadata={"account": "work"},
+    )
+    _store(
+        ks,
+        content="personal inbox document",
+        source="gmail",
+        doc_id="gmail:personal:1",
+        metadata={"account": "personal"},
+    )
+    _store(
+        ks,
+        content="legacy inbox document",
+        source="gmail",
+        doc_id="gmail:legacy:1",
+    )
+
+    assert ks.delete_by_sources(("gmail",), account="work") == 1
+
+    remaining = ks._conn.execute(
+        "SELECT doc_id FROM knowledge_chunks ORDER BY doc_id"
+    ).fetchall()
+    assert [row["doc_id"] for row in remaining] == [
+        "gmail:legacy:1",
+        "gmail:personal:1",
+    ]
 
 
 def test_clear(ks: KnowledgeStore) -> None:

--- a/tests/connectors/test_store.py
+++ b/tests/connectors/test_store.py
@@ -111,6 +111,33 @@ def test_retrieve_filter_by_source_account_alias(ks: KnowledgeStore) -> None:
     assert "gmail:work" in ks.distinct_sources()
 
 
+def test_distinct_sources_hides_out_of_scope_accounts_but_keeps_unscoped(
+    ks: KnowledgeStore,
+) -> None:
+    _store(
+        ks,
+        content="work mail",
+        source="gmail",
+        source_id="work:message",
+        metadata={"account": "work"},
+    )
+    _store(
+        ks,
+        content="personal file",
+        source="gdrive",
+        source_id="personal:file",
+        metadata={"account": "personal"},
+    )
+    _store(ks, content="shared message", source="slack", source_id="shared")
+
+    assert ks.distinct_sources(accounts=["work"]) == [
+        "gmail",
+        "gmail:work",
+        "slack",
+    ]
+    assert ks.distinct_sources(accounts=[]) == ["slack"]
+
+
 def test_retrieve_rejects_conflicting_scoped_and_explicit_accounts(
     ks: KnowledgeStore,
 ) -> None:

--- a/tests/connectors/test_store.py
+++ b/tests/connectors/test_store.py
@@ -386,6 +386,78 @@ def test_delete_by_sources_can_require_positive_connector_provenance(
     assert [row["doc_id"] for row in remaining] == ["gmail:imap:1"]
 
 
+def test_legacy_attributed_delete_handles_malformed_metadata_atomically(
+    ks: KnowledgeStore,
+) -> None:
+    _store(
+        ks,
+        content="legacy Drive row",
+        source="gdrive",
+        doc_id="gdrive:legacy:1",
+    )
+    _store(
+        ks,
+        content="ambiguous Gmail row",
+        source="gmail",
+        doc_id="gmail:ambiguous:1",
+    )
+    ks._conn.execute(
+        "UPDATE knowledge_chunks SET metadata = 'not-json' WHERE source = 'gmail'"
+    )
+    ks._conn.commit()
+
+    deleted = ks.delete_unscoped_sources_with_attribution(
+        ("gdrive",),
+        {"gmail": "gmail"},
+    )
+
+    assert deleted == 1
+    remaining = ks._conn.execute("SELECT doc_id FROM knowledge_chunks").fetchall()
+    assert [row["doc_id"] for row in remaining] == ["gmail:ambiguous:1"]
+
+
+def test_legacy_attributed_delete_rolls_back_whole_statement_on_error(
+    ks: KnowledgeStore,
+) -> None:
+    _store(
+        ks,
+        content="legacy Drive row",
+        source="gdrive",
+        doc_id="gdrive:legacy:1",
+    )
+    _store(
+        ks,
+        content="legacy Gmail row",
+        source="gmail",
+        doc_id="gmail:legacy:1",
+        metadata={"connector": "gmail"},
+    )
+    ks._conn.executescript(
+        """
+        CREATE TRIGGER reject_legacy_gmail_delete
+        BEFORE DELETE ON knowledge_chunks
+        WHEN OLD.source = 'gmail'
+        BEGIN
+          SELECT RAISE(ABORT, 'simulated migration failure');
+        END;
+        """
+    )
+
+    with pytest.raises(Exception, match="simulated migration failure"):
+        ks.delete_unscoped_sources_with_attribution(
+            ("gdrive",),
+            {"gmail": "gmail"},
+        )
+
+    remaining = ks._conn.execute(
+        "SELECT doc_id FROM knowledge_chunks ORDER BY doc_id"
+    ).fetchall()
+    assert [row["doc_id"] for row in remaining] == [
+        "gdrive:legacy:1",
+        "gmail:legacy:1",
+    ]
+
+
 def test_clear(ks: KnowledgeStore) -> None:
     """clear() removes all stored documents."""
     _store(ks, content="Document one about research")

--- a/tests/connectors/test_store.py
+++ b/tests/connectors/test_store.py
@@ -332,6 +332,29 @@ def test_delete_by_sources_can_purge_one_account_only(ks: KnowledgeStore) -> Non
     ]
 
 
+def test_delete_by_sources_can_purge_only_legacy_unscoped_rows(
+    ks: KnowledgeStore,
+) -> None:
+    _store(
+        ks,
+        content="legacy inbox document",
+        source="gmail",
+        doc_id="gmail:legacy:1",
+    )
+    _store(
+        ks,
+        content="work inbox document",
+        source="gmail",
+        doc_id="gmail:work:1",
+        metadata={"account": "work"},
+    )
+
+    assert ks.delete_by_sources(("gmail",), unscoped_only=True) == 1
+
+    remaining = ks._conn.execute("SELECT doc_id FROM knowledge_chunks").fetchall()
+    assert [row["doc_id"] for row in remaining] == ["gmail:work:1"]
+
+
 def test_clear(ks: KnowledgeStore) -> None:
     """clear() removes all stored documents."""
     _store(ks, content="Document one about research")

--- a/tests/connectors/test_store.py
+++ b/tests/connectors/test_store.py
@@ -138,6 +138,39 @@ def test_distinct_sources_hides_out_of_scope_accounts_but_keeps_unscoped(
     assert ks.distinct_sources(accounts=[]) == ["slack"]
 
 
+def test_account_scope_keeps_positive_gmail_imap_provenance(
+    ks: KnowledgeStore,
+) -> None:
+    _store(
+        ks,
+        content="work Google OAuth mail",
+        source="gmail",
+        doc_id="gmail:work:1",
+        metadata={"account": "work", "connector": "gmail"},
+    )
+    _store(
+        ks,
+        content="personal Google OAuth mail",
+        source="gmail",
+        doc_id="gmail:personal:1",
+        metadata={"account": "personal", "connector": "gmail"},
+    )
+    _store(
+        ks,
+        content="independent IMAP mail",
+        source="gmail",
+        doc_id="gmail:imap:1",
+        metadata={"imap_uid": "41", "imap_uidvalidity": "777"},
+    )
+
+    results = ks.retrieve("mail", top_k=10, accounts=["work"])
+
+    assert {result.metadata["doc_id"] for result in results} == {
+        "gmail:imap:1",
+        "gmail:work:1",
+    }
+
+
 def test_retrieve_rejects_conflicting_scoped_and_explicit_accounts(
     ks: KnowledgeStore,
 ) -> None:

--- a/tests/connectors/test_store.py
+++ b/tests/connectors/test_store.py
@@ -355,6 +355,37 @@ def test_delete_by_sources_can_purge_only_legacy_unscoped_rows(
     assert [row["doc_id"] for row in remaining] == ["gmail:work:1"]
 
 
+def test_delete_by_sources_can_require_positive_connector_provenance(
+    ks: KnowledgeStore,
+) -> None:
+    _store(
+        ks,
+        content="legacy Google OAuth mail",
+        source="gmail",
+        doc_id="gmail:oauth:1",
+        metadata={"connector": "gmail"},
+    )
+    _store(
+        ks,
+        content="unrelated IMAP mail",
+        source="gmail",
+        doc_id="gmail:imap:1",
+        metadata={"imap_uid": "41", "imap_uidvalidity": "777"},
+    )
+
+    assert (
+        ks.delete_by_sources(
+            ("gmail",),
+            unscoped_only=True,
+            metadata_connector="gmail",
+        )
+        == 1
+    )
+
+    remaining = ks._conn.execute("SELECT doc_id FROM knowledge_chunks").fetchall()
+    assert [row["doc_id"] for row in remaining] == ["gmail:imap:1"]
+
+
 def test_clear(ks: KnowledgeStore) -> None:
     """clear() removes all stored documents."""
     _store(ks, content="Document one about research")

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from openjarvis.core.config import (
     AgentConfig,
     ChannelConfig,
+    DigestConfig,
     EngineConfig,
     GpuInfo,
     HardwareInfo,
@@ -223,6 +224,29 @@ class TestAgentConfigNew:
         assert ac.context_from_memory is True
         assert ac.tools == ""
         assert ac.max_turns == 10
+        assert ac.default_accounts == []
+
+    def test_named_account_defaults(self) -> None:
+        assert AgentConfig(default_accounts=["work"]).default_accounts == ["work"]
+        assert DigestConfig(accounts=["personal", "work"]).accounts == [
+            "personal",
+            "work",
+        ]
+
+    def test_loads_named_google_account_profiles(self, tmp_path: Path) -> None:
+        config_path = tmp_path / "config.toml"
+        config_path.write_text(
+            "[connectors.google.accounts.personal]\n"
+            "enabled = true\n\n"
+            "[connectors.google.accounts.work]\n"
+            "enabled = false\n",
+            encoding="utf-8",
+        )
+
+        cfg = load_config(config_path)
+
+        assert cfg.connectors.google.accounts["personal"].enabled is True
+        assert cfg.connectors.google.accounts["work"].enabled is False
 
     def test_default_tools_backward_compat(self) -> None:
         ac = AgentConfig()

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -254,6 +254,9 @@ class TestAgentConfigNew:
         assert cfg.connectors.google.enabled_aliases(
             ["Work", "Personal", "personal"]
         ) == ["personal"]
+        assert cfg.connectors.google.account_scope([]) is None
+        assert cfg.connectors.google.account_scope(["work"]) == []
+        assert cfg.connectors.google.account_scope(["personal", "work"]) == ["personal"]
 
     def test_default_tools_backward_compat(self) -> None:
         ac = AgentConfig()

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -248,6 +248,13 @@ class TestAgentConfigNew:
         assert cfg.connectors.google.accounts["personal"].enabled is True
         assert cfg.connectors.google.accounts["work"].enabled is False
 
+        assert cfg.connectors.google.is_enabled("PERSONAL") is True
+        assert cfg.connectors.google.is_enabled("work") is False
+        assert cfg.connectors.google.is_enabled("unlisted") is True
+        assert cfg.connectors.google.enabled_aliases(
+            ["Work", "Personal", "personal"]
+        ) == ["personal"]
+
     def test_default_tools_backward_compat(self) -> None:
         ac = AgentConfig()
         ac.default_tools = "calculator,think"

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from openjarvis.core.config import (
     AgentConfig,
     ChannelConfig,
@@ -257,6 +259,23 @@ class TestAgentConfigNew:
         assert cfg.connectors.google.account_scope([]) is None
         assert cfg.connectors.google.account_scope(["work"]) == []
         assert cfg.connectors.google.account_scope(["personal", "work"]) == ["personal"]
+
+    def test_google_account_aliases_reject_canonical_duplicates(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        config_path = tmp_path / "config.toml"
+        config_path.write_text(
+            "[connectors.google.accounts.Work]\n"
+            "enabled = true\n\n"
+            "[connectors.google.accounts.work]\n"
+            "enabled = false\n",
+            encoding="utf-8",
+        )
+
+        load_config.cache_clear()
+        with pytest.raises(ValueError, match="Duplicate Google account profile"):
+            load_config(config_path)
 
     def test_default_tools_backward_compat(self) -> None:
         ac = AgentConfig()

--- a/tests/server/test_auth_middleware.py
+++ b/tests/server/test_auth_middleware.py
@@ -20,6 +20,14 @@ def _make_app(api_key: str) -> FastAPI:
     async def models():
         return {"models": []}
 
+    @app.get("/v1/connectors/gdrive/oauth/callback")
+    async def oauth_callback():
+        return {"status": "callback reached"}
+
+    @app.get("/v1/connectors/gdrive/oauth/start")
+    async def oauth_start():
+        return {"status": "start reached"}
+
     @app.get("/health")
     async def health():
         return {"status": "ok"}
@@ -76,6 +84,10 @@ class TestAuthMiddleware:
     def test_metrics_accepts_valid_key(self, client):
         resp = client.get("/metrics", headers={"Authorization": "Bearer oj_sk_test123"})
         assert resp.status_code == 200
+
+    def test_oauth_callback_exempt_but_start_remains_protected(self, client):
+        assert client.get("/v1/connectors/gdrive/oauth/callback").status_code == 200
+        assert client.get("/v1/connectors/gdrive/oauth/start").status_code == 401
 
     def test_no_key_configured_allows_all(self):
         client = TestClient(_make_app(""))

--- a/tests/server/test_connectors_router.py
+++ b/tests/server/test_connectors_router.py
@@ -495,6 +495,60 @@ def test_google_disconnect_purges_attributed_gmail_but_preserves_imap(app) -> No
             _instances.pop(connector_id, None)
 
 
+def test_default_google_disconnect_preserves_named_account_rows(app) -> None:
+    """Disconnecting legacy/default Google auth must not purge named profiles."""
+    from openjarvis.connectors._stubs import SyncStatus
+    from openjarvis.connectors.store import KnowledgeStore
+    from openjarvis.server.connectors_router import _instances
+
+    class FakeConnector:
+        def __init__(self, connector_id):
+            self.connector_id = connector_id
+            self.connected = True
+
+        def is_connected(self):
+            return self.connected
+
+        def disconnect(self):
+            self.connected = False
+
+        def sync_status(self):
+            return SyncStatus()
+
+    google_ids = ("gcalendar", "gcontacts", "gdrive", "gmail", "google_tasks")
+    for connector_id in google_ids:
+        _instances[connector_id] = FakeConnector(connector_id)
+    try:
+        with KnowledgeStore() as store:
+            store.store(
+                content="default Drive sentinel",
+                source="gdrive",
+                doc_type="file",
+                doc_id="gdrive:default-owned",
+                metadata={"connector": "gdrive"},
+            )
+            store.store(
+                content="work Drive sentinel",
+                source="gdrive",
+                doc_type="file",
+                doc_id="gdrive:work-owned",
+                metadata={"connector": "gdrive", "account": "work"},
+            )
+
+        response = app.post("/v1/connectors/gdrive/disconnect")
+        assert response.status_code == 200, response.text
+
+        with KnowledgeStore() as store:
+            remaining = store._conn.execute(
+                "SELECT doc_id FROM knowledge_chunks WHERE source = 'gdrive'"
+            ).fetchall()
+            assert [row["doc_id"] for row in remaining] == ["gdrive:work-owned"]
+            store.delete_by_source("gdrive")
+    finally:
+        for connector_id in google_ids:
+            _instances.pop(connector_id, None)
+
+
 def test_disconnect_restores_checkpoint_when_purge_fails(app, monkeypatch) -> None:
     from openjarvis.connectors.pipeline import IngestionPipeline
     from openjarvis.connectors.store import KnowledgeStore

--- a/tests/server/test_connectors_router.py
+++ b/tests/server/test_connectors_router.py
@@ -595,6 +595,62 @@ def test_disconnect_restores_checkpoint_when_purge_fails(app, monkeypatch) -> No
         _instances.pop("obsidian", None)
 
 
+def test_disconnect_restores_all_checkpoints_when_reset_fails(app, monkeypatch) -> None:
+    """A mid-provider reset failure must roll back earlier checkpoint resets."""
+    from openjarvis.connectors.pipeline import IngestionPipeline
+    from openjarvis.connectors.store import KnowledgeStore
+    from openjarvis.connectors.sync_engine import SyncEngine
+    from openjarvis.server.connectors_router import _instances
+
+    class FakeConnector:
+        def __init__(self, connector_id):
+            self.connector_id = connector_id
+            self.connected = True
+
+        def is_connected(self):
+            return self.connected
+
+        def disconnect(self):
+            self.connected = False
+
+    google_ids = ("gcalendar", "gcontacts", "gdrive", "gmail", "google_tasks")
+    for connector_id in google_ids:
+        _instances[connector_id] = FakeConnector(connector_id)
+
+    original_reset = SyncEngine.reset_checkpoint
+    with KnowledgeStore() as store:
+        with SyncEngine(pipeline=IngestionPipeline(store=store)) as engine:
+            for index, connector_id in enumerate(google_ids, start=1):
+                engine._save_checkpoint(connector_id, index, cursor=connector_id)
+
+    reset_calls = 0
+
+    def fail_second_reset(self, connector_id):
+        nonlocal reset_calls
+        reset_calls += 1
+        if reset_calls == 2:
+            raise RuntimeError("simulated reset failure")
+        return original_reset(self, connector_id)
+
+    monkeypatch.setattr(SyncEngine, "reset_checkpoint", fail_second_reset)
+    try:
+        response = app.post("/v1/connectors/gdrive/disconnect")
+        assert response.status_code == 500
+        assert all(_instances[key].is_connected() for key in google_ids)
+
+        with KnowledgeStore() as store:
+            with SyncEngine(pipeline=IngestionPipeline(store=store)) as engine:
+                for index, connector_id in enumerate(google_ids, start=1):
+                    checkpoint = engine.get_checkpoint(connector_id)
+                    assert checkpoint is not None
+                    assert checkpoint["items_synced"] == index
+                    assert checkpoint["cursor"] == connector_id
+                    original_reset(engine, connector_id)
+    finally:
+        for connector_id in google_ids:
+            _instances.pop(connector_id, None)
+
+
 def test_sync_status(app):
     """GET /v1/connectors/obsidian/sync returns a response with a state field."""
     resp = app.get("/v1/connectors/obsidian/sync")

--- a/tests/server/test_connectors_router.py
+++ b/tests/server/test_connectors_router.py
@@ -439,6 +439,62 @@ def test_disconnect_preserves_source_owned_by_connected_peer(app) -> None:
         _instances.pop("gmail_imap", None)
 
 
+def test_google_disconnect_purges_attributed_gmail_but_preserves_imap(app) -> None:
+    """Shared Gmail source cleanup must use row-level connector provenance."""
+    from openjarvis.connectors._stubs import SyncStatus
+    from openjarvis.connectors.store import KnowledgeStore
+    from openjarvis.server.connectors_router import _instances
+
+    class FakeConnector:
+        def __init__(self, connector_id, indexed_sources=()):
+            self.connector_id = connector_id
+            self.indexed_sources = indexed_sources
+            self.connected = True
+
+        def is_connected(self):
+            return self.connected
+
+        def disconnect(self):
+            self.connected = False
+
+        def sync_status(self):
+            return SyncStatus()
+
+    google_ids = ("gcalendar", "gcontacts", "gdrive", "gmail", "google_tasks")
+    for connector_id in google_ids:
+        _instances[connector_id] = FakeConnector(connector_id)
+    _instances["gmail_imap"] = FakeConnector("gmail_imap", ("gmail",))
+    try:
+        with KnowledgeStore() as store:
+            store.store(
+                content="Google OAuth sentinel",
+                source="gmail",
+                doc_type="email",
+                doc_id="gmail:oauth-owned",
+                metadata={"connector": "gmail"},
+            )
+            store.store(
+                content="ambiguous IMAP sentinel",
+                source="gmail",
+                doc_type="email",
+                doc_id="gmail:imap-owned",
+                metadata={"imap_uid": "41"},
+            )
+
+        response = app.post("/v1/connectors/gdrive/disconnect")
+        assert response.status_code == 200, response.text
+
+        with KnowledgeStore() as store:
+            remaining = store._conn.execute(
+                "SELECT doc_id FROM knowledge_chunks WHERE source = 'gmail'"
+            ).fetchall()
+            assert [row["doc_id"] for row in remaining] == ["gmail:imap-owned"]
+            store.delete_by_source("gmail")
+    finally:
+        for connector_id in (*google_ids, "gmail_imap"):
+            _instances.pop(connector_id, None)
+
+
 def test_disconnect_restores_checkpoint_when_purge_fails(app, monkeypatch) -> None:
     from openjarvis.connectors.pipeline import IngestionPipeline
     from openjarvis.connectors.store import KnowledgeStore

--- a/tests/server/test_connectors_router.py
+++ b/tests/server/test_connectors_router.py
@@ -424,18 +424,80 @@ def test_disconnect_preserves_source_owned_by_connected_peer(app) -> None:
                 doc_type="email",
                 doc_id="gmail:shared-owner",
             )
+            store.store(
+                content="Gmail IMAP ownership sentinel",
+                source="gmail",
+                doc_type="email",
+                doc_id="gmail:imap-owner",
+                metadata={"imap_uid": "41"},
+            )
 
         response = app.post("/v1/connectors/gmail_imap/disconnect")
         assert response.status_code == 200
 
         with KnowledgeStore() as store:
-            assert any(
-                result.metadata.get("doc_id") == "gmail:shared-owner"
-                for result in store.retrieve("ownership sentinel", top_k=10)
-            )
+            remaining = store._conn.execute(
+                "SELECT doc_id FROM knowledge_chunks WHERE source = 'gmail'"
+            ).fetchall()
+            assert [row["doc_id"] for row in remaining] == ["gmail:shared-owner"]
             store.delete_by_source("gmail")
     finally:
         _instances.pop("gmail", None)
+        _instances.pop("gmail_imap", None)
+
+
+def test_gmail_imap_disconnect_preserves_named_google_rows(app) -> None:
+    """IMAP cleanup must not depend on a default OAuth instance being active."""
+    from openjarvis.connectors._stubs import SyncStatus
+    from openjarvis.connectors.store import KnowledgeStore
+    from openjarvis.server.connectors_router import _instances
+
+    class FakeConnector:
+        def __init__(self, connected):
+            self.indexed_sources = ("gmail",)
+            self.connected = connected
+
+        def is_connected(self):
+            return self.connected
+
+        def disconnect(self):
+            self.connected = False
+
+        def sync_status(self):
+            return SyncStatus()
+
+    _instances["gmail"] = FakeConnector(False)
+    _instances["gmail:work"] = FakeConnector(True)
+    _instances["gmail_imap"] = FakeConnector(True)
+    try:
+        with KnowledgeStore() as store:
+            store.store(
+                content="named work OAuth mail",
+                source="gmail",
+                doc_type="email",
+                doc_id="gmail:work-owned",
+                metadata={"account": "work", "connector": "gmail"},
+            )
+            store.store(
+                content="IMAP mail",
+                source="gmail",
+                doc_type="email",
+                doc_id="gmail:imap-owned",
+                metadata={"imap_uid": "41"},
+            )
+
+        response = app.post("/v1/connectors/gmail_imap/disconnect")
+        assert response.status_code == 200, response.text
+
+        with KnowledgeStore() as store:
+            remaining = store._conn.execute(
+                "SELECT doc_id FROM knowledge_chunks WHERE source = 'gmail'"
+            ).fetchall()
+            assert [row["doc_id"] for row in remaining] == ["gmail:work-owned"]
+            store.delete_by_source("gmail")
+    finally:
+        _instances.pop("gmail", None)
+        _instances.pop("gmail:work", None)
         _instances.pop("gmail_imap", None)
 
 

--- a/tests/server/test_connectors_router.py
+++ b/tests/server/test_connectors_router.py
@@ -448,11 +448,14 @@ def test_disconnect_restores_checkpoint_when_purge_fails(app, monkeypatch) -> No
     class FakeObsidian:
         indexed_sources = ("obsidian",)
 
+        def __init__(self):
+            self.connected = True
+
         def is_connected(self):
-            return True
+            return self.connected
 
         def disconnect(self):
-            pass
+            self.connected = False
 
     with KnowledgeStore() as store:
         with SyncEngine(pipeline=IngestionPipeline(store=store)) as engine:
@@ -462,10 +465,15 @@ def test_disconnect_restores_checkpoint_when_purge_fails(app, monkeypatch) -> No
         raise RuntimeError("simulated purge failure")
 
     monkeypatch.setattr(KnowledgeStore, "delete_by_sources", fail_purge)
-    _instances["obsidian"] = FakeObsidian()
+    instance = FakeObsidian()
+    _instances["obsidian"] = instance
     try:
         response = app.post("/v1/connectors/obsidian/disconnect")
         assert response.status_code == 500
+        assert response.json()["detail"].startswith(
+            "Disconnect cleanup failed; credentials were preserved:"
+        )
+        assert instance.is_connected() is True
         with KnowledgeStore() as store:
             with SyncEngine(pipeline=IngestionPipeline(store=store)) as engine:
                 checkpoint = engine.get_checkpoint("obsidian")

--- a/tests/tools/test_digest_collect.py
+++ b/tests/tools/test_digest_collect.py
@@ -58,3 +58,34 @@ def test_digest_collect_missing_connector():
 
     assert result.success is True  # Partial success
     assert "not available" in result.content
+
+
+def test_digest_collect_supports_account_scoped_google_source() -> None:
+    from openjarvis.tools.digest_collect import DigestCollectTool
+
+    connector_cls = MagicMock()
+    connector = connector_cls.return_value
+    connector.is_connected.return_value = True
+    connector.sync.return_value = [
+        Document(
+            doc_id="gmail:work:message-1",
+            source="gmail",
+            doc_type="email",
+            content="Work-only update",
+            title="Work update",
+            author="work@example.com",
+            metadata={"account": "work", "source_profile": "work"},
+        )
+    ]
+
+    with (
+        patch.object(ConnectorRegistry, "contains", return_value=True),
+        patch.object(ConnectorRegistry, "get", return_value=connector_cls),
+        patch("openjarvis.connectors.oauth.get_provider_for_connector") as get_provider,
+    ):
+        get_provider.return_value.name = "google"
+        result = DigestCollectTool().execute(sources=["gmail:Work"])
+
+    connector_cls.assert_called_once_with(account="work")
+    assert result.success is True
+    assert "[gmail:work id=gmail:work:message-1]" in result.content

--- a/tests/tools/test_digest_collect.py
+++ b/tests/tools/test_digest_collect.py
@@ -95,3 +95,27 @@ def test_digest_collect_supports_account_scoped_google_source() -> None:
     assert (
         "[gmail:work id=gmail:work:message-1 account=work message_id=message-1]"
     ) in result.content
+
+
+def test_digest_collect_rejects_disabled_named_google_source() -> None:
+    from openjarvis.core.config import GoogleAccountProfileConfig, JarvisConfig
+    from openjarvis.tools.digest_collect import DigestCollectTool
+
+    config = JarvisConfig()
+    config.connectors.google.accounts["work"] = GoogleAccountProfileConfig(
+        enabled=False
+    )
+    connector_cls = MagicMock()
+
+    with (
+        patch.object(ConnectorRegistry, "contains", return_value=True),
+        patch.object(ConnectorRegistry, "get", return_value=connector_cls),
+        patch("openjarvis.connectors.oauth.get_provider_for_connector") as provider,
+        patch("openjarvis.core.config.load_config", return_value=config),
+    ):
+        provider.return_value.name = "google"
+        result = DigestCollectTool().execute(sources=["gmail:work"])
+
+    assert result.success is True
+    assert "disabled" in result.content
+    connector_cls.assert_not_called()

--- a/tests/tools/test_digest_collect.py
+++ b/tests/tools/test_digest_collect.py
@@ -74,7 +74,11 @@ def test_digest_collect_supports_account_scoped_google_source() -> None:
             content="Work-only update",
             title="Work update",
             author="work@example.com",
-            metadata={"account": "work", "source_profile": "work"},
+            metadata={
+                "account": "work",
+                "source_profile": "work",
+                "message_id": "message-1",
+            },
         )
     ]
 
@@ -88,4 +92,6 @@ def test_digest_collect_supports_account_scoped_google_source() -> None:
 
     connector_cls.assert_called_once_with(account="work")
     assert result.success is True
-    assert "[gmail:work id=gmail:work:message-1]" in result.content
+    assert (
+        "[gmail:work id=gmail:work:message-1 account=work message_id=message-1]"
+    ) in result.content

--- a/tests/tools/test_knowledge_search.py
+++ b/tests/tools/test_knowledge_search.py
@@ -82,6 +82,20 @@ class TestKnowledgeSearchTool:
         # Every returned result must come from gmail
         assert "slack" not in result.content
 
+    def test_account_provenance_is_visible_in_result_label(self, store):
+        store.store(
+            "Named account renewal notice.",
+            source="gmail",
+            source_id="work:renewal",
+            doc_type="email",
+            metadata={"account": "work"},
+        )
+        tool = KnowledgeSearchTool(store=store)
+
+        result = tool.execute(query="renewal", account="work")
+
+        assert "[gmail:work]" in result.content
+
     def test_filter_by_author(self, store):
         """author filter restricts results to sarah only."""
         tool = KnowledgeSearchTool(store=store)
@@ -118,7 +132,15 @@ class TestKnowledgeSearchTool:
         """ToolSpec.parameters includes all required and optional filter fields."""
         tool = KnowledgeSearchTool()
         props = tool.spec.parameters.get("properties", {})
-        for field in ("query", "source", "doc_type", "author", "since", "top_k"):
+        for field in (
+            "query",
+            "source",
+            "account",
+            "doc_type",
+            "author",
+            "since",
+            "top_k",
+        ):
             assert field in props, f"Missing parameter: {field}"
         assert "query" in tool.spec.parameters.get("required", [])
         assert tool.spec.category == "knowledge"

--- a/tests/tools/test_knowledge_search.py
+++ b/tests/tools/test_knowledge_search.py
@@ -118,6 +118,11 @@ class TestKnowledgeSearchTool:
             source_id="work:message",
             metadata={"account": "work", "source_profile": "work"},
         )
+        store.store(
+            f"Shared {marker}",
+            source="slack",
+            source_id="shared:message",
+        )
         config = JarvisConfig()
         config.agent.default_accounts = ["personal"]
         config.connectors.google.accounts = {
@@ -133,6 +138,7 @@ class TestKnowledgeSearchTool:
 
         assert unscoped.success is True
         assert "Personal" in unscoped.content
+        assert "Shared" in unscoped.content
         assert "Work" not in unscoped.content
         assert disabled_account.success is False
         assert "disabled" in disabled_account.content
@@ -147,6 +153,11 @@ class TestKnowledgeSearchTool:
             source_id="work:message",
             metadata={"account": "work", "source_profile": "work"},
         )
+        store.store(
+            f"Shared {marker}",
+            source="slack",
+            source_id="shared:message",
+        )
         config = JarvisConfig()
         config.agent.default_accounts = ["work"]
         config.connectors.google.accounts = {
@@ -157,8 +168,9 @@ class TestKnowledgeSearchTool:
             result = KnowledgeSearchTool(store=store).execute(query=marker)
 
         assert result.success is True
-        assert result.metadata["num_results"] == 0
-        assert marker not in result.content
+        assert result.metadata["num_results"] == 1
+        assert "Shared" in result.content
+        assert "gmail" not in result.content
 
     def test_filter_by_author(self, store):
         """author filter restricts results to sarah only."""

--- a/tests/tools/test_knowledge_search.py
+++ b/tests/tools/test_knowledge_search.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 import importlib
 import sys
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
 from openjarvis.connectors.store import KnowledgeStore
+from openjarvis.core.config import GoogleAccountProfileConfig, JarvisConfig
 from openjarvis.core.registry import ToolRegistry
 from openjarvis.tools.knowledge_search import KnowledgeSearchTool
 
@@ -101,6 +103,62 @@ class TestKnowledgeSearchTool:
         assert "[gmail:work]" in result.content
         assert "account user@company.example" in result.content
         assert result.metadata["sources"][0]["source_email"] == ("user@company.example")
+
+    def test_configured_account_boundary_is_enforced(self, store):
+        marker = "accountboundaryuniquemarker"
+        store.store(
+            f"Personal {marker}",
+            source="gmail",
+            source_id="personal:message",
+            metadata={"account": "personal", "source_profile": "personal"},
+        )
+        store.store(
+            f"Work {marker}",
+            source="gmail",
+            source_id="work:message",
+            metadata={"account": "work", "source_profile": "work"},
+        )
+        config = JarvisConfig()
+        config.agent.default_accounts = ["personal"]
+        config.connectors.google.accounts = {
+            "personal": GoogleAccountProfileConfig(enabled=True),
+            "work": GoogleAccountProfileConfig(enabled=False),
+        }
+        tool = KnowledgeSearchTool(store=store)
+
+        with patch("openjarvis.core.config.load_config", return_value=config):
+            unscoped = tool.execute(query=marker)
+            disabled_account = tool.execute(query=marker, account="work")
+            disabled_source = tool.execute(query=marker, source="gmail:work")
+
+        assert unscoped.success is True
+        assert "Personal" in unscoped.content
+        assert "Work" not in unscoped.content
+        assert disabled_account.success is False
+        assert "disabled" in disabled_account.content
+        assert disabled_source.success is False
+        assert "disabled" in disabled_source.content
+
+    def test_all_disabled_default_scope_matches_nothing(self, store):
+        marker = "disabledboundaryuniquemarker"
+        store.store(
+            marker,
+            source="gmail",
+            source_id="work:message",
+            metadata={"account": "work", "source_profile": "work"},
+        )
+        config = JarvisConfig()
+        config.agent.default_accounts = ["work"]
+        config.connectors.google.accounts = {
+            "work": GoogleAccountProfileConfig(enabled=False)
+        }
+
+        with patch("openjarvis.core.config.load_config", return_value=config):
+            result = KnowledgeSearchTool(store=store).execute(query=marker)
+
+        assert result.success is True
+        assert result.metadata["num_results"] == 0
+        assert marker not in result.content
 
     def test_filter_by_author(self, store):
         """author filter restricts results to sarah only."""

--- a/tests/tools/test_knowledge_search.py
+++ b/tests/tools/test_knowledge_search.py
@@ -88,13 +88,19 @@ class TestKnowledgeSearchTool:
             source="gmail",
             source_id="work:renewal",
             doc_type="email",
-            metadata={"account": "work"},
+            metadata={
+                "account": "work",
+                "source_profile": "work",
+                "source_email": "user@company.example",
+            },
         )
         tool = KnowledgeSearchTool(store=store)
 
         result = tool.execute(query="renewal", account="work")
 
         assert "[gmail:work]" in result.content
+        assert "account user@company.example" in result.content
+        assert result.metadata["sources"][0]["source_email"] == ("user@company.example")
 
     def test_filter_by_author(self, store):
         """author filter restricts results to sarah only."""

--- a/tests/tools/test_knowledge_sql.py
+++ b/tests/tools/test_knowledge_sql.py
@@ -31,6 +31,17 @@ def test_select_count(store: KnowledgeStore) -> None:
     assert "4" in result.content
 
 
+def test_scoped_sql_is_fail_closed(store: KnowledgeStore) -> None:
+    from openjarvis.tools.knowledge_sql import KnowledgeSQLTool
+
+    result = KnowledgeSQLTool(store=store, accounts=["work"]).execute(
+        query="SELECT content, metadata FROM knowledge_chunks"
+    )
+
+    assert result.success is False
+    assert "unavailable" in result.content
+
+
 def test_group_by_author(store: KnowledgeStore) -> None:
     from openjarvis.tools.knowledge_sql import KnowledgeSQLTool
 

--- a/tests/tools/test_proactive_tools_accounts.py
+++ b/tests/tools/test_proactive_tools_accounts.py
@@ -1,0 +1,46 @@
+"""Named-account boundaries for proactive Google actions."""
+
+from unittest.mock import patch
+
+from openjarvis.tools.proactive_tools import (
+    _exec_calendar_accept,
+    _exec_email_archive,
+    _exec_email_delete,
+)
+
+
+def test_email_action_uses_named_connector_and_native_id() -> None:
+    with patch("openjarvis.connectors.gmail.GmailConnector") as connector_cls:
+        ok, _ = _exec_email_delete(
+            {"account": "Work", "message_id": "gmail:work:message-42"}
+        )
+
+    assert ok is True
+    connector_cls.assert_called_once_with(account="work")
+    connector_cls.return_value.delete_message.assert_called_once_with("message-42")
+
+
+def test_legacy_prefixed_email_action_recovers_account() -> None:
+    with patch("openjarvis.connectors.gmail.GmailConnector") as connector_cls:
+        ok, _ = _exec_email_archive({"message_id": "gmail:personal:message-7"})
+
+    assert ok is True
+    connector_cls.assert_called_once_with(account="personal")
+    connector_cls.return_value.archive_message.assert_called_once_with("message-7")
+
+
+def test_calendar_action_uses_named_connector_and_native_id() -> None:
+    with patch("openjarvis.connectors.gcalendar.GCalendarConnector") as connector_cls:
+        ok, _ = _exec_calendar_accept(
+            {
+                "account": "Family",
+                "event_id": "gcalendar:family:event-9",
+                "calendar_id": "primary",
+            }
+        )
+
+    assert ok is True
+    connector_cls.assert_called_once_with(account="family")
+    connector_cls.return_value.accept_event.assert_called_once_with(
+        "event-9", calendar_id="primary"
+    )

--- a/tests/tools/test_proactive_tools_accounts.py
+++ b/tests/tools/test_proactive_tools_accounts.py
@@ -44,3 +44,24 @@ def test_calendar_action_uses_named_connector_and_native_id() -> None:
     connector_cls.return_value.accept_event.assert_called_once_with(
         "event-9", calendar_id="primary"
     )
+
+
+def test_disabled_profile_cannot_execute_proactive_google_action() -> None:
+    from openjarvis.core.config import GoogleAccountProfileConfig, JarvisConfig
+
+    config = JarvisConfig()
+    config.connectors.google.accounts["work"] = GoogleAccountProfileConfig(
+        enabled=False
+    )
+
+    with (
+        patch("openjarvis.core.config.load_config", return_value=config),
+        patch("openjarvis.connectors.gmail.GmailConnector") as connector_cls,
+    ):
+        ok, message = _exec_email_delete(
+            {"account": "work", "message_id": "message-42"}
+        )
+
+    assert ok is False
+    assert "disabled" in message
+    connector_cls.assert_not_called()

--- a/tests/tools/test_scan_chunks.py
+++ b/tests/tools/test_scan_chunks.py
@@ -54,6 +54,51 @@ def test_scan_respects_source_filter(store: KnowledgeStore) -> None:
     assert "Spain" in all_content
 
 
+def test_scan_enforces_google_account_scope_and_hides_deleted_rows(
+    tmp_path: Path,
+) -> None:
+    from openjarvis.tools.scan_chunks import ScanChunksTool
+
+    store = KnowledgeStore(str(tmp_path / "scoped.db"))
+    store.store(
+        "WORK_ALLOWED",
+        source="gmail",
+        source_id="work:message",
+        metadata={"account": "work"},
+    )
+    store.store(
+        "PERSONAL_SECRET",
+        source="gdrive",
+        source_id="personal:file",
+        metadata={"account": "personal"},
+    )
+    deleted_id = store.store(
+        "DELETED_SECRET",
+        source="slack",
+        source_id="deleted",
+    )
+    store._conn.execute(
+        "UPDATE knowledge_chunks SET deleted_at = '2026-01-01' WHERE id = ?",
+        (deleted_id,),
+    )
+    store._conn.commit()
+    engine = _fake_engine()
+
+    result = ScanChunksTool(
+        store=store,
+        engine=engine,
+        model="test",
+        accounts=["work"],
+    ).execute(question="find the marker")
+
+    assert result.success
+    messages = str(engine.generate.call_args.args[0])
+    assert "WORK_ALLOWED" in messages
+    assert "PERSONAL_SECRET" not in messages
+    assert "DELETED_SECRET" not in messages
+    store.close()
+
+
 def test_scan_empty_store(tmp_path: Path) -> None:
     from openjarvis.tools.scan_chunks import ScanChunksTool
 

--- a/tests/tools/test_scan_chunks.py
+++ b/tests/tools/test_scan_chunks.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -96,6 +96,48 @@ def test_scan_enforces_google_account_scope_and_hides_deleted_rows(
     assert "WORK_ALLOWED" in messages
     assert "PERSONAL_SECRET" not in messages
     assert "DELETED_SECRET" not in messages
+    store.close()
+
+
+def test_scan_can_narrow_multi_account_boundary(tmp_path: Path) -> None:
+    from openjarvis.core.config import GoogleAccountProfileConfig, JarvisConfig
+    from openjarvis.tools.scan_chunks import ScanChunksTool
+
+    store = KnowledgeStore(str(tmp_path / "multi-account.db"))
+    for account in ("work", "personal"):
+        store.store(
+            f"{account.upper()}_SCAN_MARKER",
+            source="gmail",
+            source_id=f"{account}:message",
+            metadata={"account": account},
+        )
+    config = JarvisConfig()
+    config.connectors.google.accounts = {
+        "work": GoogleAccountProfileConfig(enabled=True),
+        "personal": GoogleAccountProfileConfig(enabled=True),
+        "disabled": GoogleAccountProfileConfig(enabled=False),
+    }
+    engine = _fake_engine()
+    tool = ScanChunksTool(
+        store=store,
+        engine=engine,
+        model="test",
+        accounts=["work", "personal"],
+    )
+
+    with patch("openjarvis.core.config.load_config", return_value=config):
+        work = tool.execute(question="marker", source="gmail:work")
+        outside = tool.execute(question="marker", account="outside")
+        disabled = tool.execute(question="marker", account="disabled")
+
+    assert work.success is True
+    messages = str(engine.generate.call_args.args[0])
+    assert "WORK_SCAN_MARKER" in messages
+    assert "PERSONAL_SCAN_MARKER" not in messages
+    assert outside.success is False
+    assert "outside" in outside.content
+    assert disabled.success is False
+    assert "disabled" in disabled.content
     store.close()
 
 


### PR DESCRIPTION
Fixes #490.

This revives and completes the named Google-account work originally proposed in #510 by @enkayxyz, preserving that contribution while hardening the account, OAuth, retrieval, and action boundaries.

## What changed

- stores Google credentials, checkpoints, indexed documents, and sync state under normalized named profiles shared by Gmail, Drive, Calendar, Contacts, and Tasks
- supports account selection in the CLI, API, setup wizard, Data Sources UI, config, research, knowledge search, connector tool schemas, and daily-digest flows
- treats explicit/default account scope as a hard boundary: planner-generated filters may narrow it but cannot widen or replace it
- carries `account`, `source_profile`, and provider-asserted `source_email` provenance through indexing, retrieval, thread context, model context, citations, and frontend source metadata
- targets approved Gmail and Calendar proactive actions at the correct named connector using native provider IDs
- makes provider-wide disconnect cancel sibling syncs before credential mutation, purge account-owned content, reset checkpoints, and invalidate every shared connector cache
- rejects conflicting aliases, disabled configured profiles, unsafe filenames, cross-account retrieval scopes, and reauthorization while any sibling Google sync is active
- adds random, expiring, single-use OAuth state for server and CLI flows; binds callbacks to connector, account, and path; and preserves the browser click gesture for authenticated OAuth startup
- adds explicit post-auth legacy migration and real account-aware CLI sync, avoiding duplicate unscoped rows without deleting legacy data when authorization fails
- emits account-correct Gmail links when Google supplies an email claim and omits ambiguous links otherwise

## Validation

- 294 focused account/OAuth/retrieval/action/server tests passed
- 474 non-live connector tests passed, 5 skipped, 5 deselected
- 63 frontend tests passed
- TypeScript and Vite production build passed
- repository-wide Ruff check and format check passed (1,342 files)
- `git diff --check` passed

The PR remains draft pending final independent adversarial review and the current-head hosted CI matrix.
