### PR TITLE
fix(ci): publish pre-release builds to TestPyPI, not PyPI

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -78,6 +78,7 @@ jobs:
           }
 
       - name: Resolve build version from tag
+        id: version
         env:
           REF: ${{ steps.ref.outputs.ref }}
         run: |
@@ -93,6 +94,20 @@ jobs:
           # `.devN` tags, so we pin the exact build version explicitly — the
           # published version always equals the pushed tag.
           echo "SETUPTOOLS_SCM_PRETEND_VERSION=${VERSION}" >> "$GITHUB_ENV"
+          # Only a plain vX.Y.Z (or vX.Y.Z.postN) tag may publish to production
+          # PyPI. autotag.yml pushes a vX.Y.Z.devN tag for every merge to main,
+          # and every upload permanently consumes PyPI project storage: roughly
+          # 90 dev releases a month exhausted the project's 10 GB limit, after
+          # which each upload hard-failed with "400 Project size too large"
+          # (#955). Pre-release builds go to TestPyPI instead, so main stays
+          # continuously publishable without spending production quota.
+          if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(\.post[0-9]+)?$ ]]; then
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+            echo "Target index: PyPI (final release)"
+          else
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+            echo "Target index: TestPyPI (pre-release)"
+          fi
           echo "Building version ${VERSION}"
 
       - name: Build package
@@ -128,8 +143,8 @@ jobs:
           PY
           uvx twine check --strict dist/*
 
-      - name: Publish to TestPyPI (dry run)
-        if: ${{ inputs.dry_run }}
+      - name: Publish to TestPyPI (pre-releases and dry runs)
+        if: ${{ inputs.dry_run || steps.version.outputs.prerelease == 'true' }}
         env:
           UV_PUBLISH_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
         run: |
@@ -143,5 +158,5 @@ jobs:
           uv publish --publish-url https://test.pypi.org/legacy/
 
       - name: Publish to PyPI
-        if: ${{ !inputs.dry_run }}
+        if: ${{ !inputs.dry_run && steps.version.outputs.prerelease == 'false' }}
         run: uv publish


### PR DESCRIPTION
## What does this PR do?

Stops `autotag` dev builds from consuming production PyPI storage, which is what is currently breaking `Publish to PyPI`. Refs #955.

`autotag.yml` pushes a `vX.Y.Z.devN` tag on every merge to `main` and dispatches `pypi-publish.yml`, which uploaded each one to production PyPI. Every upload permanently consumes project storage, so roughly 90 dev releases a month exhausted the 10 GB project limit:

| Kind | Releases | Size |
| --- | --- | --- |
| `.devN` autotag builds | 256 | 9.837 GiB (98.4%) |
| Real releases | 5 | 0.161 GiB (1.6%) |
| **Total** | **261** | **9.998 GiB of a 10 GiB cap** |

With about 1.89 MiB of headroom left, every upload now hard-fails:

```
400 Project size too large. Limit for project 'OpenJarvis' total size is 10 GB.
```

This has been failing partially since 2026-08-31: `1.0.4.dev1067`, `1.0.4.dev1071` and `1.0.4.dev1074` through `1.0.4.dev1085` are on PyPI with a wheel but **no sdist**, because the 2 MiB wheel still fit in the remaining quota while the 16 MiB sdist did not.

### The change

Classify the resolved version, then route the upload:

- A plain `vX.Y.Z` (or `vX.Y.Z.postN`) tag publishes to **production PyPI**, as before.
- Anything else (`.devN`, `rc`, `a`/`b`) publishes to **TestPyPI**, reusing the path that already existed behind the `dry_run` input.

Dev builds stay installable and `main` stays continuously publishable, without spending production quota. `dry_run` behaviour is unchanged.

18 insertions, 3 deletions, one file.

### What this PR cannot do

It does not reclaim the ~9.8 GB already consumed. That needs a PyPI owner to delete old dev releases at https://pypi.org/manage/project/openjarvis/releases/. Per [PyPI's storage docs](https://docs.pypi.org/project-management/storage-limits), **deleting frees space but yanking does not**.

So: merging this makes the failing workflow green again, because dev builds stop touching PyPI. The manual cleanup is still required before the next real `v1.0.4` release can publish. Details and the wider context are in #955.

## How was this tested?

No Python code changed, so the repo's pytest/ruff suites are not exercised by this diff. I validated the workflow itself instead:

**1. `actionlint` 1.7.12 passes on the modified workflow.**

```
$ actionlint .github/workflows/pypi-publish.yml
$ echo $?
0
```

With a negative control to confirm the linter actually analyses this file rather than skipping it (I temporarily pointed the condition at a non-existent step id):

```
pypi-publish.yml:161:36: property "nosuchstep" is not defined in object type
{ref: {...}; version: {...}} [expression]
```

Note that the error output confirms `version` is a defined step id, which is the reference the new conditions rely on.

**2. The classification logic was extracted from the YAML and executed against a version matrix.**

Every case ran the real `run:` block from the workflow with a stubbed `GITHUB_OUTPUT`/`GITHUB_ENV`:

| Tag | `prerelease` | Target index |
| --- | --- | --- |
| `v1.0.4.dev1107` | `true` | TestPyPI |
| `v1.0.4.dev1105` | `true` | TestPyPI |
| `v1.0.4.dev0` | `true` | TestPyPI |
| `v1.0.4rc1` | `true` | TestPyPI |
| `v1.0.4b1` | `true` | TestPyPI |
| `v1.0.3` | `false` | PyPI |
| `v1.0.4` | `false` | PyPI |
| `v2.10.33` | `false` | PyPI |
| `v1.0.4.post1` | `false` | PyPI |
| `main` | rejected, exit 1 | none |

10/10 passed, including the existing guard that a non-version ref is still rejected. `SETUPTOOLS_SCM_PRETEND_VERSION` was verified to still equal the tag minus the leading `v` in every accepted case.

## Checklist

- [x] Tests pass (`uv run pytest tests/ -v`) — n/a, no Python changed; validated with `actionlint` plus the execution matrix above
- [x] Linter passes (`uv run ruff check src/ tests/`) — n/a, no Python changed
- [x] Formatter passes (`uv run ruff format --check src/ tests/`) — n/a, no Python changed
- [x] New/changed public API has docstrings — n/a
- [x] Follows registry pattern (if adding new component) — n/a
- [x] Documentation updated (if applicable) — the rationale is captured in a comment in the workflow itself

---

Happy to adjust the policy if you would rather dev builds publish nowhere at all (build and validate only) instead of going to TestPyPI. That is a one-line change to the same condition.
