### PR TITLE
fix(scheduler): make croniter required, remove silent hourly fallback

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
 ]
 dependencies = [
     "click>=8",
+    "croniter>=2.0",
     "datasets>=4.5.0",
     "ddgs>=9.11.4",
     "httpx>=0.27",
@@ -146,7 +147,7 @@ browser = ["playwright>=1.40"]
 media = ["openai>=1.30"]
 mining-pearl-vllm = ["docker>=7.0", "httpx>=0.27"]
 pdf = ["pdfplumber>=0.10"]
-scheduler = ["croniter>=2.0"]
+
 security-signing = ["cryptography>=43"]
 sandbox-wasm = ["wasmtime>=25"]
 sandbox-docker = ["docker>=7.0"]

--- a/src/openjarvis/agents/scheduler.py
+++ b/src/openjarvis/agents/scheduler.py
@@ -17,17 +17,8 @@ logger = logging.getLogger(__name__)
 
 
 def _next_cron_fire(cron_expr: str, now: float | None = None) -> float:
-    """Calculate the next fire time for a cron expression.
-
-    Uses croniter if available, otherwise falls back to a simple
-    interval-based approximation.
-    """
-    try:
-        from croniter import croniter
-    except ImportError:
-        # Fallback: treat as hourly interval
-        logger.warning("croniter not installed, treating cron as 3600s interval")
-        return (now or time.time()) + 3600
+    """Calculate the next fire time for a cron expression."""
+    from croniter import croniter
 
     base = now or time.time()
     import datetime

--- a/src/openjarvis/scheduler/scheduler.py
+++ b/src/openjarvis/scheduler/scheduler.py
@@ -306,42 +306,11 @@ class TaskScheduler:
 
     @staticmethod
     def _compute_next_cron(cron_expr: str, now: datetime) -> Optional[str]:
-        """Compute the next run time from a cron expression.
+        """Compute the next run time from a cron expression."""
+        from croniter import croniter  # type: ignore[import-untyped]
 
-        Uses ``croniter`` if available, otherwise falls back to a basic
-        minute-granularity parser for simple expressions.
-        """
-        try:
-            from croniter import croniter  # type: ignore[import-untyped]
-
-            it = croniter(cron_expr, now)
-            return it.get_next(datetime).isoformat()
-        except ImportError:
-            pass
-
-        # Basic fallback: parse "minute hour * * *" style expressions
-        parts = cron_expr.strip().split()
-        if len(parts) < 5:
-            logger.warning(
-                "Cannot parse cron without croniter: %s",
-                cron_expr,
-            )
-            return (now + timedelta(hours=1)).isoformat()
-
-        minute_part, hour_part = parts[0], parts[1]
-
-        try:
-            target_minute = int(minute_part) if minute_part != "*" else now.minute
-            target_hour = int(hour_part) if hour_part != "*" else now.hour
-        except ValueError:
-            return (now + timedelta(hours=1)).isoformat()
-
-        candidate = now.replace(
-            hour=target_hour, minute=target_minute, second=0, microsecond=0
-        )
-        if candidate <= now:
-            candidate += timedelta(days=1)
-        return candidate.isoformat()
+        it = croniter(cron_expr, now)
+        return it.get_next(datetime).isoformat()
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- Move `croniter>=2.0` from optional-dependencies to core dependencies (#777)
- Remove ImportError fallback logic in `scheduler/scheduler.py` and `agents/scheduler.py`
- Cron expressions now fail loudly if croniter is missing instead of silently degrading to hourly

## Test plan
- [x] 39/39 `tests/operators/test_operators.py` pass
- [x] Diff against upstream/main contains only the intended files (net -39 lines)