### PR TITLE
fix(telemetry): unsubscribe from event bus on TelemetryStore.close() (fixes #764)

### DIFF
--- a/src/openjarvis/telemetry/store.py
+++ b/src/openjarvis/telemetry/store.py
@@ -206,6 +206,7 @@ class TelemetryStore:
         self._last_flush_time = time.monotonic()
         self._telemetry_batch: list[tuple[Any, ...]] = []
         self._mining_batch: list[tuple[Any, ...]] = []
+        self._subscribed_buses: list[EventBus] = []
         self._closed = False
 
         # Background flusher: without it, a partial batch written just before
@@ -293,6 +294,8 @@ class TelemetryStore:
             json.dumps(rec.metadata),
         )
         with self._lock:
+            if self._closed:
+                raise RuntimeError("Cannot record telemetry to a closed TelemetryStore")
             self._telemetry_batch.append(row)
             self._maybe_flush_unlocked()
 
@@ -316,6 +319,10 @@ class TelemetryStore:
             stats.fees_owed,
         )
         with self._lock:
+            if self._closed:
+                raise RuntimeError(
+                    "Cannot record mining stats to a closed TelemetryStore"
+                )
             self._mining_batch.append(row)
             self._maybe_flush_unlocked()
 
@@ -369,9 +376,26 @@ class TelemetryStore:
 
     def subscribe_to_bus(self, bus: EventBus) -> None:
         """Subscribe to ``TELEMETRY_RECORD`` events on *bus*."""
+        with self._lock:
+            if self._closed:
+                raise RuntimeError(
+                    "Cannot subscribe a closed TelemetryStore to an event bus"
+                )
+            if bus not in self._subscribed_buses:
+                self._subscribed_buses.append(bus)
         bus.subscribe(EventType.TELEMETRY_RECORD, self._on_event)
 
+    def unsubscribe_from_bus(self, bus: EventBus) -> None:
+        """Unsubscribe from ``TELEMETRY_RECORD`` events on *bus*."""
+        bus.unsubscribe(EventType.TELEMETRY_RECORD, self._on_event)
+        with self._lock:
+            if bus in self._subscribed_buses:
+                self._subscribed_buses.remove(bus)
+
     def _on_event(self, event: Event) -> None:
+        with self._lock:
+            if self._closed:
+                return
         rec = event.data.get("record")
         if isinstance(rec, TelemetryRecord):
             try:
@@ -381,6 +405,13 @@ class TelemetryStore:
 
     def close(self) -> None:
         """Flush pending records and close the underlying SQLite connection."""
+        # Unsubscribe from all event buses first so no new events are delivered
+        with self._lock:
+            buses = list(self._subscribed_buses)
+            self._subscribed_buses.clear()
+        for bus in buses:
+            bus.unsubscribe(EventType.TELEMETRY_RECORD, self._on_event)
+
         # Set the stop event BEFORE taking the lock: a flusher iteration
         # already waiting on the lock re-checks the event after acquiring it
         # and exits instead of touching the closed connection.

--- a/tests/telemetry/test_store.py
+++ b/tests/telemetry/test_store.py
@@ -225,6 +225,68 @@ class TestTelemetryRecordFields:
         assert _count_rows_via_own_connection(db_path) == 1
         store.close()  # second close must be a no-op, not a ProgrammingError
 
