### PR TITLE
feat(connectors): add Apple Mail (.emlx) connector

### DIFF
--- a/frontend/src/pages/AgentsPage.tsx
+++ b/frontend/src/pages/AgentsPage.tsx
@@ -2033,6 +2033,7 @@ function ChannelsTab({ agentId }: { agentId: string }) {
     imessage: '\uD83D\uDCAC', gdrive: '\uD83D\uDCC1', notion: '\uD83D\uDCC4',
     obsidian: '\uD83D\uDCC1', granola: '\uD83C\uDF99\uFE0F', gcalendar: '\uD83D\uDCC5',
     gcontacts: '\uD83D\uDCC7', outlook: '\u2709\uFE0F', apple_notes: '\uD83C\uDF4E',
+    apple_mail: '\u2709\uFE0F',
     dropbox: '\uD83D\uDCE6', whatsapp: '\uD83D\uDCF1',
   };
 

--- a/frontend/src/pages/DataSourcesPage.tsx
+++ b/frontend/src/pages/DataSourcesPage.tsx
@@ -514,6 +514,7 @@ const iconMap: Record<string, LucideIcon> = {
   notion: BookText,
   obsidian: FileText,
   apple_notes: StickyNote,
+  apple_mail: Mail,
   granola: FileText,
   gcalendar: CalendarDays,
   gcontacts: Contact,

--- a/frontend/src/types/connectors.ts
+++ b/frontend/src/types/connectors.ts
@@ -436,6 +436,34 @@ export const SOURCE_CATALOG: ConnectorMeta[] = [
     ],
   },
   {
+    connector_id: 'apple_mail',
+    display_name: 'Apple Mail',
+    auth_type: 'filesystem',
+    category: 'communication',
+    icon: 'Mail',
+    color: 'text-sky-400',
+    description: 'macOS Mail app (any account Mail.app syncs, including IMAP-blocked ones)',
+    unitLabel: 'emails',
+    steps: [
+      {
+        label: 'Open the Apple menu () → System Settings → Privacy & Security (in the left sidebar) → scroll down and click "Full Disk Access". Add Terminal.app (or iTerm2/Warp) and, for the desktop app, "OpenJarvis.app", then toggle them ON and restart',
+      },
+      {
+        label: 'Find the mail store: in Finder press ⌘⇧G and open ~/Library/Mail/V10. Each folder is one account (a UUID); inside are your mailboxes as "<Name>.mbox" folders. Open a mailbox in Mail.app and check its message count to identify the account',
+      },
+      {
+        label: 'Paste the path below. Use ~/Library/Mail to index every account, one account folder to index just that account, or one .mbox folder to index a single mailbox',
+      },
+    ],
+    troubleshooting: [
+      'Only messages Mail.app has already downloaded are indexed. Open the mailbox in Mail.app (or set Account Settings → "Download Attachments: All") to fetch the rest.',
+      'Zero messages indexed usually means Full Disk Access is missing for the process running OpenJarvis.',
+    ],
+    inputFields: [
+      { name: 'path', placeholder: '/Users/you/Library/Mail/V10/<account-uuid>', type: 'text' },
+    ],
+  },
+  {
     connector_id: 'apple_contacts',
     display_name: 'Apple Contacts',
     auth_type: 'local',

--- a/src/openjarvis/agents/research_loop.py
+++ b/src/openjarvis/agents/research_loop.py
@@ -110,8 +110,9 @@ SEARCH_TOOL_SPEC: Dict[str, Any] = {
                         'Granola notes" → [\'granola\']; "check Slack and Gmail" '
                         "→ ['slack', 'gmail']). Valid IDs include: gmail, slack, "
                         "granola, notion, obsidian, gcalendar, gdrive, gmail_imap, "
-                        "outlook, imessage, whatsapp, apple_notes, apple_contacts, "
-                        "gcontacts, google_tasks, github_notifications."
+                        "outlook, imessage, whatsapp, apple_notes, apple_mail, "
+                        "apple_contacts, gcontacts, google_tasks, "
+                        "github_notifications."
                     ),
                     "items": {"type": "string"},
                 },

--- a/src/openjarvis/connectors/__init__.py
+++ b/src/openjarvis/connectors/__init__.py
@@ -54,6 +54,11 @@ except ImportError:
     pass
 
 try:
