### PR TITLE
feat(desktop): choose inference source during setup + escape hatch on engine failure

### DIFF
--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -2285,6 +2285,19 @@ fn write_inference_config(cfg: &InferenceConfig) -> Result<(), String> {
     std::fs::write(&path, json + "\n").map_err(|e| format!("Failed to save inference config: {}", e))
 }
 
+/// True when the user has explicitly recorded an inference-source choice
+/// (`~/.openjarvis/inference.json` exists). An absent file means first run:
+/// the setup screen should ask which backend to use instead of assuming
+/// Ollama and auto-installing it (#274).
+#[tauri::command]
+fn inference_source_configured() -> bool {
+    inference_source_configured_at(&inference_config_path())
+}
+
+fn inference_source_configured_at(path: &std::path::Path) -> bool {
+    path.is_file()
+}
+
 /// Upsert `[engine.<engine>] host = "<host>"` into an existing config.toml
 /// string, preserving all other content/formatting. Pure: string in, string out.
 fn upsert_engine_host(existing: &str, engine: &str, host: &str) -> Result<String, String> {
@@ -2845,6 +2858,7 @@ pub fn run() {
             get_cloud_key_status,
             get_inference_source,
             set_inference_source,
+            inference_source_configured,
             toggle_overlay,
             hide_overlay,
             get_overlay_conversation,
@@ -2870,10 +2884,11 @@ mod tests {
     use super::{
         boot_plan, default_local_model, format_extension_import_failure,
         format_missing_rust_toolchain, format_port_unavailable, format_uv_sync_failure,
-        format_uv_sync_spawn_error, matching_installed_model, model_names_match, normalize_host,
-        parse_inference_config, parse_ollama_model_names, preferred_installed_model,
-        should_persist_resolved_model, startup_installed_model, upsert_engine_host,
-        uv_sync_stderr_tail, InferenceConfig, SourceKind, DESKTOP_UV_SYNC_COMMAND,
+        format_uv_sync_spawn_error, inference_source_configured_at, matching_installed_model,
+        model_names_match, normalize_host, parse_inference_config, parse_ollama_model_names,
+        preferred_installed_model, should_persist_resolved_model, startup_installed_model,
+        upsert_engine_host, uv_sync_stderr_tail, InferenceConfig, SourceKind,
+        DESKTOP_UV_SYNC_COMMAND,
     };
     use std::path::Path;
 
@@ -3104,6 +3119,26 @@ mod tests {
         assert_eq!(cfg.model.as_deref(), Some("qwen2.5-7b"));
         assert_eq!(cfg.host.as_deref(), Some("http://localhost:1234"));
         assert_eq!(cfg.engine.as_deref(), Some("lmstudio"));
+    }
+
+    #[test]
+    fn inference_source_configured_requires_existing_file() {
+        let dir = std::env::temp_dir().join(format!(
+            "oj-setup-configured-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.subsec_nanos())
+                .unwrap_or(0)
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let missing = dir.join("inference.json");
+        // An absent file means "first run" — only a real file records a choice.
+        assert!(!inference_source_configured_at(&missing));
+        std::fs::write(&missing, "{}").unwrap();
+        assert!(inference_source_configured_at(&missing));
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/frontend/src/components/SetupScreen.source-choice.test.tsx
+++ b/frontend/src/components/SetupScreen.source-choice.test.tsx
@@ -1,0 +1,52 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../lib/api', () => ({
+  getSetupStatus: vi.fn(async () => null),
+  fetchModels: vi.fn(async () => []),
+  fetchRecommendedModel: vi.fn(async () => ({ model: '', reason: '' })),
+  inferenceSourceConfigured: vi.fn(async () => false),
+  relaunchApp: vi.fn(async () => undefined),
+  setInferenceSource: vi.fn(async () => undefined),
+}));
+vi.mock('../lib/store', () => ({
+  useAppStore: { getState: vi.fn(() => ({ selectedModel: '', setModels: vi.fn(), setModelsLoading: vi.fn(), setSelectedModel: vi.fn() })) },
+}));
+
+import { CustomSourceForm, SetupScreen, SourceChoice } from './SetupScreen';
+
+describe('first-run inference source chooser (#274)', () => {
+  it('offers the bundled engine and an existing server before booting anything', () => {
+    const html = renderToStaticMarkup(<SourceChoice onChosen={vi.fn()} />);
+
+    expect(html).toContain('How would you like to run inference?');
+    expect(html).toContain('Bundled Ollama');
+    expect(html).toContain('Existing server');
+    expect(html).toContain('LM Studio');
+  });
+
+  it('shows the custom-endpoint form fields for an existing server', () => {
+    const html = renderToStaticMarkup(
+      <div>
+        <CustomSourceForm />
+      </div>,
+    );
+
+    expect(html).toContain('Server URL');
+    expect(html).toContain('Model');
+    expect(html).toContain('Server type');
+    expect(html).toContain('LM Studio');
+    expect(html).toContain('Save &amp; Restart OpenJarvis');
+    // The endpoint backend requires host + model — Save stays disabled until
+    // both are filled (model starts empty).
+    expect(html).toMatch(/<button[^>]*disabled/);
+  });
+
+  it('shows neither the chooser nor the steps while first-run state is unknown', () => {
+    const html = renderToStaticMarkup(<SetupScreen onReady={vi.fn()} />);
+
+    expect(html).not.toContain('How would you like to run inference?');
+    expect(html).not.toContain('Inference Engine');
+    expect(html).not.toContain('Starting Ollama');
+  });
+});

--- a/frontend/src/components/SetupScreen.tsx
+++ b/frontend/src/components/SetupScreen.tsx
@@ -4,6 +4,9 @@ import {
   getSetupStatus,
   fetchModels,
   fetchRecommendedModel,
+  inferenceSourceConfigured,
+  relaunchApp,
+  setInferenceSource,
   type SetupStatus,
 } from '../lib/api';
 import { useAppStore } from '../lib/store';
@@ -16,6 +19,238 @@ const STEPS = [
 ] as const;
 
 type StepKey = (typeof STEPS)[number]['key'];
+
+const ENGINES = [
+  { value: 'lmstudio', label: 'LM Studio' },
+  { value: 'vllm', label: 'vLLM' },
+  { value: 'sglang', label: 'SGLang' },
+  { value: 'llamacpp', label: 'llama.cpp' },
+  { value: 'mlx', label: 'MLX' },
+] as const;
+
+const inputStyle = {
+  background: 'var(--color-bg-secondary)',
+  color: 'var(--color-text)',
+  border: '1px solid var(--color-border)',
+} as const;
+
+/// Shared "point OpenJarvis at an existing OpenAI-compatible server" form.
+/// Used both by the first-run source chooser and by the escape hatch shown
+/// when the bundled engine fails (#274). Saving persists the custom source
+/// and relaunches the app so `boot_backend` re-reads it.
+/// (Exported for static-render tests, mirroring the DataSourcesPage pattern.)
+export function CustomSourceForm() {
+  const [host, setHost] = useState('http://localhost:1234');
+  const [model, setModel] = useState('');
+  const [engine, setEngine] = useState<string>('lmstudio');
+  const [apiKey, setApiKey] = useState('');
+  const [msg, setMsg] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const canSave = host.trim().length > 0 && model.trim().length > 0 && !saving;
+
+  const save = async () => {
+    setSaving(true);
+    setMsg('');
+    try {
+      await setInferenceSource({
+        kind: 'custom',
+        host: host.trim(),
+        model: model.trim(),
+        engine,
+        apiKey: apiKey || undefined,
+      });
+      setMsg('Saved. Restarting OpenJarvis to connect...');
+      // boot_backend reads the saved source at launch — restart to apply.
+      await new Promise((resolve) => setTimeout(resolve, 800));
+      await relaunchApp();
+      // If relaunch is unavailable in this environment, say so instead of
+      // silently leaving the user on a dead screen.
+      setMsg('Saved. Please restart OpenJarvis to connect to your server.');
+    } catch (e: any) {
+      setMsg(e?.message ?? 'Failed to save.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div>
+        <label className="text-xs font-medium block mb-1" style={{ color: 'var(--color-text-secondary)' }}>
+          Server URL
+        </label>
+        <input
+          type="text"
+          value={host}
+          onChange={(e) => setHost(e.target.value)}
+          placeholder="http://localhost:1234"
+          disabled={saving}
+          className="text-sm px-3 py-1.5 rounded-lg outline-none w-full"
+          style={inputStyle}
+        />
+      </div>
+      <div>
+        <label className="text-xs font-medium block mb-1" style={{ color: 'var(--color-text-secondary)' }}>
+          Model
+        </label>
+        <input
+          type="text"
+          value={model}
+          onChange={(e) => setModel(e.target.value)}
+          placeholder="qwen2.5-7b-instruct"
+          disabled={saving}
+          className="text-sm px-3 py-1.5 rounded-lg outline-none w-full"
+          style={inputStyle}
+        />
+      </div>
+      <div>
+        <label className="text-xs font-medium block mb-1" style={{ color: 'var(--color-text-secondary)' }}>
+          Server type
+        </label>
+        <select
+          value={engine}
+          onChange={(e) => setEngine(e.target.value)}
+          disabled={saving}
+          className="text-sm px-3 py-1.5 rounded-lg outline-none w-full"
+          style={inputStyle}
+        >
+          {ENGINES.map((e) => (
+            <option key={e.value} value={e.value}>
+              {e.label}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div>
+        <label className="text-xs font-medium block mb-1" style={{ color: 'var(--color-text-secondary)' }}>
+          API key (optional)
+        </label>
+        <input
+          type="password"
+          value={apiKey}
+          onChange={(e) => setApiKey(e.target.value)}
+          placeholder="leave blank if none"
+          disabled={saving}
+          className="text-sm px-3 py-1.5 rounded-lg outline-none w-full"
+          style={inputStyle}
+        />
+      </div>
+      <button
+        onClick={save}
+        disabled={!canSave}
+        className="text-sm px-4 py-2 rounded-lg outline-none cursor-pointer font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+        style={{ background: 'var(--color-accent)', color: 'var(--color-on-accent)' }}
+      >
+        {saving ? 'Saving...' : 'Save & Restart OpenJarvis'}
+      </button>
+      {msg && (
+        <div className="text-xs" style={{ color: 'var(--color-text-secondary)' }}>
+          {msg}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/// First-run backend chooser (#274): let the user pick the inference source
+/// before the app tries to launch (or install) anything. Choosing the bundled
+/// engine just records the explicit choice — boot already defaults to it.
+/// Choosing an existing server persists the custom source and relaunches.
+/// (Exported for static-render tests, mirroring the DataSourcesPage pattern.)
+export function SourceChoice({ onChosen }: { onChosen: () => void }) {
+  const [showCustom, setShowCustom] = useState(false);
+  const [starting, setStarting] = useState(false);
+
+  const chooseOllama = async () => {
+    setStarting(true);
+    try {
+      await setInferenceSource({ kind: 'ollama' });
+    } catch {
+      // Non-fatal: an absent config already boots Ollama by default.
+    }
+    onChosen();
+  };
+
+  return (
+    <div className="w-full max-w-md px-6">
+      <div className="text-center mb-8">
+        <div
+          className="w-16 h-16 rounded-2xl flex items-center justify-center mx-auto mb-4"
+          style={{ background: 'var(--color-accent-subtle)', color: 'var(--color-accent)' }}
+        >
+          <Cpu size={32} />
+        </div>
+        <h1 className="text-2xl font-bold mb-1" style={{ color: 'var(--color-text)' }}>
+          OpenJarvis
+        </h1>
+        <p className="text-sm" style={{ color: 'var(--color-text-secondary)' }}>
+          How would you like to run inference?
+        </p>
+      </div>
+
+      {!showCustom ? (
+        <div className="flex flex-col gap-3">
+          <button
+            onClick={chooseOllama}
+            disabled={starting}
+            className="flex items-center gap-4 px-5 py-4 rounded-xl text-left transition-all cursor-pointer disabled:opacity-60"
+            style={{ background: 'var(--color-surface)', border: '1px solid var(--color-border)' }}
+          >
+            <div
+              className="w-10 h-10 rounded-lg flex items-center justify-center shrink-0"
+              style={{ background: 'var(--color-accent-subtle)', color: 'var(--color-accent)' }}
+            >
+              <Cpu size={18} />
+            </div>
+            <div className="flex-1">
+              <div className="text-sm font-medium" style={{ color: 'var(--color-text)' }}>
+                Bundled Ollama
+              </div>
+              <div className="text-xs" style={{ color: 'var(--color-text-tertiary)' }}>
+                Download and run models locally (recommended)
+              </div>
+            </div>
+            {starting && <Loader2 size={16} className="animate-spin" style={{ color: 'var(--color-accent)' }} />}
+          </button>
+          <button
+            onClick={() => setShowCustom(true)}
+            className="flex items-center gap-4 px-5 py-4 rounded-xl text-left transition-all cursor-pointer"
+            style={{ background: 'var(--color-surface)', border: '1px solid var(--color-border)' }}
+          >
+            <div
+              className="w-10 h-10 rounded-lg flex items-center justify-center shrink-0"
+              style={{ background: 'var(--color-accent-subtle)', color: 'var(--color-accent)' }}
+            >
+              <Server size={18} />
+            </div>
+            <div className="flex-1">
+              <div className="text-sm font-medium" style={{ color: 'var(--color-text)' }}>
+                Existing server
+              </div>
+              <div className="text-xs" style={{ color: 'var(--color-text-tertiary)' }}>
+                Connect to LM Studio, vLLM, or another OpenAI-compatible server
+              </div>
+            </div>
+          </button>
+          <p className="text-xs text-center mt-2" style={{ color: 'var(--color-text-tertiary)' }}>
+            You can change this anytime in Settings.
+          </p>
+        </div>
+      ) : (
+        <div
+          className="rounded-xl px-5 py-4"
+          style={{ background: 'var(--color-surface)', border: '1px solid var(--color-border)' }}
+        >
+          <div className="text-sm font-medium mb-3" style={{ color: 'var(--color-text)' }}>
+            Connect to an existing server
+          </div>
+          <CustomSourceForm />
+        </div>
+      )}
+    </div>
+  );
+}
 
 function StepRow({
   icon: Icon,
@@ -76,8 +311,23 @@ function StepRow({
 }
 
 export function SetupScreen({ onReady }: { onReady: () => void }) {
+  // null = checking whether the user already picked a source (first run
+  // detection, #274); false = show the chooser; true = poll boot progress.
+  const [sourceDecided, setSourceDecided] = useState<boolean | null>(null);
   const [status, setStatus] = useState<SetupStatus | null>(null);
+  const [showEscapeHatch, setShowEscapeHatch] = useState(false);
   const handedOffRef = useRef(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    inferenceSourceConfigured().then((configured) => {
+      if (!cancelled) setSourceDecided(configured);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   const poll = useCallback(async () => {
     const s = await getSetupStatus();
     if (s) setStatus(s);
@@ -111,10 +361,33 @@ export function SetupScreen({ onReady }: { onReady: () => void }) {
   }, [onReady]);
 
   useEffect(() => {
+    if (sourceDecided !== true) return;
     poll();
     const interval = setInterval(poll, 800);
     return () => clearInterval(interval);
-  }, [poll]);
+  }, [poll, sourceDecided]);
+
+  if (sourceDecided === null) {
+    return (
+      <div
+        className="fixed inset-0 flex items-center justify-center"
+        style={{ background: 'var(--color-bg)' }}
+      >
+        <Loader2 size={24} className="animate-spin" style={{ color: 'var(--color-text-tertiary)' }} />
+      </div>
+    );
+  }
+
+  if (sourceDecided === false) {
+    return (
+      <div
+        className="fixed inset-0 flex items-center justify-center"
+        style={{ background: 'var(--color-bg)' }}
+      >
+        <SourceChoice onChosen={() => setSourceDecided(true)} />
+      </div>
+    );
+  }
 
   const activeStep: StepKey | null =
     status && !status.ollama_ready
@@ -174,17 +447,41 @@ export function SetupScreen({ onReady }: { onReady: () => void }) {
 
         {/* Error */}
         {status?.error && (
-          <div
-            className="flex items-start gap-3 px-4 py-3 rounded-xl text-sm"
-            style={{
-              background: 'color-mix(in srgb, var(--color-error) 10%, transparent)',
-              border: '1px solid color-mix(in srgb, var(--color-error) 20%, transparent)',
-              color: 'var(--color-error)',
-            }}
-          >
-            <XCircle size={16} className="shrink-0 mt-0.5" />
-            <span style={{ wordBreak: 'break-word', overflowWrap: 'anywhere' }}>{status.error}</span>
-          </div>
+          <>
+            <div
+              className="flex items-start gap-3 px-4 py-3 rounded-xl text-sm"
+              style={{
+                background: 'color-mix(in srgb, var(--color-error) 10%, transparent)',
+                border: '1px solid color-mix(in srgb, var(--color-error) 20%, transparent)',
+                color: 'var(--color-error)',
+              }}
+            >
+              <XCircle size={16} className="shrink-0 mt-0.5" />
+              <span style={{ wordBreak: 'break-word', overflowWrap: 'anywhere' }}>{status.error}</span>
+            </div>
+            {/* Escape hatch (#274): engine startup failed — offer to point
+                OpenJarvis at an existing server instead of stranding the user
+                here (the rest of the app is gated behind this screen). */}
+            {!showEscapeHatch ? (
+              <button
+                onClick={() => setShowEscapeHatch(true)}
+                className="mt-3 text-xs underline underline-offset-2 cursor-pointer"
+                style={{ color: 'var(--color-text-secondary)' }}
+              >
+                Use an existing server instead (LM Studio, vLLM, ...)
+              </button>
+            ) : (
+              <div
+                className="mt-3 rounded-xl px-4 py-4"
+                style={{ background: 'var(--color-surface)', border: '1px solid var(--color-border)' }}
+              >
+                <div className="text-sm font-medium mb-3" style={{ color: 'var(--color-text)' }}>
+                  Connect to an existing server
+                </div>
+                <CustomSourceForm />
+              </div>
+            )}
+          </>
         )}
 
         {/* Progress bar */}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1145,3 +1145,28 @@ export async function setInferenceSource(
     throw new Error(e?.message ?? e ?? 'Failed to save inference source');
   }
 }
+
+/**
+ * True when the user has explicitly recorded an inference-source choice.
+ * False means first run — setup should ask which backend to use instead of
+ * auto-launching Ollama (#274). On any query failure we assume configured so
+ * a broken command can never trap a user in the chooser.
+ */
+export async function inferenceSourceConfigured(): Promise<boolean> {
+  if (isTauri()) {
+    try {
+      const { invoke } = await import('@tauri-apps/api/core');
+      return await invoke<boolean>('inference_source_configured');
+    } catch {
+      return true;
+    }
+  }
+  return true;
+}
+
+/** Restart the desktop app so `boot_backend` re-reads the saved source. */
+export async function relaunchApp(): Promise<void> {
+  if (!isTauri()) return;
+  const { relaunch } = await import('@tauri-apps/plugin-process');
+  await relaunch();
+}


### PR DESCRIPTION
Closes #274.

## The defect (why an LM Studio user gets an Ollama error)

`boot_backend` reads `~/.openjarvis/inference.json` at process start; absent/invalid file ⇒ Ollama (default). When `ollama serve` can't start it sets the status error from #274 and returns — `jarvis serve` never starts. Meanwhile `App.tsx` renders `SetupScreen` *instead of the router* until `phase === 'ready'`, and `SetupScreen` only hands off on ready. So the fix for the error — Settings' custom-endpoint form (which already fully supports LM Studio/vLLM/SGLang/llama.cpp/MLX) — sits **behind the gate that never opens**. First-run users with an existing server are hard-locked into an Ollama retry loop.

## What this PR does

**1. Pre-flight source chooser (the issue's ask):** on true first run (no `inference.json`) setup now asks "How would you like to run inference?" *before* any engine launches:
- **Bundled Ollama** — records the explicit choice; boot already defaults to it, no restart needed.
- **Existing server** — inline form (URL / model / server type / optional API key, defaults matching Settings: `http://localhost:1234` + LM Studio); persists via the existing `set_inference_source`, relaunches via the already-initialized process plugin; boot then connects to the user's server without ever touching Ollama.

**2. Error-state escape hatch (unlocks users stuck today):** when boot fails (e.g. "Could not start Ollama..."), the setup screen now offers "Use an existing server instead" → same form → Save & Restart. Boot runs once per process, so save+restart is the honest recovery — there is no fake Retry button.

**3. First-run detection:** new `inference_source_configured()` command (file-existence of `inference.json` — the same file boot reads, so chooser and boot can't desync; survives reinstalls unlike localStorage). The frontend wrapper fails open (assumes configured) so a broken command can never trap a user in the chooser.

## Tests

- Rust: `cargo test --lib` — 35/35 (new: `inference_source_configured_requires_existing_file`)
- Frontend: `vitest run` — 12 files / 55 tests (new: `SetupScreen.source-choice.test.tsx` — chooser renders both options; form requires host+model before Save; unknown-state renders neither chooser nor steps)
- `tsc --noEmit` clean

## Notes for reviewers

- Deliberately unchanged: boot ordering, the error string, `App.tsx` gate semantics. Users who already completed setup see zero change.
- Costs vs. gating `boot_backend` on the frontend decision: one app restart when choosing an existing server on first run — much smaller review surface, no abort/race semantics.
- Follow-ups (separate PRs if wanted): auto-detect a running LM Studio at `127.0.0.1:1234` and offer one-click adopt; `install.ps1 -SkipOllama` for the CLI installer path.