+    def test_bus_unsubscribes_on_close(self, tmp_path: Path) -> None:
+        store = TelemetryStore(tmp_path / "test.db")
+        bus = EventBus()
+        store.subscribe_to_bus(bus)
+
+        # Verify subscribed
+        rec = TelemetryRecord(timestamp=time.time(), model_id="m1", engine="e1")
+        bus.publish(EventType.TELEMETRY_RECORD, {"record": rec})
+        assert len(store._fetchall()) == 1
+
+        # Close store
+        store.close()
+
+        # Verify callback was removed from bus listeners
+        listeners = bus._subscribers.get(EventType.TELEMETRY_RECORD, [])
+        assert store._on_event not in listeners
+
+        # Subsequent publish to the shared bus must not raise or invoke closed store
+        rec2 = TelemetryRecord(timestamp=time.time(), model_id="m2", engine="e1")
+        bus.publish(EventType.TELEMETRY_RECORD, {"record": rec2})
+
+    def test_manual_unsubscribe_from_bus(self, tmp_path: Path) -> None:
+        store = TelemetryStore(tmp_path / "test.db")
+        bus = EventBus()
+        store.subscribe_to_bus(bus)
+        store.unsubscribe_from_bus(bus)
+
+        rec = TelemetryRecord(timestamp=time.time(), model_id="m1", engine="e1")
+        bus.publish(EventType.TELEMETRY_RECORD, {"record": rec})
+        assert len(store._fetchall()) == 0
+        store.close()
+
+    def test_multiple_buses_unsubscribed_on_close(self, tmp_path: Path) -> None:
+        store = TelemetryStore(tmp_path / "test.db")
+        bus1 = EventBus()
+        bus2 = EventBus()
+        store.subscribe_to_bus(bus1)
+        store.subscribe_to_bus(bus2)
+
+        event_type = EventType.TELEMETRY_RECORD
+        assert store._on_event in bus1._subscribers.get(event_type, [])
+        assert store._on_event in bus2._subscribers.get(event_type, [])
+
+        store.close()
+
+        assert store._on_event not in bus1._subscribers.get(event_type, [])
+        assert store._on_event not in bus2._subscribers.get(event_type, [])
+
+    def test_closed_store_guards_record_and_subscribe(self, tmp_path: Path) -> None:
+        import pytest
+
+        store = TelemetryStore(tmp_path / "test.db")
+        store.close()
+
+        rec = TelemetryRecord(timestamp=time.time(), model_id="m1", engine="e1")
+        with pytest.raises(RuntimeError, match="closed TelemetryStore"):
+            store.record(rec)
+
+        bus = EventBus()
+        with pytest.raises(RuntimeError, match="closed TelemetryStore"):
+            store.subscribe_to_bus(bus)
+
 
 def _count_rows_via_own_connection(db_path: Path) -> int:
     """Count telemetry rows through a separate connection (like the aggregator)."""


### PR DESCRIPTION
## Summary

Fixes #764. `TelemetryStore.subscribe_to_bus()` registered `self._on_event` on the supplied `EventBus` without keeping a reference to the bus or unsubscribing upon `close()`. As a result, when a store was closed in environments sharing a singleton or long-lived `EventBus` (such as desktop app restarts or test suites creating multiple system instances), dead `TelemetryStore` instances accumulated on the bus. Subsequent `TELEMETRY_RECORD` events invoked callbacks on closed stores, triggering `sqlite3.ProgrammingError: Cannot operate on a closed database`.

## What changed in `src/openjarvis/telemetry/store.py`

1. **Track Subscribed Buses:** Added `self._subscribed_buses: list[EventBus]` in `TelemetryStore.__init__`.
2. **Track in `subscribe_to_bus`:** Recorded the bus reference upon subscription, guarded against subscription on closed stores.
3. **Added `unsubscribe_from_bus`:** Added explicit public unsubscription helper.
4. **Unsubscribe in `close()`:** Iterated through all subscribed buses and unsubscribed `self._on_event` before closing the SQLite database connection.
5. **Closed Guards:** Added explicit closed guards to `record()`, `record_mining_stats()`, and `_on_event()` to prevent operations on closed connections.

## Test plan

- [x] Added `test_bus_unsubscribes_on_close`: Verified `store.close()` removes `_on_event` from the bus listeners.
- [x] Added `test_manual_unsubscribe_from_bus`: Verified manual unsubscription before close cleanly detaches listeners.
- [x] Added `test_multiple_buses_unsubscribed_on_close`: Verified multi-bus unsubscription on close.
- [x] Added `test_closed_store_guards_record_and_subscribe`: Verified operations on closed store raise clean `RuntimeError`.
- [x] Verified all 19 tests in `tests/telemetry/test_store.py` and 14 tests in `tests/core/test_events.py` pass cleanly.
- [x] Verified `ruff check` and `ruff format` pass cleanly.