+    import openjarvis.connectors.apple_mail  # noqa: F401
+except ImportError:
+    pass
+
+try:
     import openjarvis.connectors.apple_music  # noqa: F401
 except ImportError:
     pass

--- a/src/openjarvis/connectors/apple_mail.py
+++ b/src/openjarvis/connectors/apple_mail.py
@@ -1,0 +1,211 @@
+"""Apple Mail connector — reads ``.emlx`` files from the macOS Mail.app store.
+
+No network, no credentials. Mail.app keeps every synced message as one
+``.emlx`` file under ``~/Library/Mail/V<N>/<account-uuid>/<Mailbox>.mbox/``.
+This connector walks a folder of that store and yields one
+:class:`Document` per message. It is the only way to index a mailbox whose
+provider blocks IMAP (Microsoft 365 tenants with basic auth disabled, for
+example) but which Mail.app can still sync.
+
+The path given at connect time may be the whole store (``~/Library/Mail``),
+a single account folder, or a single ``.mbox`` folder. Requires **Full Disk
+Access** for the process reading the store.
+
+``.emlx`` layout::
+
+    <decimal byte count>\\n<RFC822 message><XML plist trailer>
+
+The byte count covers the RFC822 section only. The trailer plist carries
+``date-received`` (Unix epoch), ``flags``, ``remote-id`` and
+``conversation-id``. ``.partial.emlx`` files are messages Mail.app has not
+fully downloaded (typically attachments missing); their text is still indexed.
+"""
+
+from __future__ import annotations
+
+import email as email_lib
+import plistlib
+from datetime import datetime, timezone
+from email import policy
+from pathlib import Path
+from typing import Any, Dict, Iterator, Optional, Tuple
+
+from openjarvis.connectors._stubs import BaseConnector, Document, SyncStatus
+from openjarvis.connectors.gmail_imap import (
+    _decode_header,
+    _extract_text_body,
+    _parse_date,
+)
+from openjarvis.core.registry import ConnectorRegistry
+
+
+class EmlxParseError(ValueError):
+    """Raised when a ``.emlx`` file does not match the expected layout."""
+
+
+def parse_emlx(path: Path) -> Tuple[bytes, Dict[str, Any]]:
+    """Return ``(rfc822_bytes, plist_dict)`` for one ``.emlx`` file."""
+    raw = path.read_bytes()
+    newline = raw.find(b"\n")
+    if newline == -1:
+        raise EmlxParseError(f"{path}: no newline after size header")
+    try:
+        size = int(raw[:newline].strip())
+    except ValueError as exc:
+        raise EmlxParseError(f"{path}: invalid size header") from exc
+    body_start = newline + 1
+    rfc822 = raw[body_start : body_start + size]
+    trailer = raw[body_start + size :]
+    if not trailer.strip():
+        return rfc822, {}
+    try:
+        plist = plistlib.loads(trailer)
+    except Exception as exc:  # noqa: BLE001
+        raise EmlxParseError(f"{path}: trailer is not a valid plist") from exc
+    return rfc822, plist
+
+
+def _split_address_list(raw: str) -> list[str]:
+    return [part.strip() for part in raw.split(",") if part.strip()]
+
+
+def _locate(path: Path) -> Tuple[str, str]:
+    """Return ``(account_id, mailbox)`` for an ``.emlx`` path.
+
+    ``account_id`` is the UUID folder under ``V<N>``; ``mailbox`` is the
+    ``.mbox`` chain relative to it (nested mailboxes joined with ``/``).
+    Falls back to empty strings when the file lives outside a Mail store.
+    """
+    parts = path.parts
+    account_id = ""
+    for index, part in enumerate(parts):
+        if part.startswith("V") and part[1:].isdigit() and index + 1 < len(parts):
+            account_id = parts[index + 1]
+            break
+    mailbox = "/".join(p[: -len(".mbox")] for p in parts if p.endswith(".mbox"))
+    return account_id, mailbox
+
+
+@ConnectorRegistry.register("apple_mail")
+class AppleMailConnector(BaseConnector):
+    """Connector that reads messages from the local Mail.app ``.emlx`` store.
+
+    Parameters
+    ----------
+    mailbox_path:
+        Folder to index: the whole store, one account folder, or one
+        ``.mbox``. Empty means "not yet configured".
+    """
+
+    connector_id = "apple_mail"
+    display_name = "Apple Mail"
+    auth_type = "filesystem"
+
+    def __init__(self, mailbox_path: str = "") -> None:
+        self._vault_path: str = mailbox_path
+        self._connected: bool = bool(mailbox_path) and Path(mailbox_path).is_dir()
+        self._items_synced: int = 0
+        self._items_total: int = 0
+        self._last_sync: Optional[datetime] = None
+
+    @property
+    def mailbox_path(self) -> str:
+        return self._vault_path
+
+    # ------------------------------------------------------------------
+    # BaseConnector interface
+    # ------------------------------------------------------------------
+
+    def is_connected(self) -> bool:
+        return bool(self._vault_path) and Path(self._vault_path).is_dir()
+
+    def disconnect(self) -> None:
+        self._vault_path = ""
+        self._connected = False
+
+    def sync(
+        self,
+        *,
+        since: Optional[datetime] = None,
+        cursor: Optional[str] = None,  # noqa: ARG002
+    ) -> Iterator[Document]:
+        """Walk the configured folder and yield one :class:`Document` per message.
+
+        ``since`` is compared against the ``date-received`` trailer value
+        (falling back to the ``Date`` header), so incremental syncs pick up
+        messages Mail.app downloaded after the last run.
+        """
+        root = Path(self._vault_path).expanduser() if self._vault_path else None
+        if root is None or not root.is_dir():
+            return
+
+        since_utc: Optional[datetime] = None
+        if since is not None:
+            since_utc = since if since.tzinfo else since.replace(tzinfo=timezone.utc)
+
+        paths = sorted(p for p in root.rglob("*.emlx") if "MailData" not in p.parts)
+        self._items_total = len(paths)
+        synced = 0
+
+        for path in paths:
+            try:
+                rfc822, plist = parse_emlx(path)
+            except (EmlxParseError, OSError):
+                continue
+
+            msg = email_lib.message_from_bytes(rfc822, policy=policy.compat32)
+            received = plist.get("date-received")
+            if isinstance(received, (int, float)) and received > 0:
+                timestamp = datetime.fromtimestamp(received, tz=timezone.utc)
+            else:
+                timestamp = _parse_date(msg)
+                if timestamp.tzinfo is None:
+                    timestamp = timestamp.replace(tzinfo=timezone.utc)
+
+            if since_utc is not None and timestamp < since_utc:
+                continue
+
+            account_id, mailbox = _locate(path)
+            uid = path.name.split(".", 1)[0]
+            message_id = _decode_header(msg.get("Message-ID", "")).strip()
+            source_id = message_id or f"{account_id}:{mailbox}:{uid}"
+            subject = _decode_header(msg.get("Subject", ""))
+            sender = _decode_header(msg.get("From", ""))
+            recipients = _split_address_list(
+                _decode_header(msg.get("To", ""))
+            ) + _split_address_list(_decode_header(msg.get("Cc", "")))
+
+            synced += 1
+            yield Document(
+                doc_id=f"apple_mail:{source_id}",
+                source="apple_mail",
+                doc_type="email",
+                content=_extract_text_body(msg),
+                title=subject,
+                author=sender,
+                participants=recipients,
+                timestamp=timestamp,
+                thread_id=_decode_header(msg.get("In-Reply-To", "")) or None,
+                metadata={
+                    "message_id": message_id,
+                    "account_id": account_id,
+                    "mailbox": mailbox,
+                    "emlx_uid": uid,
+                    "partial": path.name.endswith(".partial.emlx"),
+                    "path": str(path),
+                },
+                source_id=source_id,
+                participants_raw=recipients,
+                channel=mailbox or None,
+            )
+
+        self._items_synced = synced
+        self._last_sync = datetime.now(tz=timezone.utc)
+
+    def sync_status(self) -> SyncStatus:
+        return SyncStatus(
+            state="idle",
+            items_synced=self._items_synced,
+            items_total=self._items_total,
+            last_sync=self._last_sync,
+        )

