### PR TITLE
fix(cli): wire router policy into jarvis ask (fixes #943)

### DIFF
--- a/src/openjarvis/cli/ask.py
+++ b/src/openjarvis/cli/ask.py
@@ -769,6 +769,15 @@ def _print_profile(
         "(overrides config). Pass 'none' to disable all persona files."
     ),
 )
+@click.option(
+    "--route",
+    "--router-policy",
+    "router_policy",
+    default=None,
+    help=(
+        "Routing policy to select model (e.g. heuristic, learned). Overrides config."
+    ),
+)
 @click.pass_context
 def ask(
     ctx: click.Context,
@@ -788,6 +797,7 @@ def ask(
     persona_name: str | None,
     image_paths: tuple[str, ...] = (),
     capture_screen: bool = False,
+    router_policy: str | None = None,
 ) -> None:
     """Ask Jarvis a question."""
     quiet = (ctx.obj or {}).get("quiet", False) or output_json
@@ -957,9 +967,65 @@ def ask(
     for ek, model_ids in all_models.items():
         merge_discovered_models(ek, model_ids)
 
-    # Resolve model via config fallback chain
+    # Resolve model via learning router policy or config fallback chain
     if model_name is None:
-        model_name = config.intelligence.default_model
+        effective_router_policy = router_policy
+        if not effective_router_policy and getattr(config.learning, "enabled", False):
+            effective_router_policy = getattr(config.learning.routing, "policy", "")
+
+        if effective_router_policy:
+            try:
+                from openjarvis.core.registry import RouterPolicyRegistry
+                from openjarvis.learning import ensure_registered
+                from openjarvis.learning.routing.router import build_routing_context
+
+                ensure_registered()
+                engine_models = all_models.get(engine_name, [])
+                candidates = list(
+                    dict.fromkeys(
+                        [
+                            m
+                            for m in [
+                                config.intelligence.default_model,
+                                *engine_models,
+                                config.intelligence.fallback_model,
+                            ]
+                            if m
+                        ]
+                    )
+                )
+                if candidates and RouterPolicyRegistry.contains(
+                    effective_router_policy
+                ):
+                    policy = RouterPolicyRegistry.create(
+                        effective_router_policy,
+                        available_models=candidates,
+                        default_model=config.intelligence.default_model
+                        or candidates[0],
+                        fallback_model=config.intelligence.fallback_model
+                        or candidates[0],
+                    )
+                    ctx = build_routing_context(
+                        query_text,
+                        model=config.intelligence.default_model,
+                    )
+                    selected = policy.select_model(ctx)
+                    if selected:
+                        logger.info(
+                            "Router (%s) selected model %s for query",
+                            effective_router_policy,
+                            selected,
+                        )
+                        model_name = selected
+            except Exception as exc:
+                logger.debug(
+                    "Failed to route model via %s: %s",
+                    effective_router_policy,
+                    exc,
+                )
+
+        if model_name is None:
+            model_name = config.intelligence.default_model
     if not model_name:
         # Try first available from engine
         engine_models = all_models.get(engine_name, [])

--- a/tests/cli/test_ask_router.py
+++ b/tests/cli/test_ask_router.py
@@ -151,3 +151,151 @@ class TestAskModelResolution:
             result = CliRunner().invoke(cli, ["ask", "Hello"])
         assert result.exit_code == 0, result.output
         assert engine.generate.call_args.kwargs["model"] == "fallback-model"
+
+    def test_router_selects_code_model_for_code_query(self) -> None:
+        """When routing is enabled, a code query routes to coder model."""
+        engine = _mock_engine()
+        patches = _patch_engine(engine)
+        models = ["llama3.2:3b", "qwen2.5-coder:7b"]
+        with (
+            patches[0],
+            patches[1],
+            mock.patch.object(
+                _ask_mod,
+                "discover_models",
+                return_value={"mock": models},
+            ),
+            patches[3],
+            patches[4],
+            patches[5],
+            mock.patch.object(
+                _ask_mod,
+                "load_config",
+                return_value=JarvisConfig(),
+            ) as mock_config,
+        ):
+            cfg = mock_config.return_value
+            cfg.telemetry.enabled = False
+            cfg.learning.enabled = True
+            cfg.learning.routing.policy = "heuristic"
+            cfg.intelligence.default_model = "llama3.2:3b"
+            cfg.agent.default_agent = ""
+            result = CliRunner().invoke(
+                cli,
+                ["ask", "Write a Python function to parse JSON: def parse(): pass"],
+            )
+        assert result.exit_code == 0, result.output
+        assert engine.generate.call_args.kwargs["model"] == "qwen2.5-coder:7b"
+
+    def test_router_selects_small_model_for_simple_query(self) -> None:
+        """When routing is enabled, a low complexity query routes to smallest model."""
+        from openjarvis.intelligence.model_catalog import register_builtin_models
+
+        register_builtin_models()
+        engine = _mock_engine()
+        patches = _patch_engine(engine)
+        models = ["llama3.2:3b", "qwen2.5-coder:7b"]
+        with (
+            patches[0],
+            patches[1],
+            mock.patch.object(
+                _ask_mod,
+                "discover_models",
+                return_value={"mock": models},
+            ),
+            patches[3],
+            patches[4],
+            patches[5],
+            mock.patch.object(
+                _ask_mod,
+                "load_config",
+                return_value=JarvisConfig(),
+            ) as mock_config,
+        ):
+            cfg = mock_config.return_value
+            cfg.telemetry.enabled = False
+            cfg.learning.enabled = True
+            cfg.learning.routing.policy = "heuristic"
+            cfg.intelligence.default_model = "qwen2.5-coder:7b"
+            cfg.agent.default_agent = ""
+            result = CliRunner().invoke(cli, ["ask", "hi"])
+        assert result.exit_code == 0, result.output
+        assert engine.generate.call_args.kwargs["model"] == "llama3.2:3b"
+
+    def test_cli_route_flag_overrides_config(self) -> None:
+        """The --route flag enables router even when learning is disabled in config."""
+        engine = _mock_engine()
+        patches = _patch_engine(engine)
+        models = ["llama3.2:3b", "qwen2.5-coder:7b"]
+        with (
+            patches[0],
+            patches[1],
+            mock.patch.object(
+                _ask_mod,
+                "discover_models",
+                return_value={"mock": models},
+            ),
+            patches[3],
+            patches[4],
+            patches[5],
+            mock.patch.object(
+                _ask_mod,
+                "load_config",
+                return_value=JarvisConfig(),
+            ) as mock_config,
+        ):
+            cfg = mock_config.return_value
+            cfg.telemetry.enabled = False
+            cfg.learning.enabled = False
+            cfg.intelligence.default_model = "llama3.2:3b"
+            cfg.agent.default_agent = ""
+            result = CliRunner().invoke(
+                cli,
+                [
+                    "ask",
+                    "--route",
+                    "heuristic",
+                    "Write a Python function to parse JSON: def parse(): pass",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        assert engine.generate.call_args.kwargs["model"] == "qwen2.5-coder:7b"
+
+    def test_explicit_model_flag_bypasses_router(self) -> None:
+        """The -m flag overrides router policy completely."""
+        engine = _mock_engine()
+        patches = _patch_engine(engine)
+        models = ["llama3.2:3b", "qwen2.5-coder:7b"]
+        with (
+            patches[0],
+            patches[1],
+            mock.patch.object(
+                _ask_mod,
+                "discover_models",
+                return_value={"mock": models},
+            ),
+            patches[3],
+            patches[4],
+            patches[5],
+            mock.patch.object(
+                _ask_mod,
+                "load_config",
+                return_value=JarvisConfig(),
+            ) as mock_config,
+        ):
+            cfg = mock_config.return_value
+            cfg.telemetry.enabled = False
+            cfg.learning.enabled = True
+            cfg.learning.routing.policy = "heuristic"
+            cfg.agent.default_agent = ""
+            result = CliRunner().invoke(
+                cli,
+                [
+                    "ask",
+                    "-m",
+                    "forced-model",
+                    "Write a Python function: def parse(): pass",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        assert engine.generate.call_args.kwargs["model"] == "forced-model"


### PR DESCRIPTION
## Summary

Fixes #943. `jarvis ask` computes query complexity via `score_complexity()` but previously only used the score for token budgeting (`max_tokens`). Model selection always fell back to `config.intelligence.default_model` without ever invoking `RouterPolicyRegistry` or `policy.select_model()`.

## What changed in `src/openjarvis/cli/ask.py`

1. **CLI Route Option**: Added `@click.option("--route", "--router-policy", "router_policy", default=None, ...)` to `jarvis ask` allowing explicit policy selection at the CLI.
2. **Wire Router Policy**: In model resolution, when `model_name` is not explicitly passed (`-m` / `--model`), check for configured router policy (`--route` flag or `[learning] enabled = true` with `[learning.routing] policy`).
3. **Pool Engine Candidates**: Collect candidate models available on the active engine.
4. **Invoke Policy**: Create router policy from `RouterPolicyRegistry`, evaluate `build_routing_context(query_text)`, and set `model_name` if a suitable candidate is selected.
5. **Preserve Fallbacks**: If routing is not enabled, fails, or returns nothing, seamlessly falls back to the existing default chain (`default_model` -> engine model -> `fallback_model`).

## Test plan

- [x] Added `test_router_selects_code_model_for_code_query`: Verifies code query routes to coder model when routing is enabled.
- [x] Added `test_router_selects_small_model_for_simple_query`: Verifies low complexity query routes to smallest model.
- [x] Added `test_cli_route_flag_overrides_config`: Verifies `--route heuristic` triggers routing even if config has learning disabled.
- [x] Added `test_explicit_model_flag_bypasses_router`: Verifies `-m` / `--model` overrides router policy.
- [x] All 8/8 tests in `tests/cli/test_ask_router.py` pass.
- [x] `uv run ruff check` and `uv run ruff format --check` pass on changed files.
