### PR TITLE
fix(agents): guard managed-agent streaming ticks

### DIFF
--- a/src/openjarvis/server/agent_manager_routes.py
+++ b/src/openjarvis/server/agent_manager_routes.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import re as _re
 import threading
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from openjarvis.agents.manager import AgentManager
 from openjarvis.agents.tool_resolver import (
@@ -852,12 +852,15 @@ async def _stream_managed_agent(
     engine: Any,
     bus: Any,
     app_state: Any = None,
+    on_complete: Optional[Callable[[], None]] = None,
 ) -> StreamingResponse:
     """Run a managed agent with real LLM token streaming via SSE.
 
     Uses ``engine.stream_full()`` to yield tokens as they arrive from the
     LLM. Supports multi-turn tool-calling: when the model emits tool_calls,
-    they are executed and the results fed back for the next turn.
+    they are executed and the results fed back for the next turn. When
+    ``on_complete`` is provided, it runs after either streaming branch has
+    finished its response-local cleanup.
     """
     import json
     import uuid
@@ -867,6 +870,15 @@ async def _stream_managed_agent(
     from openjarvis.core.types import Message, Role
 
     agent_id = agent_record["id"]
+
+    def _complete_stream() -> None:
+        if on_complete is None:
+            return
+        try:
+            on_complete()
+        except Exception:
+            logger.warning("Managed agent stream cleanup failed", exc_info=True)
+
     config = agent_record.get("config", {})
     # Resolve the model: prefer the agent's own config, then the server's
     # resolved model (app.state.model — what the engine was booted with),
@@ -1238,6 +1250,7 @@ async def _stream_managed_agent(
                     "Cache-Control": "no-cache",
                     "Connection": "keep-alive",
                 },
+                background=BackgroundTask(_complete_stream),
             )
 
     # The canonical resolver exposes the same live instances as OpenAI specs
@@ -1306,7 +1319,10 @@ async def _stream_managed_agent(
         try:
             _persist_final()
         finally:
-            resolved_toolkit.close()
+            try:
+                resolved_toolkit.close()
+            finally:
+                _complete_stream()
 
     async def generate():
         """Async generator yielding SSE-formatted chunks with real token streaming."""
@@ -1991,8 +2007,29 @@ def create_agent_manager_router(
         ):
             manager.update_agent(agent_id, status="idle")
 
+        stream_tick_acquired = False
+        stream_engine = None
+        if req.stream:
+            stream_engine = getattr(request.app.state, "engine", None)
+            if stream_engine is not None:
+                # Unlike the queued/immediate paths, streaming runs directly
+                # in the request, so it must acquire the same tick guard here.
+                try:
+                    manager.start_tick(agent_id)
+                    stream_tick_acquired = True
+                except ValueError:
+                    raise HTTPException(
+                        status_code=409,
+                        detail="Agent is already running",
+                    )
+
         # Store user message in DB (always, regardless of stream mode)
-        msg = manager.send_message(agent_id, req.content, mode=req.mode)
+        try:
+            msg = manager.send_message(agent_id, req.content, mode=req.mode)
+        except Exception:
+            if stream_tick_acquired:
+                manager.end_tick(agent_id)
+            raise
 
         if not req.stream and req.mode != "immediate":
             return msg
@@ -2072,7 +2109,7 @@ def create_agent_manager_router(
             return msg
 
         # --- Streaming mode: run agent and return SSE response ---
-        engine = getattr(request.app.state, "engine", None)
+        engine = stream_engine
         bus = getattr(request.app.state, "bus", None)
         if engine is None:
             raise HTTPException(
@@ -2080,15 +2117,21 @@ def create_agent_manager_router(
                 detail="Engine not available for streaming",
             )
 
-        return await _stream_managed_agent(
-            manager=manager,
-            agent_record=agent_record,
-            user_content=req.content,
-            message_id=msg["id"],
-            engine=engine,
-            bus=bus,
-            app_state=request.app.state,
-        )
+        try:
+            return await _stream_managed_agent(
+                manager=manager,
+                agent_record=agent_record,
+                user_content=req.content,
+                message_id=msg["id"],
+                engine=engine,
+                bus=bus,
+                app_state=request.app.state,
+                on_complete=lambda: manager.end_tick(agent_id),
+            )
+        except Exception:
+            if stream_tick_acquired:
+                manager.end_tick(agent_id)
+            raise
 
     # ── State inspection ─────────────────────────────────────
 

--- a/tests/server/test_agent_manager_routes.py
+++ b/tests/server/test_agent_manager_routes.py
@@ -487,6 +487,105 @@ class TestAgentManagerStreaming:
         assert resp.status_code == 200
         assert "Error:" in resp.text or "error" in resp.text.lower()
         assert "data: [DONE]" in resp.text
+        assert manager.get_agent(agent["id"])["status"] == "idle"
+
+    def test_streaming_requests_share_tick_guard(self, manager, tmp_path, monkeypatch):
+        """A second stream for the same agent must not start another tick."""
+        import asyncio
+
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        from openjarvis.engine._stubs import StreamChunk
+        from openjarvis.server.agent_manager_routes import (
+            create_agent_manager_router,
+        )
+
+        class SlowEngine:
+            engine_id = "slow"
+            _model = "test-model"
+
+            def __init__(self):
+                self.calls = 0
+                self.lock = threading.Lock()
+                self.first_started = threading.Event()
+                self.second_started = threading.Event()
+                self.release = threading.Event()
+
+            async def stream_full(self, messages, *, model, **kwargs):
+                with self.lock:
+                    self.calls += 1
+                    call = self.calls
+                if call == 1:
+                    self.first_started.set()
+                else:
+                    self.second_started.set()
+                while not self.release.is_set():
+                    await asyncio.sleep(0.01)
+                yield StreamChunk(content=f"response-{call}")
+                yield StreamChunk(finish_reason="stop")
+
+        monkeypatch.setenv("OPENJARVIS_HOME", str(tmp_path / "runtime"))
+        engine = SlowEngine()
+        app = FastAPI()
+        app.state.engine = engine
+        app.state.bus = None
+        for router in create_agent_manager_router(manager):
+            app.include_router(router)
+
+        agent = manager.create_agent(name="stream-race", agent_type="simple")
+        url = f"/v1/managed-agents/{agent['id']}/messages"
+
+        def send(client):
+            return client.post(url, json={"content": "hello", "stream": True})
+
+        client1 = TestClient(app)
+        client2 = TestClient(app)
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            first = pool.submit(send, client1)
+            assert engine.first_started.wait(5)
+            second = pool.submit(send, client2)
+            try:
+                assert not engine.second_started.wait(0.5)
+                second_response = second.result(timeout=5)
+                assert second_response.status_code == 409
+            finally:
+                engine.release.set()
+
+            first_response = first.result(timeout=10)
+
+        assert first_response.status_code == 200
+        assert engine.calls == 1
+        assert manager.get_agent(agent["id"])["status"] == "idle"
+
+    def test_stream_initialization_failure_releases_tick_guard(self, manager):
+        """A stream setup error must not leave the agent marked as running."""
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient as TC
+
+        from openjarvis.server.agent_manager_routes import (
+            create_agent_manager_router,
+        )
+
+        app = FastAPI()
+        app.state.engine = MagicMock()
+        app.state.bus = None
+        for router in create_agent_manager_router(manager):
+            app.include_router(router)
+        client = TC(app, raise_server_exceptions=False)
+
+        agent = manager.create_agent(name="stream-init-error", agent_type="simple")
+        with patch(
+            "openjarvis.server.agent_manager_routes._stream_managed_agent",
+            new=AsyncMock(side_effect=RuntimeError("stream setup failed")),
+        ):
+            resp = client.post(
+                f"/v1/managed-agents/{agent['id']}/messages",
+                json={"content": "fail during setup", "stream": True},
+            )
+
+        assert resp.status_code == 500
+        assert manager.get_agent(agent["id"])["status"] == "idle"
 
 
 @pytest.mark.skipif(not HAS_FASTAPI, reason="fastapi not installed")

--- a/tests/server/test_deep_research_tools_wiring.py
+++ b/tests/server/test_deep_research_tools_wiring.py
@@ -181,6 +181,7 @@ async def test_server_deep_research_merges_and_executes_all_tool_sources(
     manager = MagicMock()
     manager.list_messages.return_value = []
     engine = _ScriptedDeepResearchEngine()
+    on_complete = MagicMock()
 
     response = await routes._stream_managed_agent(
         manager=manager,
@@ -199,11 +200,15 @@ async def test_server_deep_research_merges_and_executes_all_tool_sources(
         engine=engine,
         bus=None,
         app_state=app_state,
+        on_complete=on_complete,
     )
 
     body_parts: list[str] = []
     async for part in response.body_iterator:
         body_parts.append(part.decode() if isinstance(part, bytes) else part)
+    assert response.background is not None
+    await response.background()
+    on_complete.assert_called_once_with()
 
     expected_names = {
         _ConfiguredResearchProbe.tool_id,


### PR DESCRIPTION
## Summary

- Prevent two `stream=true` requests from starting the same managed agent at the same time.
- Streaming now acquires the existing `AgentManager` tick guard; a busy agent returns `409 Conflict`.
- The guard is released after generic and deep-research streams finish, including stream setup and engine-error paths.

## Changes by area

| Area | Change | Verification |
| --- | --- | --- |
| Runtime | Route-level streaming requests use `start_tick()` before execution and reject an already-running agent. | Deterministic two-client regression: one engine call, second response `409`. |
| Streaming cleanup | Generic SSE cleanup and deep-research background cleanup release the tick guard after response-local resources are handled. | Engine-error and setup-error regressions both leave the agent `idle`. |
| Deep research | The existing deep-research worker keeps its behavior; its `StreamingResponse` now has the same completion hook as the generic path. | Deep-research/tool wiring tests pass (`20 passed`). |
| Compatibility | Queued and immediate message paths, SSE payloads, tool resolution, and message persistence remain unchanged. | Managed-agent route suite passes (`38 passed`). |
| Tests | Added coverage for concurrent streams, setup failures, engine errors, and the deep-research completion hook. | Targeted test and lint results are listed below. |

## Test plan

- [x] `tests/server/test_agent_manager_routes.py` — `38 passed` (one existing Starlette/httpx deprecation warning)
- [x] `tests/server/test_managed_agent_streaming.py tests/server/test_managed_agent_resolved_tools.py tests/server/test_deep_research_tools_wiring.py` — `20 passed`
- [x] Ruff check — all checks passed
- [x] Ruff format check — all three files already formatted
- [x] Python compilation check — changed Python files compile successfully
- [x] `git diff --check` — no whitespace errors
- [ ] Full repository suite and hosted OS matrix — pending GitHub Actions

## Remaining validation

- This PR depends on [#933](https://github.com/open-jarvis/OpenJarvis/pull/933), which makes `end_tick()` preserve a user pause/archive while a stream is finishing. Please merge #933 first or review the two changes together.
- [#927](https://github.com/open-jarvis/OpenJarvis/issues/927) tracks the separate check-then-update race inside `start_tick()` itself. This PR closes the streaming route's bypass of that guard; it does not claim to make `start_tick()` atomic.
- The local targeted environment covered the behavior above. The full repository suite, Windows/macOS hosted runs, and any live model/provider validation are left to PR CI.

## Compatibility / Not changed

- Non-streaming queued and immediate message handling is unchanged.
- The SSE event format, tool resolution, deep-research worker, and existing user-message persistence are unchanged.
- No database schema, server API contract, or dependency changes are included.
- The only new lifecycle action is releasing the stream's own tick guard after cleanup.