--- a/tests/connectors/test_apple_mail.py
+++ b/tests/connectors/test_apple_mail.py
@@ -1,0 +1,221 @@
+"""Tests for AppleMailConnector — local Mail.app ``.emlx`` store connector.
+
+All tests build a fake ``~/Library/Mail/V10`` tree in ``tmp_path``. No real
+Mail.app store is required.
+"""
+
+from __future__ import annotations
+
+import plistlib
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List
+
+import pytest
+
+from openjarvis.connectors._stubs import Document
+from openjarvis.core.registry import ConnectorRegistry
+
+_ACCOUNT = "9691CB23-B31E-4A68-8D60-1308897B62EF"
+
+
+def _epoch(*args: int) -> int:
+    return int(datetime(*args, tzinfo=timezone.utc).timestamp())
+
+
+def _write_emlx(
+    path: Path,
+    rfc822: bytes,
+    *,
+    date_received: int | None = None,
+    trailer: bool = True,
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    body = f"{len(rfc822)}\n".encode() + rfc822
+    if trailer:
+        plist = {"conversation-id": 1, "flags": 0}
+        if date_received is not None:
+            plist["date-received"] = date_received
+        body += plistlib.dumps(plist)
+    path.write_bytes(body)
+
+
+_MSG_ONE = (
+    b"From: Vikram <vikram@astro.caltech.edu>\r\n"
+    b"To: Jakob Faber <jfaber@caltech.edu>, other@example.com\r\n"
+    b"Cc: admin@caltech.edu\r\n"
+    b"Subject: DSA reimbursement\r\n"
+    b"Message-ID: <one@caltech.edu>\r\n"
+    b"Date: Tue, 01 Sep 2026 10:00:00 +0000\r\n"
+    b"Content-Type: text/plain; charset=utf-8\r\n"
+    b"\r\n"
+    b"Please submit the receipt for $53.22.\r\n"
+)
+
+_MSG_TWO = (
+    b"From: gp@astro.caltech.edu\r\n"
+    b"To: jfaber@caltech.edu\r\n"
+    b"Subject: =?utf-8?q?Missing_receipts_=E2=80=94_reminder?=\r\n"
+    b"Message-ID: <two@caltech.edu>\r\n"
+    b"In-Reply-To: <one@caltech.edu>\r\n"
+    b"Date: Wed, 02 Sep 2026 10:00:00 +0000\r\n"
+    b"Content-Type: multipart/alternative; boundary=BOUND\r\n"
+    b"\r\n"
+    b"--BOUND\r\n"
+    b"Content-Type: text/html; charset=utf-8\r\n"
+    b"\r\n"
+    b"<p>html only</p>\r\n"
+    b"--BOUND\r\n"
+    b"Content-Type: text/plain; charset=utf-8\r\n"
+    b"\r\n"
+    b"plain part wins\r\n"
+    b"--BOUND--\r\n"
+)
+
+_MSG_PARTIAL = (
+    b"From: noreply@example.com\r\n"
+    b"To: jfaber@caltech.edu\r\n"
+    b"Subject: headers only\r\n"
+    b"Date: Thu, 03 Sep 2026 10:00:00 +0000\r\n"
+    b"\r\n"
+)
+
+
+@pytest.fixture()
+def mail_store(tmp_path: Path) -> Path:
+    """Return the fake ``~/Library/Mail`` root with one account and two mailboxes."""
+    root = tmp_path / "Mail"
+    account = root / "V10" / _ACCOUNT
+    billing = account / "Billing & Payments.mbox" / "F858" / "Data" / "0" / "Messages"
+    inbox = account / "INBOX.mbox" / "F858" / "Data" / "Messages"
+
+    _write_emlx(billing / "101.emlx", _MSG_ONE, date_received=_epoch(2026, 9, 1, 18, 0))
+    _write_emlx(billing / "102.emlx", _MSG_TWO, date_received=_epoch(2026, 9, 2, 18, 0))
+    _write_emlx(
+        inbox / "103.partial.emlx",
+        _MSG_PARTIAL,
+        date_received=_epoch(2026, 9, 3, 18, 0),
+    )
+    # Non-message files that must be ignored.
+    (billing.parent / "Attachments").mkdir(parents=True, exist_ok=True)
+    (billing.parent / "Attachments" / "101.pdf").write_bytes(b"%PDF")
+    (root / "V10" / "MailData").mkdir(parents=True)
+    _write_emlx(root / "V10" / "MailData" / "999.emlx", _MSG_ONE)
+    return root
+
+
+@pytest.fixture()
+def connector(mail_store: Path):
+    from openjarvis.connectors.apple_mail import AppleMailConnector  # noqa: PLC0415
+
+    return AppleMailConnector(mailbox_path=str(mail_store))
+
+
+def test_registered() -> None:
+    # conftest clears every registry between tests; re-import to re-register.
+    import importlib  # noqa: PLC0415
+
+    import openjarvis.connectors.apple_mail as apple_mail  # noqa: PLC0415
+
+    importlib.reload(apple_mail)
+    assert ConnectorRegistry.get("apple_mail") is apple_mail.AppleMailConnector
+
+
+def test_not_connected_without_path() -> None:
+    from openjarvis.connectors.apple_mail import AppleMailConnector  # noqa: PLC0415
+
+    assert AppleMailConnector().is_connected() is False
+    assert AppleMailConnector(mailbox_path="/nonexistent/Mail").is_connected() is False
+    assert list(AppleMailConnector().sync()) == []
+
+
+def test_is_connected_and_disconnect(connector) -> None:
+    assert connector.is_connected() is True
+    connector.disconnect()
+    assert connector.is_connected() is False
+    assert connector.mailbox_path == ""
+
+
+def test_sync_yields_messages(connector) -> None:
+    docs: List[Document] = list(connector.sync())
+    assert len(docs) == 3
+    assert {d.source for d in docs} == {"apple_mail"}
+    assert {d.doc_type for d in docs} == {"email"}
+    assert connector.sync_status().items_synced == 3
+    assert connector.sync_status().items_total == 3
+
+
+def test_sync_document_fields(connector) -> None:
+    docs = {d.doc_id: d for d in connector.sync()}
+
+    one = docs["apple_mail:<one@caltech.edu>"]
+    assert one.title == "DSA reimbursement"
+    assert one.author == "Vikram <vikram@astro.caltech.edu>"
+    assert one.participants == [
+        "Jakob Faber <jfaber@caltech.edu>",
+        "other@example.com",
+        "admin@caltech.edu",
+    ]
+    assert "$53.22" in one.content
+    assert one.timestamp == datetime(2026, 9, 1, 18, 0, tzinfo=timezone.utc)
+    assert one.metadata["account_id"] == _ACCOUNT
+    assert one.metadata["mailbox"] == "Billing & Payments"
+    assert one.metadata["emlx_uid"] == "101"
+    assert one.metadata["partial"] is False
+    assert one.channel == "Billing & Payments"
+    assert one.source_id == "<one@caltech.edu>"
+
+    two = docs["apple_mail:<two@caltech.edu>"]
+    assert two.title == "Missing receipts — reminder"
+    assert two.content.strip() == "plain part wins"
+    assert two.thread_id == "<one@caltech.edu>"
+
+
+def test_partial_message_falls_back_to_path_id(connector) -> None:
+    docs = {d.doc_id: d for d in connector.sync()}
+    partial = docs[f"apple_mail:{_ACCOUNT}:INBOX:103"]
+    assert partial.title == "headers only"
+    assert partial.content == ""
+    assert partial.metadata["partial"] is True
+    assert partial.metadata["mailbox"] == "INBOX"
+
+
+def test_since_filter_uses_date_received(connector) -> None:
+    since = datetime(2026, 9, 2, 0, 0, tzinfo=timezone.utc)
+    docs = list(connector.sync(since=since))
+    assert {d.title for d in docs} == {"Missing receipts — reminder", "headers only"}
+
+    naive = datetime(2026, 9, 3, 0, 0)
+    assert [d.title for d in connector.sync(since=naive)] == ["headers only"]
+
+
+def test_single_mbox_path(mail_store: Path) -> None:
+    from openjarvis.connectors.apple_mail import AppleMailConnector  # noqa: PLC0415
+
+    mbox = mail_store / "V10" / _ACCOUNT / "Billing & Payments.mbox"
+    docs = list(AppleMailConnector(mailbox_path=str(mbox)).sync())
+    assert len(docs) == 2
+    assert {d.metadata["mailbox"] for d in docs} == {"Billing & Payments"}
+
+
+def test_malformed_emlx_is_skipped(mail_store: Path) -> None:
+    from openjarvis.connectors.apple_mail import AppleMailConnector  # noqa: PLC0415
+
+    bad = mail_store / "V10" / _ACCOUNT / "INBOX.mbox" / "bad.emlx"
+    bad.write_bytes(b"not-a-size\nFrom: x\r\n\r\n")
+    (mail_store / "V10" / _ACCOUNT / "INBOX.mbox" / "empty.emlx").write_bytes(b"")
+
+    docs = list(AppleMailConnector(mailbox_path=str(mail_store)).sync())
+    assert len(docs) == 3
+
+
+def test_date_header_fallback_without_trailer(tmp_path: Path) -> None:
+    from openjarvis.connectors.apple_mail import AppleMailConnector  # noqa: PLC0415
+
+    _write_emlx(tmp_path / "loose.emlx", _MSG_ONE, trailer=False)
+    docs = list(AppleMailConnector(mailbox_path=str(tmp_path)).sync())
+    assert len(docs) == 1
+    assert docs[0].timestamp == datetime(2026, 9, 1, 10, 0, tzinfo=timezone.utc)
+    assert docs[0].metadata["account_id"] == ""
+    assert docs[0].metadata["mailbox"] == ""
+    assert docs[0].channel is None

--- a/tests/connectors/test_connector_health.py
+++ b/tests/connectors/test_connector_health.py
@@ -11,6 +11,7 @@ import pytest
 # All connectors that should be testable without credentials
 _LOCAL_CONNECTORS = [
     ("apple_notes", "openjarvis.connectors.apple_notes", "AppleNotesConnector"),
+    ("apple_mail", "openjarvis.connectors.apple_mail", "AppleMailConnector"),
     ("imessage", "openjarvis.connectors.imessage", "IMessageConnector"),
 ]
 


### PR DESCRIPTION
## Summary

Adds an **Apple Mail** connector that indexes messages straight from the local Mail.app store (`~/Library/Mail/V<N>/<account>/<Mailbox>.mbox/**/*.emlx`). No network, no credentials.

Motivation: some providers block IMAP outright (Microsoft 365 tenants with basic auth disabled return `NO LOGIN failed` even with a valid app password), so the existing `outlook` / `imap` connectors cannot reach them. Mail.app still syncs those accounts, and this connector reads what it has downloaded.

## Design

- `auth_type = "filesystem"`, mirroring `obsidian`: the UI already renders a path input and the router already sets `_vault_path`, so no new router or frontend plumbing.
- Path may be the whole store, one account folder, or one `.mbox`. An empty path means "not connected", which prevents an accidental scan of every account on the machine.
- `.emlx` parsing: decimal size header, RFC822 body, XML plist trailer. Timestamp comes from the trailer's `date-received` (Date header fallback) and `since` filters on it for incremental syncs.
- `doc_id` is `apple_mail:<Message-ID>`, else `apple_mail:<account>:<mailbox>:<uid>`. Account UUID, mailbox, uid, and a `partial` flag go in `metadata`; mailbox is also the `channel`.
- Reuses `_decode_header`, `_extract_text_body`, `_parse_date` from `gmail_imap` (same pattern as `imap.py`).

## Registration

`connectors/__init__.py`, research-loop source list, frontend catalog entry with setup steps and icon maps, `test_connector_health` local list.

## Verification

- `tests/connectors/test_apple_mail.py`: 10 tests on a synthetic store (nested mailboxes, partial files, `since`, malformed files, MailData exclusion, header decoding).
- `pytest tests/connectors`: 445 passed; the 4 failures in `test_new_connectors_live.py` are pre-existing and hit live APIs with an empty bearer token.
- `ruff check` / `ruff format --check` clean, `tsc -b` exit 0, `vitest` 48 passed.
- Live store: 226/226 messages from one mailbox in 0.5s, 48,901/48,901 from a full Exchange account in 57s, no duplicate ids, no empty bodies.

Not included: a section in `docs/user-guide/channels-and-connectors.md`. Happy to add one if maintainers want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HfPaToQD4NMasfqfFuzGhk
