### PR TITLE
ci: pin third-party actions to SHAs and set least-privilege perms

### DIFF
--- a/.github/workflows/bash-tests.yml
+++ b/.github/workflows/bash-tests.yml
@@ -12,6 +12,12 @@ on:
       - 'scripts/install/**'
       - 'tests/install/bash/**'
 
+# Least-privilege default: every job here only reads the repository.
+# Without this block the workflow inherits the repository default, which
+# may be read/write.
+permissions:
+  contents: read
+
 jobs:
   bats:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,12 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+# Least-privilege default: every job here only reads the repository.
+# Without this block the workflow inherits the repository default, which
+# may be read/write.
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -22,7 +28,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v10.0.1
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           enable-cache: true
 
@@ -46,7 +52,9 @@ jobs:
           python-version: "3.12"
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
+        with:
+          toolchain: stable
 
       - name: Cargo cache
         uses: actions/cache@v6
@@ -59,7 +67,7 @@ jobs:
           restore-keys: rust-${{ runner.os }}-
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v10.0.1
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           enable-cache: true
 
@@ -118,7 +126,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v10.0.1
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           enable-cache: true
 
@@ -138,7 +146,9 @@ jobs:
           uv run pytest tests/hardware/test_hardware_profiles.py tests/cli/test_cli.py -v -m "not live and not cloud"
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
+        with:
+          toolchain: stable
 
       - name: Build + import the PyO3 extension on Windows
         shell: bash
@@ -160,8 +170,9 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
         with:
+          toolchain: stable
           components: clippy
 
       - name: Cargo cache

--- a/.github/workflows/claude-issues.yml
+++ b/.github/workflows/claude-issues.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@d75b94d5ad426cb8546e6628b6f5f19b84e5cce1 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -51,7 +51,7 @@ jobs:
           cat REVIEW.md >> "$GITHUB_OUTPUT"
           echo "$EOF" >> "$GITHUB_OUTPUT"
 
-      - uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@d75b94d5ad426cb8546e6628b6f5f19b84e5cce1 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -60,10 +60,12 @@ jobs:
         run: npx tsc --noEmit
 
       - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
+        with:
+          toolchain: stable
 
       - name: Rust cache
-        uses: swatinem/rust-cache@v2
+        uses: swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           workspaces: 'frontend/src-tauri -> target'
 
@@ -236,12 +238,13 @@ jobs:
             libdbus-1-dev
 
       - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
         with:
