### PR TITLE
fix(agents): serialize shared manager database access

### DIFF
--- a/src/openjarvis/agents/manager.py
+++ b/src/openjarvis/agents/manager.py
@@ -9,8 +9,10 @@ from __future__ import annotations
 import json
 import logging
 import sqlite3
+import threading
 import time
 import uuid
+from functools import wraps
 from typing import Any, Dict, List, Optional
 from uuid import uuid4
 
@@ -95,6 +97,17 @@ CREATE TABLE IF NOT EXISTS agent_learning_log (
 _SUMMARY_MAX = 16000
 
 
+def _db_locked(func):
+    """Serialize access to the connection shared by manager worker threads."""
+
+    @wraps(func)
+    def wrapped(self, *args, **kwargs):
+        with self._db_lock:
+            return func(self, *args, **kwargs)
+
+    return wrapped
+
+
 class AgentManager:
     """Persistent agent lifecycle manager with SQLite backing."""
 
@@ -107,6 +120,7 @@ class AgentManager:
 
     def __init__(self, db_path: str, *, clear_stale_running: bool = False) -> None:
         self._db_path = str(db_path)
+        self._db_lock = threading.RLock()
         self._conn = sqlite3.connect(self._db_path, check_same_thread=False)
         self._conn.row_factory = sqlite3.Row
         self._conn.execute("PRAGMA journal_mode=WAL")
@@ -149,6 +163,7 @@ class AgentManager:
         if clear_stale_running:
             self._clear_stale_running_state()
 
+    @_db_locked
     def _clear_stale_running_state(self) -> None:
         """Reset any agent stuck in ``status='running'`` on startup.
 
@@ -175,11 +190,13 @@ class AgentManager:
                 cur.rowcount,
             )
 
+    @_db_locked
     def close(self) -> None:
         self._conn.close()
 
     # ── Agent CRUD ────────────────────────────────────────────────
 
+    @_db_locked
     def create_agent(
         self,
         name: str,
@@ -209,6 +226,7 @@ class AgentManager:
         self._conn.commit()
         return self.get_agent(agent_id)  # type: ignore[return-value]
 
+    @_db_locked
     def list_agents(self, include_archived: bool = False) -> List[Dict[str, Any]]:
         query = "SELECT * FROM managed_agents"
         if not include_archived:
@@ -217,12 +235,14 @@ class AgentManager:
         rows = self._conn.execute(query).fetchall()
         return [self._row_to_agent(r) for r in rows]
 
+    @_db_locked
     def get_agent(self, agent_id: str) -> Optional[Dict[str, Any]]:
         row = self._conn.execute(
             "SELECT * FROM managed_agents WHERE id = ?", (agent_id,)
         ).fetchone()
         return self._row_to_agent(row) if row else None
 
+    @_db_locked
     def update_agent(self, agent_id: str, **kwargs: Any) -> Dict[str, Any]:
         sets: List[str] = []
         vals: List[Any] = []
@@ -270,15 +290,19 @@ class AgentManager:
         self._conn.commit()
         return self.get_agent(agent_id)  # type: ignore[return-value]
 
+    @_db_locked
     def delete_agent(self, agent_id: str) -> None:
         self._set_status(agent_id, "archived")
 
+    @_db_locked
     def pause_agent(self, agent_id: str) -> None:
         self._set_status(agent_id, "paused")
 
+    @_db_locked
     def resume_agent(self, agent_id: str) -> None:
         self._set_status(agent_id, "idle")
 
+    @_db_locked
     def _set_status(self, agent_id: str, status: str) -> None:
         self._conn.execute(
             "UPDATE managed_agents SET status = ?, updated_at = ? WHERE id = ?",
@@ -308,6 +332,7 @@ class AgentManager:
             )
         self._set_status(agent_id, "running")
 
+    @_db_locked
     def end_tick(self, agent_id: str) -> None:
         self._conn.execute(
             "UPDATE managed_agents SET status = 'idle', "
@@ -320,6 +345,7 @@ class AgentManager:
 
     _CHECKPOINT_RETENTION = 5
 
+    @_db_locked
     def save_checkpoint(
         self,
         agent_id: str,
@@ -357,6 +383,7 @@ class AgentManager:
             "created_at": now,
         }
 
+    @_db_locked
     def list_checkpoints(self, agent_id: str) -> list:
         rows = self._conn.execute(
             "SELECT * FROM agent_checkpoints"
@@ -365,6 +392,7 @@ class AgentManager:
         ).fetchall()
         return [self._row_to_checkpoint(r) for r in rows]
 
+    @_db_locked
     def get_latest_checkpoint(self, agent_id: str) -> Optional[Dict[str, Any]]:
         row = self._conn.execute(
             "SELECT * FROM agent_checkpoints"
@@ -373,6 +401,7 @@ class AgentManager:
         ).fetchone()
         return self._row_to_checkpoint(row) if row else None
 
+    @_db_locked
     def recover_agent(self, agent_id: str) -> Optional[Dict[str, Any]]:
         checkpoint = self.get_latest_checkpoint(agent_id)
         # Always reset to idle — clearing the error state is the primary purpose
@@ -392,6 +421,7 @@ class AgentManager:
 
     # ── Summary memory ────────────────────────────────────────────
 
+    @_db_locked
     def update_summary_memory(self, agent_id: str, summary: str) -> None:
         truncated = summary[:_SUMMARY_MAX]
         self._conn.execute(
@@ -402,6 +432,7 @@ class AgentManager:
 
     # ── Task CRUD ─────────────────────────────────────────────────
 
+    @_db_locked
     def create_task(
         self, agent_id: str, description: str, status: str = "pending"
     ) -> Dict[str, Any]:
@@ -415,6 +446,7 @@ class AgentManager:
         self._conn.commit()
         return self._get_task(task_id)  # type: ignore[return-value]
 
+    @_db_locked
     def list_tasks(
         self, agent_id: str, status: Optional[str] = None
     ) -> List[Dict[str, Any]]:
@@ -427,6 +459,7 @@ class AgentManager:
         rows = self._conn.execute(query, params).fetchall()
         return [self._row_to_task(r) for r in rows]
 
+    @_db_locked
     def update_task(self, task_id: str, **kwargs: Any) -> Dict[str, Any]:
         sets: List[str] = []
         vals: List[Any] = []
@@ -449,10 +482,12 @@ class AgentManager:
         self._conn.commit()
         return self._get_task(task_id)  # type: ignore[return-value]
 
+    @_db_locked
     def delete_task(self, task_id: str) -> None:
         self._conn.execute("DELETE FROM agent_tasks WHERE id = ?", (task_id,))
         self._conn.commit()
 
+    @_db_locked
     def _get_task(self, task_id: str) -> Optional[Dict[str, Any]]:
         row = self._conn.execute(
             "SELECT * FROM agent_tasks WHERE id = ?", (task_id,)
@@ -461,6 +496,7 @@ class AgentManager:
 
     # ── Channel bindings ──────────────────────────────────────────
 
+    @_db_locked
     def bind_channel(
         self,
         agent_id: str,
@@ -480,22 +516,26 @@ class AgentManager:
         self._conn.commit()
         return self._get_binding(binding_id)  # type: ignore[return-value]
 
+    @_db_locked
     def list_channel_bindings(self, agent_id: str) -> List[Dict[str, Any]]:
         rows = self._conn.execute(
             "SELECT * FROM channel_bindings WHERE agent_id = ?", (agent_id,)
         ).fetchall()
         return [self._row_to_binding(r) for r in rows]
 
+    @_db_locked
     def unbind_channel(self, binding_id: str) -> None:
         self._conn.execute("DELETE FROM channel_bindings WHERE id = ?", (binding_id,))
         self._conn.commit()
 
+    @_db_locked
     def _get_binding(self, binding_id: str) -> Optional[Dict[str, Any]]:
         row = self._conn.execute(
             "SELECT * FROM channel_bindings WHERE id = ?", (binding_id,)
         ).fetchone()
         return self._row_to_binding(row) if row else None
 
+    @_db_locked
     def find_binding_for_channel(
         self, channel_type: str, channel_id: str
     ) -> Optional[Dict[str, Any]]:
@@ -577,6 +617,7 @@ class AgentManager:
 
     # ── Message queue ─────────────────────────────────────────────
 
+    @_db_locked
     def send_message(self, agent_id: str, content: str, mode: str = "queued") -> dict:
         msg_id = uuid4().hex[:16]
         now = time.time()
@@ -597,6 +638,7 @@ class AgentManager:
             "created_at": now,
         }
 
+    @_db_locked
     def store_agent_response(
         self,
         agent_id: str,
@@ -632,6 +674,7 @@ class AgentManager:
             "tool_calls": tool_calls or None,
         }
 
+    @_db_locked
     def list_messages(self, agent_id: str, limit: int = 50) -> list[dict]:
         rows = self._conn.execute(
             "SELECT * FROM agent_messages"
@@ -640,6 +683,7 @@ class AgentManager:
         ).fetchall()
         return [self._row_to_message(r) for r in rows]
 
+    @_db_locked
     def get_pending_messages(self, agent_id: str) -> list[dict]:
         rows = self._conn.execute(
             "SELECT * FROM agent_messages"
@@ -649,6 +693,7 @@ class AgentManager:
         ).fetchall()
         return [self._row_to_message(r) for r in rows]
 
+    @_db_locked
     def mark_message_delivered(self, message_id: str) -> None:
         self._conn.execute(
             "UPDATE agent_messages SET status = 'delivered' WHERE id = ?",
@@ -656,6 +701,7 @@ class AgentManager:
         )
         self._conn.commit()
 
+    @_db_locked
     def add_agent_response(self, agent_id: str, content: str) -> dict:
         msg_id = uuid4().hex[:16]
         now = time.time()
@@ -701,6 +747,7 @@ class AgentManager:
 
     # ── Learning log ──────────────────────────────────────────
 
+    @_db_locked
     def add_learning_log(
         self,
         agent_id: str,
@@ -726,6 +773,7 @@ class AgentManager:
             "created_at": now,
         }
 
+    @_db_locked
     def list_learning_log(self, agent_id: str, limit: int = 50) -> list[dict]:
         rows = self._conn.execute(
             "SELECT * FROM agent_learning_log"

--- a/tests/agents/test_manager.py
+++ b/tests/agents/test_manager.py
@@ -373,3 +373,23 @@ class TestSchemaAndThreading:
         t.join(timeout=5)
         assert len(results) == 1
         assert results[0]["name"] == "threaded"
+
+    def test_concurrent_updates_are_serialized(self, manager):
+        """Concurrent updates on the shared manager connection must not be lost."""
+        from concurrent.futures import ThreadPoolExecutor
+
+        agent = manager.create_agent(name="concurrent", agent_type="simple")
+        workers = 8
+        updates_per_worker = 20
+
+        def update_many():
+            for _ in range(updates_per_worker):
+                manager.update_agent(agent["id"], total_tokens_increment=1)
+
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            futures = [pool.submit(update_many) for _ in range(workers)]
+            for future in futures:
+                future.result()
+
+        updated = manager.get_agent(agent["id"])
+        assert updated["total_tokens"] == workers * updates_per_worker


### PR DESCRIPTION
## Summary

- Prevents concurrent agent workers from corrupting or interleaving a shared `AgentManager` SQLite connection.
- Serializes database-backed manager methods with a re-entrant lock, so nested CRUD calls remain safe.
- Adds a regression test that runs 8 workers with 20 token updates each and verifies that no updates are lost.

## Changes by area

| Area | What changed | Verification |
| --- | --- | --- |
| AgentManager runtime | Added one per-manager `RLock` and applied it to connection-using methods, including reads, writes, commits, and close. | Local stress run: 160 expected updates, 160 stored, 0 failures |
| Regression coverage | Added a multi-threaded test against the existing shared-connection fixture. | `tests/agents/test_manager.py`: 34 passed |
| Compatibility | Public method signatures, SQLite schema, API responses, and dependencies are unchanged. | Ruff check/format and `git diff --check` passed |

## Test plan

- [x] `PYTHONPATH=src python -m pytest tests/agents/test_manager.py -q` — 34 passed
- [x] `ruff check src/openjarvis/agents/manager.py tests/agents/test_manager.py`
- [x] `ruff format --check src/openjarvis/agents/manager.py tests/agents/test_manager.py`
- [x] `git diff --check`
- [ ] Full `tests/agents` suite — 570 passed, 1 failed (see Remaining validation)

## Remaining validation

- The broader `tests/agents` run has one failure in `tests/agents/test_loop_guard.py::TestLoopGuard::test_identical_calls_blocked`; the failing code and test are outside this PR. The result was `570 passed, 1 failed`.
- GitHub Actions will provide the repository CI checks after this PR is opened.
- Issue #927 remains separate: it covers atomic tick acquisition across independent connections/processes. This PR covers thread safety for one shared `AgentManager` connection.

## Compatibility / Not changed

- No database migration, public API, or dependency change is introduced.
- Existing manager methods keep their signatures and nested behavior.
- The lock is intentionally per `AgentManager` instance; it does not claim to coordinate separate processes.