### PR TITLE
fix(security): reject symlinks in imported skills

### DIFF
--- a/src/openjarvis/skills/importer.py
+++ b/src/openjarvis/skills/importer.py
@@ -3,14 +3,15 @@
 Steps performed by ``import_skill``:
 
 1. Parse the source SKILL.md through SkillParser (strict + tolerant).
-2. Translate tool references in the markdown body via ToolTranslator.
-3. Decide on scripts (default-skip; opt-in via with_scripts=True).
-4. Write to disk at <target_root>/<source>/<name>/:
+2. Reject symlinks in directories that would be copied into the install.
+3. Translate tool references in the markdown body via ToolTranslator.
+4. Decide on scripts (default-skip; opt-in via with_scripts=True).
+5. Write to disk at <target_root>/<source>/<name>/:
    - translated SKILL.md
    - references/, assets/, templates/ (always copied)
    - scripts/ (only if approved)
    - .source metadata file
-5. Return ImportResult with status, warnings, translated/missing tools.
+6. Return ImportResult with status, warnings, translated/missing tools.
 """
 
 from __future__ import annotations
@@ -143,7 +144,29 @@ class SkillImporter:
                 "and/or write to the filesystem."
             )
 
-        # 2. Translate tool references
+        # 2. Validate copied resources and translate tool references
+        copied_subdirs = list(COPIED_SUBDIRS)
+        if with_scripts:
+            copied_subdirs.append("scripts")
+        symlinks = [
+            link
+            for subdir in copied_subdirs
+            for link in self._find_symlinks(resolved.path / subdir)
+        ]
+        if symlinks:
+            names = ", ".join(
+                str(link.relative_to(resolved.path)) for link in symlinks[:3]
+            )
+            if len(symlinks) > 3:
+                names += f", and {len(symlinks) - 3} more"
+            result.success = False
+            result.warnings.append(
+                "Refusing to install: skill contains symlinked entries in "
+                f"copied directories ({names}). Imported skills must not "
+                "read files outside their source package."
+            )
+            return result
+
         translated_body, untranslated = self._translator.translate_markdown(body)
         result.untranslated_tools = untranslated
         # Compute the list of translations actually applied
@@ -186,6 +209,15 @@ class SkillImporter:
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
+
+    @staticmethod
+    def _find_symlinks(root: Path) -> list[Path]:
+        """Return symlinks below *root* without following them."""
+        if not root.exists() and not root.is_symlink():
+            return []
+        if root.is_symlink():
+            return [root]
+        return [path for path in root.rglob("*") if path.is_symlink()]
 
     def _read_skill_md(self, path: Path) -> tuple[dict, str]:
         """Parse a SKILL.md file into (frontmatter dict, markdown body)."""

--- a/tests/skills/test_importer.py
+++ b/tests/skills/test_importer.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from openjarvis.skills.importer import SkillImporter
 from openjarvis.skills.parser import SkillParser
 from openjarvis.skills.sources.base import ResolvedSkill
@@ -164,6 +166,53 @@ class TestImportSkill:
         target = target_root / "hermes" / "my-skill"
         assert (target / "references" / "REFERENCE.md").exists()
         assert (target / "assets" / "template.txt").exists()
+
+    @pytest.mark.parametrize(
+        ("subdir", "with_scripts"),
+        [("references", False), ("scripts", True)],
+    )
+    def test_rejects_symlinks_before_copying_external_targets(
+        self, tmp_path: Path, subdir: str, with_scripts: bool
+    ):
+        target_root = tmp_path / "skills"
+        src_dir = tmp_path / "source" / "my-skill"
+        src_dir.mkdir(parents=True)
+        (src_dir / "SKILL.md").write_text(
+            "---\nname: my-skill\ndescription: A test skill\n---\n"
+        )
+
+        outside = tmp_path / "outside.txt"
+        outside.write_text("SENSITIVE-SENTINEL")
+        copied_root = src_dir / subdir
+        copied_root.mkdir()
+        try:
+            (copied_root / "linked.txt").symlink_to(outside)
+        except OSError:
+            pytest.skip("filesystem does not permit creating symlinks")
+
+        resolved = ResolvedSkill(
+            name="my-skill",
+            source="hermes",
+            path=src_dir,
+            category="x",
+            description="A test skill",
+            commit="a",
+        )
+        importer = SkillImporter(
+            parser=SkillParser(),
+            tool_translator=ToolTranslator(),
+            target_root=target_root,
+        )
+        target = target_root / "hermes" / "my-skill"
+        target.mkdir(parents=True)
+        (target / "keep.txt").write_text("existing install")
+
+        result = importer.import_skill(resolved, with_scripts=with_scripts, force=True)
+
+        assert not result.success
+        assert any("symlink" in warning.lower() for warning in result.warnings)
+        assert (target / "keep.txt").read_text() == "existing install"
+        assert not (target / subdir / "linked.txt").exists()
 
     def test_force_overwrites_existing_install(self, tmp_path: Path):
         target_root = tmp_path / "skills"


### PR DESCRIPTION
Fixes #960

## Summary

- Prevent imported skills from reading files outside their source package through filesystem symlinks.
- Scan every directory that would be copied before writing the destination; opt-in `scripts/` is checked only when `with_scripts=True`.
- Keep regular files and directories, the default scripts skip, and existing installs unchanged.

## Changes by area

| Area | What changed | Verification |
| --- | --- | --- |
| Installer / runtime | `SkillImporter` rejects symlinked entries in `references/`, `assets/`, `templates/`, and opt-in `scripts/` before translating or deleting the destination. | The real importer smoke test rejects an external link with no destination write; the focused importer suite covers both copied resources and opt-in scripts. |
| Tests | Added a parameterized regression test for an outside-target symlink and verifies a forced import preserves the existing installation. | `tests/skills/test_importer.py` — 13 passed locally. |
| Compatibility | Regular resources still copy normally; scripts remain skipped unless explicitly requested. | Existing importer tests remain green. |

## Test plan

- [x] Focused importer tests: `tests/skills/test_importer.py` — `13 passed`
- [x] Direct importer smoke test: an external symlink is rejected before destination creation.
- [x] Ruff check on changed files.
- [x] Ruff format check on changed files.
- [x] Python compilation check for changed Python files.
- [x] `git diff --check`
- [x] GitHub Actions `test` job — repository Python test workflow passed.
- [x] GitHub Actions `test-windows (3.12)` and `test-windows (3.13)` jobs passed.
- [x] GitHub Actions `lint`, `rust`, and `build` jobs passed.
- [ ] Local full suite: `uv run pytest tests/ -v` (not run because `uv` is not installed in this checkout).

## Remaining validation

- No required GitHub CI job remains pending. The `deploy` job is skipped by workflow configuration, not a test failure.
- The exact local `uv run pytest tests/ -v` command was not run because `uv` is unavailable in this checkout; the repository test workflow completed successfully on Linux and Windows.
- On hosts where creating symlinks requires an OS privilege (for example, Windows without Developer Mode), the new symlink cases intentionally skip; the importer still fails closed whenever a symlink is present.

## Compatibility / Not changed

- Regular files and directories retain their existing import behavior.
- `scripts/` remains skipped by default; only an explicitly requested scripts directory is scanned and rejected when it contains links.
- A rejected `force=True` import leaves the previously installed skill in place.
- No new dependencies, public API changes, or server changes are introduced.
- This is the importer boundary fix described in #960; the broader install-time scanner proposal in #472 remains separate.
