### PR TITLE
fix(agents): preserve user lifecycle state on tick cleanup

### DIFF
--- a/src/openjarvis/agents/manager.py
+++ b/src/openjarvis/agents/manager.py
@@ -311,7 +311,8 @@ class AgentManager:
     def end_tick(self, agent_id: str) -> None:
         self._conn.execute(
             "UPDATE managed_agents SET status = 'idle', "
-            "current_activity = '', updated_at = ? WHERE id = ?",
+            "current_activity = '', updated_at = ? "
+            "WHERE id = ? AND status = 'running'",
             (time.time(), agent_id),
         )
         self._conn.commit()

--- a/tests/agents/test_manager.py
+++ b/tests/agents/test_manager.py
@@ -167,6 +167,22 @@ class TestConcurrency:
         with pytest.raises(ValueError, match="already executing"):
             manager.start_tick(agent["id"])
 
+    @pytest.mark.parametrize(
+        ("change_status", "expected_status"),
+        [("pause_agent", "paused"), ("delete_agent", "archived")],
+    )
+    def test_end_tick_preserves_user_status_change(
+        self, manager, change_status, expected_status
+    ):
+        """A late tick cleanup must not undo a user's pause or archive action."""
+        agent = manager.create_agent(name="lifecycle", agent_type="simple")
+        manager.start_tick(agent["id"])
+
+        getattr(manager, change_status)(agent["id"])
+        manager.end_tick(agent["id"])
+
+        assert manager.get_agent(agent["id"])["status"] == expected_status
+
 
 class TestCheckpoints:
     def test_save_checkpoint(self, manager):


### PR DESCRIPTION
## Summary

- Preserve a user's `paused` or `archived` choice when a tick finishes after that choice was made.
- Make `end_tick()` change `running` to `idle` only while the row is still `running`.
- Keep the normal `running` → `idle` completion path unchanged.

## Changes by area

| Area | What changed | Verification |
| --- | --- | --- |
| Runtime | Tick cleanup now uses a conditional SQLite update, so a late cleanup cannot overwrite `paused` or `archived`. | Two-connection smoke test: `pause -> paused`, `archive -> archived`, `running -> idle`. |
| Tests | Added regression coverage for pause/archive actions that happen before late cleanup. | `tests/agents/test_manager.py`; the two new cases fail before the fix and pass after it. |
| Compatibility | Status values, database schema, public APIs, and ordinary completion behavior are unchanged. | Targeted lifecycle tests and patch checks pass. |

## Test plan

- [x] `PYTHONPATH=src python -m pytest tests/agents/test_manager.py tests/agents/test_executor.py tests/agents/test_agent_lifecycle_scenarios.py -q` — `56 passed`
- [x] `PYTHONPATH=src python -m pytest tests/agents -q` — `571 passed, 1 failed` (see Remaining validation)
- [x] Ruff check and format check for the changed files
- [x] Python bytecode compilation for the changed files
- [x] `git diff --check`

## Remaining validation

- The full `tests/agents` run has one environment-dependent failure in `tests/agents/test_loop_guard.py::TestLoopGuard::test_identical_calls_blocked`. This checkout reports `RUST_AVAILABLE=False`, so the test's Rust-backend expectation is not available; the failure is outside the changed files.
- GitHub Actions will provide the repository's normal CI validation after the PR is opened.

## Compatibility / Not changed

- A normal tick that is still `running` when it finishes still becomes `idle`.
- `pause_agent()` and `delete_agent()` keep their existing status values and behavior.
- No database migration, API response, dependency, scheduler, or start-tick guard behavior is changed.
- This is limited to the cleanup race; it does not duplicate the separate concurrent-acquisition issue tracked in #927.