+          toolchain: stable
           targets: ${{ matrix.platform == 'macos-14' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
       - name: Rust cache
-        uses: swatinem/rust-cache@v2
+        uses: swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           workspaces: 'frontend/src-tauri -> target'
 
@@ -352,7 +355,7 @@ jobs:
 
       - name: Build and release
         timeout-minutes: 120
-        uses: tauri-apps/tauri-action@v1
+        uses: tauri-apps/tauri-action@1deb371b0cd8bd54025b384f1cd735e725c4060f # v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,7 +36,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v10.0.1
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
 
       - name: Install dependencies
         run: uv sync --extra docs

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -17,6 +17,12 @@ concurrency:
   group: frontend-${{ github.ref }}
   cancel-in-progress: true
 
+# Least-privilege default: every job here only reads the repository.
+# Without this block the workflow inherits the repository default, which
+# may be read/write.
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/installer-integration.yml
+++ b/.github/workflows/installer-integration.yml
@@ -10,6 +10,12 @@ on:
   schedule:
     - cron: '0 6 * * *'
 
+# Least-privilege default: every job here only reads the repository.
+# Without this block the workflow inherits the repository default, which
+# may be read/write.
+permissions:
+  contents: read
+
 jobs:
   container-matrix:
     name: ${{ matrix.image }}

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -45,7 +45,7 @@ jobs:
           ref: ${{ steps.ref.outputs.ref }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v10.0.1
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v7

--- a/.github/workflows/track-clones.yml
+++ b/.github/workflows/track-clones.yml
@@ -14,8 +14,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
-        with:
-          token: ${{ secrets.TRAFFIC_TOKEN }}
 
       - name: Fetch clone traffic
         env:


### PR DESCRIPTION
# Overview
Supply Chain attacks are how local mahcines are being attcked, so im stepping in . I love this repo and what it has done for the community ❤️ 

## What does this PR do?
Supply-chain hardening for `.github/workflows/`. Three independent changes, 10 files, +47/-17.

### 1. Pin every third-party action to a commit SHA (15 references, 5 actions) does this solve every CI attack? no, but it shrinks the surface. 

| Action | Was | Now |
| --- | --- | --- |
| `dtolnay/rust-toolchain` | `@stable` (**branch**) | `@6bed0761...` |
| `swatinem/rust-cache` | `@v2` | `@6323deb1...` |
| `tauri-apps/tauri-action` | `@v1` | `@1deb371b...` |
| `anthropics/claude-code-action` | `@v1` | `@d75b94d5...` |
| `astral-sh/setup-uv` | `@v10.0.1` | `@20cfd1bf...` |

Tags and branches are mutable: whoever controls the upstream repository can repoint them at any commit, and that code then runs inside jobs that hold this repository's secrets. Moving a tag is how the `tj-actions/changed-files` compromise (March 2025) reached its downstreams. Pinning to an immutable SHA removes that path; Dependabot still proposes updates, they just become reviewable commits.

`dtolnay/rust-toolchain@stable` is worth calling out because `stable` is a **branch**, not a tag:

```
GET /repos/dtolnay/rust-toolchain/git/ref/heads/stable
{"ref":"refs/heads/stable","sha":"6bed0761...","type":"commit"}
```

**Every SHA here is the exact commit its previous ref resolved to when this PR was written**, resolved through the GitHub API rather than transcribed by hand. The same action code runs before and after this change, so it is a behavioural no-op by construction.

### 2. Keep `dtolnay/rust-toolchain` behaviour intact

That action selects the toolchain by *branch name* (`@stable`, `@nightly`, `@1.75.0` are different branches, each with a different default in its own `action.yml`). Pinning to a SHA drops that signal, so all 5 call sites now pass an explicit `toolchain: stable`.

To be clear about what this does and does not freeze: it pins the **action**, not the Rust release. `rustup` still resolves `stable` at run time, so Rust keeps updating exactly as it does today.

### 3. Least-privilege `permissions` on four workflows

`ci.yml`, `bash-tests.yml`, `frontend.yml` and `installer-integration.yml` had no top-level `permissions:` block, so they inherited the repository default, which may be read/write. All four are read-only test workflows. Each now declares:

```yaml
permissions:
  contents: read
```

`desktop.yml`, `docs.yml`, `autotag.yml`, `pypi-publish.yml`, `claude-*.yml` and `track-clones.yml` already scoped theirs and are unchanged in this respect.

### 4. Scope `TRAFFIC_TOKEN` out of `actions/checkout`

`track-clones.yml` passed `secrets.TRAFFIC_TOKEN` as the checkout token. `actions/checkout` persists its token into `.git/config` for the remainder of the job, so a long-lived PAT was readable by every later step when only the `gh api .../traffic/clones` call needs it. Checkout now uses the default `GITHUB_TOKEN`.

The later `git push` still works: this workflow already declares `contents: write`, and `persist-credentials` is left at its default so the push keeps its credentials. I chose this over `persist-credentials: false`, which would have broken that push.

### Deliberately not included

- **First-party `actions/*` are still on tags** (29 references). Pinning those is a larger mechanical change and a separate judgement call; happy to follow up if you want it.
- One further hardening item in `desktop.yml` is **not** in this PR because I cannot test it without your macOS signing secrets, and getting release signing wrong is worse than the finding. It has been reported separately through your private vulnerability reporting.

## How was this tested?

No Python, Rust or frontend source is touched, so `pytest` / `ruff` prove nothing about this diff. I verified the workflows themselves instead, in four layers.

### 1. `actionlint` 1.7.12: clean across all 12 workflows

```
$ actionlint .github/workflows/*.yml
$ echo $?
0
```

Confirmed the linter actually analyses these files rather than skipping them, using a negative control (a condition temporarily pointed at a non-existent step id):

```
pypi-publish.yml:161:36: property "nosuchstep" is not defined in object type
{ref: {...}; version: {...}} [expression]
```

### 2. `zizmor` differential: 90 -> 65 findings, no new rule classes

| Rule | Before | After | Delta |
| --- | ---: | ---: | ---: |
| `unpinned-uses` | 44 | 29 | **-15** |
| `excessive-permissions` (Medium) | 10 | 0 | **-10** |
| all other rules | 36 | 36 | 0 |

The `-15` and `-10` match the change exactly: 15 pinned references and 4 workflows given a `permissions` block. Nothing else moved, and no new rule class appeared. The remaining 29 `unpinned-uses` are the first-party `actions/*` left out on purpose.

### 3. Differential CI on a fork

Static checks cannot prove `contents: read` is sufficient, so both states were run against the same base commit on a fork:

- Baseline, empty commit, no changes: https://github.com/OpenSource-For-Freedom/OpenJarvis/pull/1 - **CI passed**
- This change: https://github.com/OpenSource-For-Freedom/OpenJarvis/pull/2

Running both means any difference is attributable to this diff rather than to fork environment differences (the fork holds no secrets).

Two properties made this a fair test:

- The four workflows gaining a `permissions` block each list their own path in their `pull_request` trigger filter, so **editing them triggers them**. The change tests itself.
- The fork's default workflow token is already read-only (`{"default_workflow_permissions":"read"}`), so a green run there is direct evidence that `contents: read` suffices for these jobs.

| Workflow | Result | What it exercises |
| --- | --- | --- |
| Frontend CI | **pass** (35s) | `permissions` block, pinned `setup-uv` + `setup-node` |
| Bash tests | **pass** (25s) | `permissions` block |
| Installer integration | **pass** | `permissions` block, macOS matrix |
| CI | still running when this was opened | pinned `dtolnay/rust-toolchain` + `toolchain: stable`, `permissions` |
| Desktop Build & Release (`validate`) | still running when this was opened | pinned `dtolnay` + `swatinem` |

The baseline run of `CI` passed, so that job is known-good at this base commit; the matching run on this change was still in flight when this PR was opened. I will comment with the outcome either way rather than leave it implied, and this repository's own CI will re-run everything on approval regardless.

### 4. Honest gap

`track-clones.yml` is the one change I could not execute end-to-end: it needs `TRAFFIC_TOKEN` and runs on a schedule, neither of which is reproducible on a fork. The reasoning is in section 4 above, and the failure mode is a visibly failing scheduled job rather than a silent one. Please give that hunk a closer read than the rest.

## Checklist

- [x] Tests pass (`uv run pytest tests/ -v`) - n/a, no Python changed; verified with `actionlint`, `zizmor` and the fork CI runs above
- [x] Linter passes (`uv run ruff check src/ tests/`) - n/a, no Python changed
- [x] Formatter passes (`uv run ruff format --check src/ tests/`) - n/a, no Python changed
- [x] New/changed public API has docstrings - n/a
- [x] Follows registry pattern (if adding new component) - n/a
- [x] Documentation updated (if applicable) - rationale is captured in comments in the workflows themselves
