### PR TITLE
fix(routing): rank unknown cloud models for escalation

### DIFF
--- a/docs/architecture/learning.md
+++ b/docs/architecture/learning.md
@@ -120,6 +120,9 @@ The `HeuristicRouter` is the default routing policy. It is defined in `learning/
 !!! note "Priority 5 overrides all others"
     The urgency check (rule 5) is evaluated **first** in the code — if urgency exceeds 0.8, the router immediately returns the smallest model regardless of query content.
 
+!!! note "Models without public parameter counts"
+    Cloud catalog entries use `parameter_count_b = 0.0` because providers do not publish those figures. When a largest-model rule fires, an explicitly cloud-backed model is treated as a separate high-capability tier so it can beat a known local model; an unknown non-cloud model is not assumed to be large.
+
 ### Usage
 
 ```python

--- a/src/openjarvis/learning/routing/router.py
+++ b/src/openjarvis/learning/routing/router.py
@@ -51,6 +51,27 @@ def _model_size(key: str) -> float:
         return 0.0
 
 
+def _model_rank(key: str) -> tuple[int, float]:
+    """Return the capability rank used when selecting the largest model.
+
+    A positive parameter count is the strongest signal for local models. Cloud
+    providers do not publish parameter counts, so their catalog entries use
+    ``0.0``; an explicitly cloud-backed model gets a separate higher tier
+    instead of being treated as smaller than every known local model. Models
+    with unknown non-cloud metadata remain at the lowest tier.
+    """
+    try:
+        spec = ModelRegistry.get(key)
+        size = spec.parameter_count_b
+        if size > 0:
+            return (1, size)
+        if "cloud" in spec.supported_engines:
+            return (2, 0.0)
+    except (KeyError, AttributeError, TypeError) as exc:
+        logger.debug("Failed to compute model capability rank: %s", exc)
+    return (0, 0.0)
+
+
 def _find_model_by_tag(available: List[str], tag: str) -> Optional[str]:
     """Find the first available model whose key contains *tag* (case-insensitive)."""
     tag_lower = tag.lower()
@@ -61,16 +82,16 @@ def _find_model_by_tag(available: List[str], tag: str) -> Optional[str]:
 
 
 def _largest_model(available: List[str]) -> Optional[str]:
-    """Return the model with the largest parameter count from the available list."""
+    """Return the most capable model from the available list."""
     if not available:
         return None
     best = available[0]
-    best_size = _model_size(best)
+    best_rank = _model_rank(best)
     for key in available[1:]:
-        size = _model_size(key)
-        if size > best_size:
+        rank = _model_rank(key)
+        if rank > best_rank:
             best = key
-            best_size = size
+            best_rank = rank
     return best
 
 

--- a/tests/learning/test_router.py
+++ b/tests/learning/test_router.py
@@ -93,6 +93,28 @@ class TestHeuristicRouter:
         assert ctx.complexity_score > 0.20
         assert router.select_model(ctx) == "large"
 
+    def test_unknown_local_model_does_not_beat_known_local_model(self) -> None:
+        _register_models()
+        ModelRegistry.register_value(
+            "unknown-local",
+            ModelSpec(
+                model_id="unknown-local",
+                name="Unknown local model",
+                parameter_count_b=0.0,
+                context_length=4096,
+                supported_engines=("ollama",),
+            ),
+        )
+        router = HeuristicRouter(available_models=["small", "unknown-local"])
+        ctx = RoutingContext(
+            query="solve this carefully",
+            query_length=20,
+            has_math=True,
+            complexity_score=0.4,
+        )
+
+        assert router.select_model(ctx) == "small"
+
     def test_low_complexity_math_prefers_small(self) -> None:
         """Regression test: a trivial math query ("calculate 2+2") must not
         escalate to the largest model just because it contains a math

--- a/tests/learning/test_routing_models.py
+++ b/tests/learning/test_routing_models.py
@@ -83,6 +83,18 @@ class TestRouterWithNewModels:
         selected = router.select_model(ctx)
         assert selected == "gpt-oss:120b"
 
+    def test_unknown_cloud_model_escalates_over_known_local(self) -> None:
+        _setup_models()
+        router = HeuristicRouter(available_models=["qwen3:8b", "gpt-5-mini"])
+        ctx = RoutingContext(
+            query="prove this carefully",
+            query_length=20,
+            has_math=True,
+            complexity_score=0.4,
+        )
+
+        assert router.select_model(ctx) == "gpt-5-mini"
+
     def test_high_complexity_routes_to_largest(self) -> None:
         _setup_models()
         router = HeuristicRouter(


### PR DESCRIPTION
Fixes #942

## Summary

- `HeuristicRouter` now lets explicitly cloud-backed models win largest-model escalation even when their providers do not publish parameter counts (`parameter_count_b=0.0`).
- Known positive parameter counts are still compared numerically.
- Unknown non-cloud models remain unranked instead of being guessed as large.

## Changes by area

| Area | Change | Verification |
| --- | --- | --- |
| Runtime | Added a separate capability tier for unknown cloud models in `_largest_model`; the existing smallest-model path is unchanged. | Mixed local/cloud reproduction now selects `gpt-5-mini` for a math query. |
| Tests | Added regression coverage for the real built-in cloud metadata and for unknown local models. | Focused routing and catalog tests: `42 passed`; broader Learning + Intelligence scope: `140 passed`; CI Python suite: `8593 passed, 62 skipped`. |
| Docs | Documented how unknown cloud and non-cloud model metadata is handled. | `git diff --check`; Ruff format check passes. |
| Compatibility | Kept existing positive parameter-count ordering, fallback behavior, and public `ModelSpec` shape unchanged. | Full Ruff check passes; existing routing tests remain green. |

## Test plan

- [x] `PYTHONPATH=src python -m pytest tests/learning/test_router.py tests/learning/test_routing_models.py tests/intelligence/test_router.py tests/intelligence/test_routing_models.py -q` — 42 passed
- [x] `PYTHONPATH=src python -m pytest tests/learning/routing tests/learning/test_router.py tests/learning/test_routing_models.py tests/intelligence -q` — 140 passed
- [x] `ruff check src/ tests/` — All checks passed
- [x] `ruff format --check src/ tests/` — 1383 files already formatted
- [x] `git diff --check`
- [x] GitHub Actions Python `test` — `uv run pytest tests/ -n auto -q --tb=short -m "not live and not cloud and not hub"`: `8593 passed, 62 skipped`, coverage `65.96%`
- [x] GitHub Actions Windows 3.12 — `30 passed, 2 skipped`
- [x] GitHub Actions Windows 3.13 — `30 passed, 2 skipped`
- [x] GitHub Actions `lint`, `build` (including MkDocs), and `rust` — passed

## Remaining validation

No required automated validation remains: the focused local tests and the repository's Linux, Windows, lint, documentation, and Rust CI jobs are green. The separate Windows test environment was unavailable during this turn, but the hosted Windows matrix passed on both supported Python versions. The Mac fallback virtualenv could not collect the full suite because project dependencies were not installed; that local setup limitation is not used as test evidence.

## Compatibility / Not changed

- Existing positive `parameter_count_b` ordering is unchanged.
- Unknown non-cloud discovered models still do not outrank known local models.
- No new dependencies, public fields, engine APIs, or CLI behavior were added.
- This PR fixes only the ranking leg; the separate CLI wiring work in #943 remains independent.
- PR scope is limited to the routing implementation, its regression tests, and the architecture note.