### PR TITLE
feat(server): speak assistant replies in the web UI

### DIFF
--- a/frontend/src/components/Chat/ChatArea.tsx
+++ b/frontend/src/components/Chat/ChatArea.tsx
@@ -43,9 +43,18 @@ export function ChatArea() {
     useTtsStore.getState().ensureHealth();
   }, [voiceOutputEnabled]);
 
+  // Speak on the falling edge of a stream -- the moment a reply finishes -- and
+  // never merely because a finished reply happens to be on screen. Opening the
+  // app or switching conversations would otherwise read stale history aloud,
+  // and browsers block that anyway: playback with no preceding user gesture is
+  // rejected outright, so the failure would be silent in both senses.
+  const wasStreamingRef = useRef(false);
   useEffect(() => {
+    const justFinished = wasStreamingRef.current && !isCurrentChatStreaming;
+    wasStreamingRef.current = isCurrentChatStreaming;
+
+    if (!justFinished) return;
     if (!voiceOutputEnabled || !voiceAutoplay) return;
-    if (isCurrentChatStreaming) return;
 
     const last = messages[messages.length - 1];
     if (!last || last.role !== 'assistant') return;

--- a/frontend/src/components/Chat/ChatArea.tsx
+++ b/frontend/src/components/Chat/ChatArea.tsx
@@ -4,6 +4,8 @@ import { MessageBubble } from './MessageBubble';
 import { InputArea } from './InputArea';
 import { StreamingDots } from './StreamingDots';
 import { useAppStore } from '../../lib/store';
+import { useTtsStore } from '../../lib/tts';
+import { stripThinkTags } from '../../lib/message-text';
 import { Sparkles, PanelRightOpen, PanelRightClose, Database, MessageSquare, X } from 'lucide-react';
 import { listConnectors } from '../../lib/connectors-api';
 
@@ -26,6 +28,38 @@ export function ChatArea() {
   const wasStreaming = useRef(false);
   const lastScrollTop = useRef(0);
   const isCurrentChatStreaming = streamState.isStreaming && streamState.conversationId === activeId;
+
+  // Autoplay: speak a reply once it is finished, never while it streams -- a
+  // partial sentence would be synthesized and then cut off by the next chunk.
+  // autoSpokenId fences the message so re-renders cannot repeat it.
+  const voiceOutputEnabled = useAppStore((s) => s.settings.voiceOutputEnabled);
+  const voiceAutoplay = useAppStore((s) => s.settings.voiceAutoplay);
+  // Probe the backend as soon as voice output is switched on. Without this the
+  // first reply could never autoplay: `available` is only set by ensureHealth,
+  // which until now ran solely from the per-message read-aloud button -- and
+  // that button does not exist until a reply is already on screen.
+  useEffect(() => {
+    if (!voiceOutputEnabled) return;
+    useTtsStore.getState().ensureHealth();
+  }, [voiceOutputEnabled]);
+
+  useEffect(() => {
+    if (!voiceOutputEnabled || !voiceAutoplay) return;
+    if (isCurrentChatStreaming) return;
+
+    const last = messages[messages.length - 1];
+    if (!last || last.role !== 'assistant') return;
+
+    const tts = useTtsStore.getState();
+    if (tts.available !== true) return;
+    if (tts.autoSpokenId === last.id) return;
+
+    const text = stripThinkTags(last.content);
+    if (!text) return;
+
+    tts.markAutoSpoken(last.id);
+    void tts.speak(last.id, text);
+  }, [messages, isCurrentChatStreaming, voiceOutputEnabled, voiceAutoplay]);
   const currentStreamContent = isCurrentChatStreaming ? streamState.content : '';
 
   // Check if any data sources are connected

--- a/frontend/src/components/Chat/MessageBubble.tsx
+++ b/frontend/src/components/Chat/MessageBubble.tsx
@@ -11,6 +11,7 @@ import { ToolCallCard } from './ToolCallCard';
 import { ResearchTimeline } from './ResearchTimeline';
 import { rehypeCitations } from '../../lib/rehype-citations';
 import { XRayFooter } from './XRayFooter';
+import { SpeakMessageButton } from './SpeakMessageButton';
 import type { ChatMessage } from '../../types';
 
 function stripThinkTags(text: string): string {
@@ -178,9 +179,10 @@ export function MessageBubble({ message, isLive = false }: Props) {
         </div>
       )}
 
-      {/* Footer: copy + x-ray */}
+      {/* Footer: copy + read aloud + x-ray */}
       <div className="flex items-center gap-2 mt-1.5">
         <CopyMessageButton content={cleanContent} />
+        {!isUser && !isLive && <SpeakMessageButton content={cleanContent} />}
       </div>
       <XRayFooter
         usage={message.usage}

--- a/frontend/src/components/Chat/MessageBubble.tsx
+++ b/frontend/src/components/Chat/MessageBubble.tsx
@@ -13,12 +13,7 @@ import { rehypeCitations } from '../../lib/rehype-citations';
 import { XRayFooter } from './XRayFooter';
 import { SpeakMessageButton } from './SpeakMessageButton';
 import type { ChatMessage } from '../../types';
-
-function stripThinkTags(text: string): string {
-  let cleaned = text.replace(/<think>[\s\S]*?<\/think>\s*/gi, '');
-  cleaned = cleaned.replace(/^[\s\S]*?<\/think>\s*/i, '');
-  return cleaned.trim();
-}
+import { stripThinkTags } from '../../lib/message-text';
 
 interface Props {
   message: ChatMessage;
@@ -182,7 +177,9 @@ export function MessageBubble({ message, isLive = false }: Props) {
       {/* Footer: copy + read aloud + x-ray */}
       <div className="flex items-center gap-2 mt-1.5">
         <CopyMessageButton content={cleanContent} />
-        {!isUser && !isLive && <SpeakMessageButton content={cleanContent} />}
+        {!isUser && !isLive && (
+          <SpeakMessageButton messageId={message.id} content={cleanContent} />
+        )}
       </div>
       <XRayFooter
         usage={message.usage}

--- a/frontend/src/components/Chat/SpeakMessageButton.tsx
+++ b/frontend/src/components/Chat/SpeakMessageButton.tsx
@@ -2,26 +2,38 @@ import { Volume2, Square } from 'lucide-react';
 import { useTts } from '../../hooks/useTts';
 import { useAppStore } from '../../lib/store';
 
+interface Props {
+  messageId: string;
+  content: string;
+}
+
 /** Reads one assistant message aloud through the server's TTS backend. */
-export function SpeakMessageButton({ content }: { content: string }) {
+export function SpeakMessageButton({ messageId, content }: Props) {
   const voiceOutputEnabled = useAppStore((s) => s.settings.voiceOutputEnabled);
-  const { speak, stop, available, isLoading, isSpeaking, error } = useTts();
+  const { speak, stop, speakingId, available, state, error } = useTts();
 
   if (!voiceOutputEnabled || !available) return null;
 
-  const busy = isLoading || isSpeaking;
+  // Playback is global, so this button reflects the shared utterance only when
+  // that utterance is this message.
+  const isMine = speakingId === messageId;
+  const busy = isMine && (state === 'loading' || state === 'speaking');
 
   return (
     <button
-      onClick={() => (busy ? stop() : speak(content))}
+      onClick={() => (busy ? stop() : speak(messageId, content))}
       className="p-1 rounded opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer"
       style={{
         color: busy ? 'var(--color-accent)' : 'var(--color-text-tertiary)',
         opacity: busy ? 1 : undefined,
       }}
       title={
-        error ??
-        (isLoading ? 'Synthesizing...' : isSpeaking ? 'Stop' : 'Read aloud')
+        (isMine && error) ||
+        (isMine && state === 'loading'
+          ? 'Synthesizing...'
+          : isMine && state === 'speaking'
+            ? 'Stop'
+            : 'Read aloud')
       }
       aria-label={busy ? 'Stop reading message' : 'Read message aloud'}
     >

--- a/frontend/src/components/Chat/SpeakMessageButton.tsx
+++ b/frontend/src/components/Chat/SpeakMessageButton.tsx
@@ -1,0 +1,31 @@
+import { Volume2, Square } from 'lucide-react';
+import { useTts } from '../../hooks/useTts';
+import { useAppStore } from '../../lib/store';
+
+/** Reads one assistant message aloud through the server's TTS backend. */
+export function SpeakMessageButton({ content }: { content: string }) {
+  const voiceOutputEnabled = useAppStore((s) => s.settings.voiceOutputEnabled);
+  const { speak, stop, available, isLoading, isSpeaking, error } = useTts();
+
+  if (!voiceOutputEnabled || !available) return null;
+
+  const busy = isLoading || isSpeaking;
+
+  return (
+    <button
+      onClick={() => (busy ? stop() : speak(content))}
+      className="p-1 rounded opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer"
+      style={{
+        color: busy ? 'var(--color-accent)' : 'var(--color-text-tertiary)',
+        opacity: busy ? 1 : undefined,
+      }}
+      title={
+        error ??
+        (isLoading ? 'Synthesizing...' : isSpeaking ? 'Stop' : 'Read aloud')
+      }
+      aria-label={busy ? 'Stop reading message' : 'Read message aloud'}
+    >
+      {busy ? <Square size={14} /> : <Volume2 size={14} />}
+    </button>
+  );
+}

--- a/frontend/src/hooks/useTts.ts
+++ b/frontend/src/hooks/useTts.ts
@@ -1,100 +1,33 @@
-import { useState, useCallback, useRef, useEffect } from 'react';
-import { synthesizeSpeech, fetchTtsHealth } from '../lib/api';
+import { useEffect } from 'react';
+import { useTtsStore } from '../lib/tts';
 
-export type TtsState = 'idle' | 'loading' | 'speaking';
+export type { TtsState } from '../lib/tts';
 
 /**
- * Play assistant replies through the server's TTS backend.
+ * Read-aloud controls backed by the shared voice-output store.
  *
- * One utterance plays at a time: starting a new one stops whatever is running,
- * and a stale request that resolves after the user moved on is discarded rather
- * than played over the top.
+ * Every consumer talks to the same utterance, so starting one reply stops the
+ * previous one instead of layering on top of it. The health probe runs once per
+ * document, no matter how many components mount this hook.
  */
 export function useTts() {
-  const [state, setState] = useState<TtsState>('idle');
-  const [error, setError] = useState<string | null>(null);
-  const [available, setAvailable] = useState(false);
-  const audioRef = useRef<HTMLAudioElement | null>(null);
-  const urlRef = useRef<string | null>(null);
-  const requestRef = useRef(0);
+  const state = useTtsStore((s) => s.state);
+  const speakingId = useTtsStore((s) => s.speakingId);
+  const error = useTtsStore((s) => s.error);
+  const available = useTtsStore((s) => s.available);
+  const speak = useTtsStore((s) => s.speak);
+  const stop = useTtsStore((s) => s.stop);
+  const ensureHealth = useTtsStore((s) => s.ensureHealth);
 
   useEffect(() => {
-    fetchTtsHealth()
-      .then((health) => setAvailable(health.available))
-      .catch(() => setAvailable(false));
-  }, []);
-
-  const cleanup = useCallback(() => {
-    if (audioRef.current) {
-      audioRef.current.pause();
-      audioRef.current.src = '';
-      audioRef.current = null;
-    }
-    if (urlRef.current) {
-      URL.revokeObjectURL(urlRef.current);
-      urlRef.current = null;
-    }
-  }, []);
-
-  const stop = useCallback(() => {
-    requestRef.current += 1;
-    cleanup();
-    setState('idle');
-  }, [cleanup]);
-
-  const speak = useCallback(
-    async (text: string): Promise<void> => {
-      const trimmed = text.trim();
-      if (!trimmed) return;
-
-      requestRef.current += 1;
-      const token = requestRef.current;
-      cleanup();
-      setError(null);
-      setState('loading');
-
-      try {
-        const blob = await synthesizeSpeech(trimmed);
-        if (token !== requestRef.current) return; // superseded while synthesizing
-
-        const url = URL.createObjectURL(blob);
-        urlRef.current = url;
-
-        const audio = new Audio(url);
-        audioRef.current = audio;
-        audio.onended = () => {
-          if (token === requestRef.current) {
-            cleanup();
-            setState('idle');
-          }
-        };
-        audio.onerror = () => {
-          if (token === requestRef.current) {
-            cleanup();
-            setError('Playback failed');
-            setState('idle');
-          }
-        };
-
-        await audio.play();
-        if (token === requestRef.current) setState('speaking');
-      } catch (err) {
-        if (token !== requestRef.current) return;
-        cleanup();
-        setError(err instanceof Error ? err.message : 'Speech synthesis failed');
-        setState('idle');
-      }
-    },
-    [cleanup],
-  );
-
-  // Never leave audio playing or a blob URL leaked behind an unmounted view.
-  useEffect(() => cleanup, [cleanup]);
+    ensureHealth();
+  }, [ensureHealth]);
 
   return {
     state,
+    speakingId,
     error,
-    available,
+    available: available === true,
     speak,
     stop,
     isLoading: state === 'loading',

--- a/frontend/src/hooks/useTts.ts
+++ b/frontend/src/hooks/useTts.ts
@@ -1,0 +1,103 @@
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { synthesizeSpeech, fetchTtsHealth } from '../lib/api';
+
+export type TtsState = 'idle' | 'loading' | 'speaking';
+
+/**
+ * Play assistant replies through the server's TTS backend.
+ *
+ * One utterance plays at a time: starting a new one stops whatever is running,
+ * and a stale request that resolves after the user moved on is discarded rather
+ * than played over the top.
+ */
+export function useTts() {
+  const [state, setState] = useState<TtsState>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const [available, setAvailable] = useState(false);
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const urlRef = useRef<string | null>(null);
+  const requestRef = useRef(0);
+
+  useEffect(() => {
+    fetchTtsHealth()
+      .then((health) => setAvailable(health.available))
+      .catch(() => setAvailable(false));
+  }, []);
+
+  const cleanup = useCallback(() => {
+    if (audioRef.current) {
+      audioRef.current.pause();
+      audioRef.current.src = '';
+      audioRef.current = null;
+    }
+    if (urlRef.current) {
+      URL.revokeObjectURL(urlRef.current);
+      urlRef.current = null;
+    }
+  }, []);
+
+  const stop = useCallback(() => {
+    requestRef.current += 1;
+    cleanup();
+    setState('idle');
+  }, [cleanup]);
+
+  const speak = useCallback(
+    async (text: string): Promise<void> => {
+      const trimmed = text.trim();
+      if (!trimmed) return;
+
+      requestRef.current += 1;
+      const token = requestRef.current;
+      cleanup();
+      setError(null);
+      setState('loading');
+
+      try {
+        const blob = await synthesizeSpeech(trimmed);
+        if (token !== requestRef.current) return; // superseded while synthesizing
+
+        const url = URL.createObjectURL(blob);
+        urlRef.current = url;
+
+        const audio = new Audio(url);
+        audioRef.current = audio;
+        audio.onended = () => {
+          if (token === requestRef.current) {
+            cleanup();
+            setState('idle');
+          }
+        };
+        audio.onerror = () => {
+          if (token === requestRef.current) {
+            cleanup();
+            setError('Playback failed');
+            setState('idle');
+          }
+        };
+
+        await audio.play();
+        if (token === requestRef.current) setState('speaking');
+      } catch (err) {
+        if (token !== requestRef.current) return;
+        cleanup();
+        setError(err instanceof Error ? err.message : 'Speech synthesis failed');
+        setState('idle');
+      }
+    },
+    [cleanup],
+  );
+
+  // Never leave audio playing or a blob URL leaked behind an unmounted view.
+  useEffect(() => cleanup, [cleanup]);
+
+  return {
+    state,
+    error,
+    available,
+    speak,
+    stop,
+    isLoading: state === 'loading',
+    isSpeaking: state === 'speaking',
+  };
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -388,6 +388,42 @@ export async function transcribeAudio(audioBlob: Blob, filename = 'recording.web
   return res.json();
 }
 
+export interface TtsHealth {
+  available: boolean;
+  backend?: string;
+  voice_id?: string;
+  speed?: number;
+  reason?: string;
+}
+
+export async function synthesizeSpeech(
+  text: string,
+  opts: { voiceId?: string; speed?: number } = {},
+): Promise<Blob> {
+  const res = await apiFetch(`/v1/speech/synthesize`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ text, voice_id: opts.voiceId, speed: opts.speed }),
+  });
+  if (!res.ok) {
+    let detail = '';
+    try {
+      const body = await res.json();
+      detail = typeof body.detail === 'string' ? body.detail : '';
+    } catch {
+      // Keep the status-only message below when the body is not JSON.
+    }
+    throw new Error(detail || `Speech synthesis failed: ${res.status}`);
+  }
+  return res.blob();
+}
+
+export async function fetchTtsHealth(): Promise<TtsHealth> {
+  const res = await apiFetch(`/v1/speech/tts/health`);
+  if (!res.ok) return { available: false };
+  return res.json();
+}
+
 export async function fetchSpeechHealth(): Promise<SpeechHealth> {
   if (isTauri()) {
     try {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -398,12 +398,13 @@ export interface TtsHealth {
 
 export async function synthesizeSpeech(
   text: string,
-  opts: { voiceId?: string; speed?: number } = {},
+  opts: { voiceId?: string; speed?: number; signal?: AbortSignal } = {},
 ): Promise<Blob> {
   const res = await apiFetch(`/v1/speech/synthesize`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ text, voice_id: opts.voiceId, speed: opts.speed }),
+    signal: opts.signal,
   });
   if (!res.ok) {
     let detail = '';

--- a/frontend/src/lib/message-text.ts
+++ b/frontend/src/lib/message-text.ts
@@ -1,0 +1,8 @@
+/** Text helpers shared between the message renderer and voice output. */
+
+/** Remove <think> reasoning blocks so they are neither shown nor spoken. */
+export function stripThinkTags(text: string): string {
+  let cleaned = text.replace(/<think>[\s\S]*?<\/think>\s*/gi, '');
+  cleaned = cleaned.replace(/^[\s\S]*?<\/think>\s*/i, '');
+  return cleaned.trim();
+}

--- a/frontend/src/lib/store.ts
+++ b/frontend/src/lib/store.ts
@@ -106,6 +106,7 @@ interface Settings {
   temperature: number;
   maxTokens: number;
   speechEnabled: boolean;
+  voiceOutputEnabled: boolean;
 }
 
 function loadSettings(): Settings {
@@ -119,6 +120,7 @@ function loadSettings(): Settings {
     temperature: 0.7,
     maxTokens: 4096,
     speechEnabled: false,
+    voiceOutputEnabled: false,
   };
   try {
     const raw = localStorage.getItem(SETTINGS_KEY);

--- a/frontend/src/lib/store.ts
+++ b/frontend/src/lib/store.ts
@@ -107,6 +107,7 @@ interface Settings {
   maxTokens: number;
   speechEnabled: boolean;
   voiceOutputEnabled: boolean;
+  voiceAutoplay: boolean;
 }
 
 function loadSettings(): Settings {
@@ -121,6 +122,7 @@ function loadSettings(): Settings {
     maxTokens: 4096,
     speechEnabled: false,
     voiceOutputEnabled: false,
+    voiceAutoplay: false,
   };
   try {
     const raw = localStorage.getItem(SETTINGS_KEY);

--- a/frontend/src/lib/tts.test.ts
+++ b/frontend/src/lib/tts.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./api', () => ({
+  synthesizeSpeech: vi.fn(),
+  fetchTtsHealth: vi.fn(),
+}));
+
+import { synthesizeSpeech, fetchTtsHealth } from './api';
+import { useTtsStore, __resetTtsForTests } from './tts';
+
+const synth = vi.mocked(synthesizeSpeech);
+const health = vi.mocked(fetchTtsHealth);
+
+/** Minimal HTMLAudioElement stand-in; jsdom cannot decode or play real audio. */
+class FakeAudio {
+  static instances: FakeAudio[] = [];
+  onended: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  src: string;
+  paused = false;
+  playCalls = 0;
+
+  constructor(src: string) {
+    this.src = src;
+    FakeAudio.instances.push(this);
+  }
+
+  play(): Promise<void> {
+    this.playCalls += 1;
+    return Promise.resolve();
+  }
+
+  pause(): void {
+    this.paused = true;
+  }
+}
+
+const created: string[] = [];
+const revoked: string[] = [];
+let urlCounter = 0;
+
+beforeEach(() => {
+  vi.stubGlobal('Audio', FakeAudio as unknown as typeof Audio);
+  vi.stubGlobal('URL', {
+    createObjectURL: () => {
+      const url = `blob:fake/${++urlCounter}`;
+      created.push(url);
+      return url;
+    },
+    revokeObjectURL: (url: string) => {
+      revoked.push(url);
+    },
+  });
+
+  synth.mockReset();
+  health.mockReset();
+
+  // Reset the store first: it tears down whatever the previous test left
+  // playing, and that teardown revokes a URL. Clearing the ledgers afterwards
+  // keeps that bookkeeping out of this test's assertions.
+  __resetTtsForTests();
+  FakeAudio.instances = [];
+  created.length = 0;
+  revoked.length = 0;
+  urlCounter = 0;
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('shared voice output', () => {
+  it('plays one utterance and reports which message owns it', async () => {
+    synth.mockResolvedValue(new Blob(['wav']));
+
+    await useTtsStore.getState().speak('m1', 'Hallo');
+
+    expect(FakeAudio.instances).toHaveLength(1);
+    expect(FakeAudio.instances[0].playCalls).toBe(1);
+    expect(useTtsStore.getState().state).toBe('speaking');
+    expect(useTtsStore.getState().speakingId).toBe('m1');
+  });
+
+  it('starting a second message stops the first instead of overlapping it', async () => {
+    synth.mockResolvedValue(new Blob(['wav']));
+
+    await useTtsStore.getState().speak('m1', 'Erste');
+    const first = FakeAudio.instances[0];
+
+    await useTtsStore.getState().speak('m2', 'Zweite');
+
+    expect(first.paused).toBe(true);
+    expect(useTtsStore.getState().speakingId).toBe('m2');
+    expect(revoked).toContain(created[0]);
+  });
+
+  it('aborts a synthesis that is superseded before it resolves', async () => {
+    const pending = deferred<Blob>();
+    synth.mockReturnValueOnce(pending.promise);
+    synth.mockResolvedValueOnce(new Blob(['wav']));
+
+    const firstCall = useTtsStore.getState().speak('m1', 'Erste');
+    const signal = synth.mock.calls[0][1]?.signal as AbortSignal;
+    expect(signal.aborted).toBe(false);
+
+    await useTtsStore.getState().speak('m2', 'Zweite');
+    expect(signal.aborted).toBe(true);
+
+    // The stale response must not start playback or leak its blob URL.
+    pending.resolve(new Blob(['stale']));
+    await firstCall;
+
+    expect(FakeAudio.instances).toHaveLength(1);
+    expect(useTtsStore.getState().speakingId).toBe('m2');
+  });
+
+  it('stop() halts playback and revokes the blob URL', async () => {
+    synth.mockResolvedValue(new Blob(['wav']));
+
+    await useTtsStore.getState().speak('m1', 'Hallo');
+    useTtsStore.getState().stop();
+
+    expect(FakeAudio.instances[0].paused).toBe(true);
+    expect(revoked).toEqual(created);
+    expect(useTtsStore.getState().state).toBe('idle');
+    expect(useTtsStore.getState().speakingId).toBeNull();
+  });
+
+  it('finishing playback leaves no error behind', async () => {
+    synth.mockResolvedValue(new Blob(['wav']));
+
+    await useTtsStore.getState().speak('m1', 'Hallo');
+    const el = FakeAudio.instances[0];
+
+    el.onended?.();
+    // Clearing src fires a media error; the handler must already be detached.
+    el.onerror?.();
+
+    expect(useTtsStore.getState().error).toBeNull();
+    expect(useTtsStore.getState().state).toBe('idle');
+    expect(revoked).toEqual(created);
+  });
+
+  it('surfaces a synthesis failure', async () => {
+    synth.mockRejectedValue(new Error('No text-to-speech backend available'));
+
+    await useTtsStore.getState().speak('m1', 'Hallo');
+
+    expect(useTtsStore.getState().error).toBe('No text-to-speech backend available');
+    expect(useTtsStore.getState().state).toBe('idle');
+  });
+
+  it('ignores empty text', async () => {
+    await useTtsStore.getState().speak('m1', '   ');
+    expect(synth).not.toHaveBeenCalled();
+  });
+
+  it('probes the backend once no matter how many callers ask', () => {
+    health.mockResolvedValue({ available: true });
+
+    useTtsStore.getState().ensureHealth();
+    useTtsStore.getState().ensureHealth();
+    useTtsStore.getState().ensureHealth();
+
+    expect(health).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/lib/tts.test.ts
+++ b/frontend/src/lib/tts.test.ts
@@ -175,3 +175,65 @@ describe('shared voice output', () => {
     expect(health).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('autoplay gating', () => {
+  // The rule ChatArea implements: speak on the falling edge of a stream, never
+  // merely because a finished reply is on screen. Encoded here so the intent
+  // survives even though the effect itself lives in the component.
+  function shouldSpeak(prev: { wasStreaming: boolean; autoSpokenId: string | null }, now: {
+    isStreaming: boolean;
+    lastRole: string;
+    lastId: string;
+  }): boolean {
+    const justFinished = prev.wasStreaming && !now.isStreaming;
+    if (!justFinished) return false;
+    if (now.lastRole !== 'assistant') return false;
+    return prev.autoSpokenId !== now.lastId;
+  }
+
+  it('stays silent when a finished conversation is merely restored', () => {
+    // Page load: nothing was streaming, a completed reply is already on screen.
+    expect(
+      shouldSpeak(
+        { wasStreaming: false, autoSpokenId: null },
+        { isStreaming: false, lastRole: 'assistant', lastId: 'old' },
+      ),
+    ).toBe(false);
+  });
+
+  it('speaks when a stream finishes', () => {
+    expect(
+      shouldSpeak(
+        { wasStreaming: true, autoSpokenId: null },
+        { isStreaming: false, lastRole: 'assistant', lastId: 'fresh' },
+      ),
+    ).toBe(true);
+  });
+
+  it('stays silent while the reply is still streaming', () => {
+    expect(
+      shouldSpeak(
+        { wasStreaming: true, autoSpokenId: null },
+        { isStreaming: true, lastRole: 'assistant', lastId: 'fresh' },
+      ),
+    ).toBe(false);
+  });
+
+  it('never repeats a message it already spoke', () => {
+    expect(
+      shouldSpeak(
+        { wasStreaming: true, autoSpokenId: 'fresh' },
+        { isStreaming: false, lastRole: 'assistant', lastId: 'fresh' },
+      ),
+    ).toBe(false);
+  });
+
+  it('ignores a trailing user message', () => {
+    expect(
+      shouldSpeak(
+        { wasStreaming: true, autoSpokenId: null },
+        { isStreaming: false, lastRole: 'user', lastId: 'u1' },
+      ),
+    ).toBe(false);
+  });
+});

--- a/frontend/src/lib/tts.ts
+++ b/frontend/src/lib/tts.ts
@@ -1,0 +1,141 @@
+import { create } from 'zustand';
+import { synthesizeSpeech, fetchTtsHealth } from './api';
+
+export type TtsState = 'idle' | 'loading' | 'speaking';
+
+/**
+ * Voice output is a single shared resource: one utterance at a time, for the
+ * whole app. The state lives in one store rather than per component, because a
+ * per-component hook would give every message its own audio element -- two
+ * replies would then talk over each other, and autoplay would make that the
+ * normal case rather than the exception.
+ */
+interface TtsStore {
+  state: TtsState;
+  /** id of the message currently loading or speaking, if any. */
+  speakingId: string | null;
+  error: string | null;
+  /** null until the health probe has answered. */
+  available: boolean | null;
+  /** Last message spoken by autoplay, so a re-render never repeats it. */
+  autoSpokenId: string | null;
+  speak: (id: string, text: string) => Promise<void>;
+  stop: () => void;
+  ensureHealth: () => void;
+  markAutoSpoken: (id: string) => void;
+}
+
+// Playback handles are not render state -- keeping them out of the store avoids
+// re-rendering every subscriber when an audio element is swapped.
+let audio: HTMLAudioElement | null = null;
+let objectUrl: string | null = null;
+let controller: AbortController | null = null;
+let token = 0;
+let healthProbe: Promise<void> | null = null;
+
+function teardown(): void {
+  if (audio) {
+    // Detach first: clearing src re-runs the media load algorithm, which fails
+    // on an empty source and dispatches an `error` event. With the handler
+    // still attached that surfaces as a bogus "Playback failed" after every
+    // successful utterance.
+    audio.onended = null;
+    audio.onerror = null;
+    audio.pause();
+    audio.src = '';
+    audio = null;
+  }
+  if (objectUrl) {
+    URL.revokeObjectURL(objectUrl);
+    objectUrl = null;
+  }
+  if (controller) {
+    controller.abort();
+    controller = null;
+  }
+}
+
+export const useTtsStore = create<TtsStore>((set, get) => ({
+  state: 'idle',
+  speakingId: null,
+  error: null,
+  available: null,
+  autoSpokenId: null,
+
+  ensureHealth: () => {
+    if (healthProbe) return;
+    healthProbe = fetchTtsHealth()
+      .then((health) => set({ available: health.available }))
+      .catch(() => set({ available: false }));
+  },
+
+  markAutoSpoken: (id: string) => set({ autoSpokenId: id }),
+
+  speak: async (id: string, text: string) => {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+
+    // Bump before teardown so a synthesis still in flight is both aborted and
+    // fenced off by the token, even if the abort loses the race.
+    token += 1;
+    const mine = token;
+    teardown();
+    set({ state: 'loading', speakingId: id, error: null });
+
+    const ac = new AbortController();
+    controller = ac;
+
+    try {
+      const blob = await synthesizeSpeech(trimmed, { signal: ac.signal });
+      if (mine !== token) return;
+
+      const url = URL.createObjectURL(blob);
+      objectUrl = url;
+      const el = new Audio(url);
+      audio = el;
+
+      el.onended = () => {
+        if (mine !== token) return;
+        teardown();
+        set({ state: 'idle', speakingId: null });
+      };
+      el.onerror = () => {
+        if (mine !== token) return;
+        teardown();
+        set({ state: 'idle', speakingId: null, error: 'Playback failed' });
+      };
+
+      await el.play();
+      if (mine === token) set({ state: 'speaking', speakingId: id });
+    } catch (err) {
+      if (mine !== token) return;
+      if (err instanceof DOMException && err.name === 'AbortError') return;
+      teardown();
+      set({
+        state: 'idle',
+        speakingId: null,
+        error: err instanceof Error ? err.message : 'Speech synthesis failed',
+      });
+    }
+  },
+
+  stop: () => {
+    token += 1;
+    teardown();
+    set({ state: 'idle', speakingId: null });
+  },
+}));
+
+/** Test seam: reset module-level playback handles between cases. */
+export function __resetTtsForTests(): void {
+  teardown();
+  token = 0;
+  healthProbe = null;
+  useTtsStore.setState({
+    state: 'idle',
+    speakingId: null,
+    error: null,
+    available: null,
+    autoSpokenId: null,
+  });
+}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -744,6 +744,26 @@ export function SettingsPage() {
                 />
               </button>
             </SettingRow>
+            <SettingRow label="Speak replies automatically" description="Read every assistant reply aloud as soon as it finishes">
+              <button
+                onClick={() => { updateSettings({ voiceAutoplay: !settings.voiceAutoplay }); showSaved(); }}
+                disabled={!settings.voiceOutputEnabled}
+                className="relative w-11 h-6 rounded-full transition-colors cursor-pointer"
+                style={{
+                  background: settings.voiceAutoplay && settings.voiceOutputEnabled ? 'var(--color-accent)' : 'var(--color-bg-tertiary)',
+                  opacity: settings.voiceOutputEnabled ? 1 : 0.4,
+                  cursor: settings.voiceOutputEnabled ? 'pointer' : 'default',
+                }}
+              >
+                <span
+                  className="absolute top-0.5 left-0.5 w-5 h-5 rounded-full transition-transform bg-white"
+                  style={{
+                    transform: settings.voiceAutoplay && settings.voiceOutputEnabled ? 'translateX(20px)' : 'translateX(0)',
+                    boxShadow: '0 1px 3px rgba(0,0,0,0.2)',
+                  }}
+                />
+              </button>
+            </SettingRow>
             <SettingRow label="Voice" description="Backend and voice used for spoken replies">
               <div className="flex items-center gap-2">
                 <span

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -22,6 +22,7 @@ import { useAppStore, type ThemeMode } from '../lib/store';
 import {
   checkHealth,
   fetchSpeechHealth,
+  fetchTtsHealth,
   getMemoryStats,
   getInferenceSource,
   setInferenceSource,
@@ -240,6 +241,7 @@ export function SettingsPage() {
   const serverInfo = useAppStore((s) => s.serverInfo);
   const [healthy, setHealthy] = useState<boolean | null>(null);
   const [speechBackendAvailable, setSpeechBackendAvailable] = useState<boolean | null>(null);
+  const [ttsBackend, setTtsBackend] = useState<{ available: boolean; backend?: string; voice_id?: string } | null>(null);
   const [saved, setSaved] = useState(false);
 
   const [autoUpdateEnabled, setAutoUpdateEnabled] = useState(() => !isAutoUpdateDisabled());
@@ -314,6 +316,9 @@ export function SettingsPage() {
     fetchSpeechHealth()
       .then((h) => setSpeechBackendAvailable(h.available))
       .catch(() => setSpeechBackendAvailable(false));
+    fetchTtsHealth()
+      .then((h) => setTtsBackend(h))
+      .catch(() => setTtsBackend({ available: false }));
     getMemoryStats()
       .then(setMemoryStats)
       .catch(() => setMemoryStats(null));
@@ -721,6 +726,38 @@ export function SettingsPage() {
                   }}
                 />
               </button>
+            </SettingRow>
+            <SettingRow label="Text-to-Speech" description="Show a read-aloud button on assistant replies">
+              <button
+                onClick={() => { updateSettings({ voiceOutputEnabled: !settings.voiceOutputEnabled }); showSaved(); }}
+                className="relative w-11 h-6 rounded-full transition-colors cursor-pointer"
+                style={{
+                  background: settings.voiceOutputEnabled ? 'var(--color-accent)' : 'var(--color-bg-tertiary)',
+                }}
+              >
+                <span
+                  className="absolute top-0.5 left-0.5 w-5 h-5 rounded-full transition-transform bg-white"
+                  style={{
+                    transform: settings.voiceOutputEnabled ? 'translateX(20px)' : 'translateX(0)',
+                    boxShadow: '0 1px 3px rgba(0,0,0,0.2)',
+                  }}
+                />
+              </button>
+            </SettingRow>
+            <SettingRow label="Voice" description="Backend and voice used for spoken replies">
+              <div className="flex items-center gap-2">
+                <span
+                  className="w-2 h-2 rounded-full"
+                  style={{
+                    background: ttsBackend?.available ? 'var(--color-success)' : 'var(--color-text-tertiary)',
+                  }}
+                />
+                <span className="text-xs" style={{ color: 'var(--color-text-secondary)' }}>
+                  {ttsBackend === null ? 'Checking...'
+                    : ttsBackend.available ? `${ttsBackend.backend}${ttsBackend.voice_id ? ` / ${ttsBackend.voice_id}` : ''}`
+                    : 'Not configured'}
+                </span>
+              </div>
             </SettingRow>
             <SettingRow label="Backend status" description="Requires Whisper, Deepgram, or another speech backend">
               <div className="flex items-center gap-2">

--- a/src/openjarvis/cli/_voice_chat.py
+++ b/src/openjarvis/cli/_voice_chat.py
@@ -7,15 +7,24 @@ from typing import Any, Optional
 from rich.markup import escape
 
 VOICE_EXIT = object()
-_TTS_BACKEND_ORDER = ("kokoro", "openai_tts", "cartesia")
-# Voice IDs are backend-specific and NOT portable. ``speech.voice_id`` applies
-# only to ``speech.tts_backend``; if synthesis falls back to another backend we
-# use that backend's own default rather than passing an unrecognized ID through.
-_BACKEND_DEFAULT_VOICE = {
-    "kokoro": "bm_george",  # British male
-    "openai_tts": "onyx",  # deepest OpenAI preset
-    "cartesia": "",  # no safe static default; let Cartesia choose
+
+# Backend selection is shared with the API server and lives in
+# openjarvis.speech._tts_discovery. Importing that at module level would pull
+# the whole speech stack -- numpy included -- into every `jarvis` invocation,
+# which tests/cli/test_cli.py guards against, so these aliases resolve lazily.
+_LAZY_TTS_NAMES = {
+    "_TTS_BACKEND_ORDER": "TTS_BACKEND_ORDER",
+    "_BACKEND_DEFAULT_VOICE": "BACKEND_DEFAULT_VOICE",
 }
+
+
+def __getattr__(name: str) -> Any:
+    target = _LAZY_TTS_NAMES.get(name)
+    if target is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    from openjarvis.speech import _tts_discovery
+
+    return getattr(_tts_discovery, target)
 
 
 def _terminal_safe_text(value: object) -> str:
@@ -54,40 +63,20 @@ class VoiceSession:
         if self._tts_backend is not None:
             return self._tts_backend
 
-        # Import triggers built-in backend registration only when voice output
-        # is actually requested.
-        import openjarvis.speech  # noqa: F401
-        from openjarvis.core.registry import TTSRegistry
+        from openjarvis.speech._tts_discovery import get_tts_backend
 
         preferred, _, _ = self.get_voice_preferences()
-        backend_order = dict.fromkeys((preferred, *_TTS_BACKEND_ORDER))
-        for key in backend_order:
-            if key in self._tts_attempted:
-                continue
-            self._tts_attempted.add(key)
-            if not TTSRegistry.contains(key):
-                continue
-            try:
-                candidate = TTSRegistry.get(key)()
-                if candidate.health():
-                    self._tts_backend = candidate
-                    return candidate
-            except Exception:
-                continue
-        return None
+        self._tts_backend = get_tts_backend(preferred, attempted=self._tts_attempted)
+        return self._tts_backend
 
     def get_voice_preferences(self) -> tuple[str, str, float]:
         """Resolve configured (tts_backend, voice_id, speed), cached per session."""
         if self._voice_prefs is None:
             from openjarvis.core.config import load_config
+            from openjarvis.speech._tts_discovery import voice_preferences
 
             config = self._config if self._config is not None else load_config()
-            speech = getattr(config, "speech", None)
-            self._voice_prefs = (
-                getattr(speech, "tts_backend", "kokoro") or "kokoro",
-                getattr(speech, "voice_id", "") or "",
-                float(getattr(speech, "voice_speed", 1.0)),
-            )
+            self._voice_prefs = voice_preferences(config)
         return self._voice_prefs
 
     def voice_for_backend(self, backend: Any, console: Any = None) -> tuple[str, float]:
@@ -103,7 +92,9 @@ class VoiceSession:
         if active == want_backend:
             return voice_id, speed
 
-        substitute = _BACKEND_DEFAULT_VOICE.get(active, "")
+        from openjarvis.speech._tts_discovery import default_voice_for
+
+        substitute = default_voice_for(active)
         if console is not None and active not in self._voice_warned:
             self._voice_warned.add(active)
             console.print(

--- a/src/openjarvis/server/api_routes.py
+++ b/src/openjarvis/server/api_routes.py
@@ -9,7 +9,14 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, HTTPException, Request, WebSocket, WebSocketDisconnect
+from fastapi import (
+    APIRouter,
+    HTTPException,
+    Request,
+    Response,
+    WebSocket,
+    WebSocketDisconnect,
+)
 from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
@@ -25,6 +32,12 @@ class AgentCreateRequest(BaseModel):
 
 class AgentMessageRequest(BaseModel):
     message: str
+
+
+class SpeechSynthesizeRequest(BaseModel):
+    text: str
+    voice_id: Optional[str] = None
+    speed: Optional[float] = None
 
 
 class MemoryStoreRequest(BaseModel):
@@ -1041,6 +1054,120 @@ async def speech_health(request: Request):
         "available": available,
         "backend": backend.backend_id,
         **({"reason": reason} if reason else {}),
+    }
+
+
+# Synthesis is CPU-bound and runs in a worker thread; cap the input so one
+# request cannot occupy that thread for minutes.
+_MAX_TTS_CHARS = 5000
+
+
+def _resolve_tts_backend(request: Request):
+    """Return a healthy TTS backend, resolved once and cached on app state.
+
+    Backends load models on construction, so this stays lazy: a server whose
+    users never ask for audio never pays for it.
+    """
+    app = request.app
+    if getattr(app.state, "tts_resolved", False):
+        return getattr(app.state, "tts_backend", None)
+
+    from openjarvis.speech._tts_discovery import get_tts_backend, voice_preferences
+
+    config = getattr(app.state, "config", None)
+    if config is None:
+        from openjarvis.core.config import load_config
+
+        config = load_config()
+
+    preferred, _, _ = voice_preferences(config)
+    backend = get_tts_backend(preferred)
+    app.state.tts_backend = backend
+    app.state.tts_resolved = True
+    return backend
+
+
+def _tts_voice_and_speed(request: Request, backend) -> tuple[str, float]:
+    """Resolve the voice ID and speed to use with *backend*.
+
+    Voice IDs are not portable between backends, so a configured ``voice_id``
+    applies only when the resolved backend is the configured one; otherwise the
+    fallback backend's own default is used.
+    """
+    from openjarvis.speech._tts_discovery import default_voice_for, voice_preferences
+
+    config = getattr(request.app.state, "config", None)
+    if config is None:
+        return "", 1.0
+
+    preferred, voice_id, speed = voice_preferences(config)
+    active = getattr(backend, "backend_id", "")
+    if active and active != preferred:
+        voice_id = default_voice_for(active)
+    return voice_id, speed
+
+
+@speech_router.post("/synthesize")
+async def synthesize_speech(request: Request, body: SpeechSynthesizeRequest):
+    """Synthesize text to speech and return the audio as WAV."""
+    backend = _resolve_tts_backend(request)
+    if backend is None:
+        raise HTTPException(
+            status_code=501, detail="No text-to-speech backend available"
+        )
+
+    text = body.text.strip()
+    if not text:
+        raise HTTPException(status_code=400, detail="Missing 'text'")
+    if len(text) > _MAX_TTS_CHARS:
+        raise HTTPException(
+            status_code=413,
+            detail=f"Text exceeds {_MAX_TTS_CHARS} characters",
+        )
+
+    voice_id, speed = _tts_voice_and_speed(request, backend)
+    if body.voice_id:
+        voice_id = body.voice_id
+    if body.speed is not None:
+        speed = body.speed
+
+    try:
+        result = await asyncio.to_thread(
+            backend.synthesize,
+            text,
+            voice_id=voice_id,
+            speed=speed,
+            output_format="wav",
+        )
+    except Exception as exc:
+        logger.exception("Speech synthesis failed")
+        raise HTTPException(
+            status_code=500, detail=f"Speech synthesis failed: {exc}"
+        ) from exc
+
+    return Response(
+        content=result.audio,
+        media_type="audio/wav",
+        headers={
+            "X-Voice-Id": result.voice_id or voice_id,
+            "X-Sample-Rate": str(result.sample_rate),
+        },
+    )
+
+
+@speech_router.get("/tts/health")
+async def tts_health(request: Request):
+    """Report whether voice output is available, and with which voice."""
+    backend = _resolve_tts_backend(request)
+    if backend is None:
+        return {"available": False, "reason": "No text-to-speech backend available"}
+
+    voice_id, speed = _tts_voice_and_speed(request, backend)
+    return {
+        "available": True,
+        "backend": getattr(backend, "backend_id", ""),
+        "voice_id": voice_id,
+        "speed": speed,
     }
 
 

--- a/src/openjarvis/server/middleware.py
+++ b/src/openjarvis/server/middleware.py
@@ -45,11 +45,16 @@ def create_security_middleware() -> Any:
                 "max-age=31536000; includeSubDomains"
             )
             response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+            # microphone=(self): the chat UI records voice input from this same
+            # origin. An empty allowlist blocked its own feature.
             response.headers["Permissions-Policy"] = (
-                "camera=(), microphone=(), geolocation=()"
+                "camera=(), microphone=(self), geolocation=()"
             )
+            # media-src blob: lets the UI play synthesized speech, which arrives
+            # as a blob URL; default-src alone refused it.
             response.headers["Content-Security-Policy"] = (
-                "default-src 'self' 'unsafe-inline' 'unsafe-eval'"
+                "default-src 'self' 'unsafe-inline' 'unsafe-eval'; "
+                "media-src 'self' blob:"
             )
             return response
 
@@ -63,6 +68,8 @@ SECURITY_HEADERS = {
     "X-XSS-Protection": "1; mode=block",
     "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
     "Referrer-Policy": "strict-origin-when-cross-origin",
-    "Permissions-Policy": "camera=(), microphone=(), geolocation=()",
-    "Content-Security-Policy": "default-src 'self' 'unsafe-inline' 'unsafe-eval'",
+    "Permissions-Policy": "camera=(), microphone=(self), geolocation=()",
+    "Content-Security-Policy": (
+        "default-src 'self' 'unsafe-inline' 'unsafe-eval'; media-src 'self' blob:"
+    ),
 }

--- a/src/openjarvis/speech/_tts_discovery.py
+++ b/src/openjarvis/speech/_tts_discovery.py
@@ -1,0 +1,85 @@
+"""Auto-discover available text-to-speech backends.
+
+Mirrors ``speech/_discovery.py``, which does the same for speech-to-text. The
+selection rules used to live in ``cli/_voice_chat.py``; they moved here so the
+API server can reuse them instead of importing from the CLI package.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, Optional
+
+if TYPE_CHECKING:
+    from openjarvis.core.config import JarvisConfig
+
+logger = logging.getLogger(__name__)
+
+# Priority order: local first, then cloud.
+TTS_BACKEND_ORDER = ("kokoro", "openai_tts", "cartesia")
+
+# Voice IDs are backend-specific and NOT portable. ``speech.voice_id`` applies
+# only to ``speech.tts_backend``; if synthesis falls back to another backend we
+# use that backend's own default rather than passing an unrecognized ID through.
+BACKEND_DEFAULT_VOICE = {
+    "kokoro": "bm_george",  # British male
+    "openai_tts": "onyx",  # deepest OpenAI preset
+    "cartesia": "",  # no safe static default; let Cartesia choose
+}
+
+
+def default_voice_for(backend_id: str) -> str:
+    """Return the fallback voice ID for *backend_id*, or an empty string."""
+    return BACKEND_DEFAULT_VOICE.get(backend_id, "")
+
+
+def get_tts_backend(
+    preferred: str = "",
+    *,
+    attempted: Optional[set[str]] = None,
+) -> Optional[Any]:
+    """Return the first healthy TTS backend, preferring *preferred*.
+
+    ``attempted`` lets a caller carry state across calls so a backend that
+    already failed is not retried; it is mutated in place.
+    """
+    # Import triggers built-in backend registration only when voice output is
+    # actually requested.
+    import openjarvis.speech  # noqa: F401
+    from openjarvis.core.registry import TTSRegistry
+
+    seen = attempted if attempted is not None else set()
+
+    for key in dict.fromkeys((preferred, *TTS_BACKEND_ORDER)):
+        if not key or key in seen:
+            continue
+        seen.add(key)
+        if not TTSRegistry.contains(key):
+            continue
+        try:
+            candidate = TTSRegistry.get(key)()
+            if candidate.health():
+                return candidate
+        except Exception:
+            logger.debug("TTS backend %s unavailable", key, exc_info=True)
+            continue
+    return None
+
+
+def voice_preferences(config: "JarvisConfig") -> tuple[str, str, float]:
+    """Resolve ``(tts_backend, voice_id, speed)`` from *config*."""
+    speech = getattr(config, "speech", None)
+    return (
+        getattr(speech, "tts_backend", "kokoro") or "kokoro",
+        getattr(speech, "voice_id", "") or "",
+        float(getattr(speech, "voice_speed", 1.0)),
+    )
+
+
+__all__ = [
+    "BACKEND_DEFAULT_VOICE",
+    "TTS_BACKEND_ORDER",
+    "default_voice_for",
+    "get_tts_backend",
+    "voice_preferences",
+]

--- a/tests/server/test_middleware.py
+++ b/tests/server/test_middleware.py
@@ -118,3 +118,23 @@ class TestSecurityHeaders:
         assert "access-control-allow-origin" in resp.headers
         # Security headers should NOT be present on preflight
         assert "X-Frame-Options" not in resp.headers
+
+
+class TestSpeechHeaders:
+    """The security headers must not block the web UI's own speech features."""
+
+    def test_csp_allows_blob_media(self):
+        """Synthesized speech reaches the player as a blob URL."""
+        csp = SECURITY_HEADERS["Content-Security-Policy"]
+        assert "media-src 'self' blob:" in csp
+
+    def test_microphone_allowed_for_same_origin(self):
+        """An empty allowlist would block the chat UI's own voice input."""
+        policy = SECURITY_HEADERS["Permissions-Policy"]
+        assert "microphone=(self)" in policy
+        assert "microphone=()" not in policy
+
+    def test_camera_and_geolocation_stay_blocked(self):
+        policy = SECURITY_HEADERS["Permissions-Policy"]
+        assert "camera=()" in policy
+        assert "geolocation=()" in policy

--- a/tests/server/test_speech_routes.py
+++ b/tests/server/test_speech_routes.py
@@ -137,3 +137,157 @@ def test_health_no_backend():
     assert response.status_code == 200
     data = response.json()
     assert data["available"] is False
+
+
+# ---------------------------------------------------------------------------
+# Text-to-speech
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_tts_backend():
+    from openjarvis.speech.tts import TTSResult
+
+    backend = MagicMock()
+    backend.backend_id = "mock_tts"
+    backend.health.return_value = True
+    backend.synthesize.return_value = TTSResult(
+        audio=b"RIFFfake-wav-bytes",
+        format="wav",
+        duration_seconds=1.25,
+        voice_id="mock-voice",
+        sample_rate=22050,
+    )
+    return backend
+
+
+def _tts_app(backend, *, config=None):
+    from fastapi import FastAPI
+
+    from openjarvis.server.api_routes import speech_router
+
+    app = FastAPI()
+    app.include_router(speech_router)
+    # Pre-resolve so the route does not go through backend discovery.
+    app.state.tts_backend = backend
+    app.state.tts_resolved = True
+    app.state.config = config
+    return TestClient(app)
+
+
+def test_synthesize_returns_wav(mock_tts_backend):
+    client = _tts_app(mock_tts_backend)
+
+    response = client.post("/v1/speech/synthesize", json={"text": "Hallo Welt"})
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "audio/wav"
+    assert response.headers["x-sample-rate"] == "22050"
+    assert response.headers["x-voice-id"] == "mock-voice"
+    assert response.content == b"RIFFfake-wav-bytes"
+    assert mock_tts_backend.synthesize.call_args.kwargs["output_format"] == "wav"
+
+
+def test_synthesize_honours_request_overrides(mock_tts_backend):
+    client = _tts_app(mock_tts_backend)
+
+    client.post(
+        "/v1/speech/synthesize",
+        json={"text": "Hallo", "voice_id": "de_DE-thorsten-medium", "speed": 1.5},
+    )
+
+    kwargs = mock_tts_backend.synthesize.call_args.kwargs
+    assert kwargs["voice_id"] == "de_DE-thorsten-medium"
+    assert kwargs["speed"] == 1.5
+
+
+def test_synthesize_rejects_empty_text(mock_tts_backend):
+    client = _tts_app(mock_tts_backend)
+
+    response = client.post("/v1/speech/synthesize", json={"text": "   "})
+
+    assert response.status_code == 400
+    mock_tts_backend.synthesize.assert_not_called()
+
+
+def test_synthesize_rejects_oversized_text(mock_tts_backend):
+    from openjarvis.server.api_routes import _MAX_TTS_CHARS
+
+    client = _tts_app(mock_tts_backend)
+
+    response = client.post(
+        "/v1/speech/synthesize", json={"text": "a" * (_MAX_TTS_CHARS + 1)}
+    )
+
+    assert response.status_code == 413
+    mock_tts_backend.synthesize.assert_not_called()
+
+
+def test_synthesize_without_backend_returns_501():
+    client = _tts_app(None)
+
+    response = client.post("/v1/speech/synthesize", json={"text": "Hallo"})
+
+    assert response.status_code == 501
+
+
+def test_synthesize_surfaces_backend_failure(mock_tts_backend):
+    mock_tts_backend.synthesize.side_effect = RuntimeError("voice model missing")
+    client = _tts_app(mock_tts_backend)
+
+    response = client.post("/v1/speech/synthesize", json={"text": "Hallo"})
+
+    assert response.status_code == 500
+    assert "voice model missing" in response.json()["detail"]
+
+
+def test_synthesize_offloads_backend_work(mock_tts_backend):
+    from openjarvis.speech.tts import TTSResult
+
+    client = _tts_app(mock_tts_backend)
+    expected = TTSResult(audio=b"RIFFoffloaded", format="wav", sample_rate=22050)
+
+    with patch(
+        "openjarvis.server.api_routes.asyncio.to_thread",
+        new_callable=AsyncMock,
+        return_value=expected,
+    ) as to_thread:
+        response = client.post("/v1/speech/synthesize", json={"text": "Hallo"})
+
+    assert response.content == b"RIFFoffloaded"
+    to_thread.assert_awaited_once()
+
+
+def test_tts_health_reports_backend(mock_tts_backend):
+    client = _tts_app(mock_tts_backend)
+
+    data = client.get("/v1/speech/tts/health").json()
+
+    assert data["available"] is True
+    assert data["backend"] == "mock_tts"
+
+
+def test_tts_health_without_backend():
+    client = _tts_app(None)
+
+    data = client.get("/v1/speech/tts/health").json()
+
+    assert data["available"] is False
+    assert "reason" in data
+
+
+def test_voice_id_not_reused_across_backends(mock_tts_backend):
+    """A configured voice belongs to its backend; a fallback uses its own."""
+    from types import SimpleNamespace
+
+    config = SimpleNamespace(
+        speech=SimpleNamespace(
+            tts_backend="kokoro", voice_id="bm_george", voice_speed=1.0
+        )
+    )
+    client = _tts_app(mock_tts_backend, config=config)
+
+    client.post("/v1/speech/synthesize", json={"text": "Hallo"})
+
+    # Backend is mock_tts, not the configured kokoro, so bm_george must not leak.
+    assert mock_tts_backend.synthesize.call_args.kwargs["voice_id"] != "bm_george"


### PR DESCRIPTION
## Problem

The chat UI can listen but not talk. It records voice input and posts it to `/v1/speech/transcribe`, while text-to-speech exists only behind `jarvis chat --voice`. A browser user has no way to hear a reply.

## What this adds

**Server**

- `POST /v1/speech/synthesize` → WAV, and `GET /v1/speech/tts/health` so the UI can tell whether voice output is configured at all.
- Backend selection moves out of `cli/_voice_chat.py` into `speech/_tts_discovery.py`, mirroring the existing `speech/_discovery.py` for STT — the server no longer reaches into the `cli` package for it. `_voice_chat` keeps `_TTS_BACKEND_ORDER` / `_BACKEND_DEFAULT_VOICE` as lazy aliases via module `__getattr__`, so existing imports still resolve **and** `import openjarvis.cli` still stays clear of numpy (`tests/cli/test_cli.py` guards this; an eager import broke it during development).
- The backend resolves lazily and is cached on app state, so a server whose users never ask for audio never pays the model-loading cost.

**UI**

- Assistant messages get a read-aloud button beside the copy button, and Settings grows a Text-to-Speech toggle plus a row showing the active backend and voice.
- **Speak replies automatically** — an optional setting that reads each reply aloud as it completes. Gated on the message being *finished*: synthesizing a partial sentence only to cut it off on the next chunk is worse than silence.
- Voice output lives in one shared store (`lib/tts.ts`) rather than per component. The first draft called `useTts()` inside the per-message button, which gave every reply its own audio element, request token and health probe. That meant two replies read aloud simultaneously played over each other, and opening a conversation fired one `GET /v1/speech/tts/health` per assistant message even with the feature switched off. Autoplay would have turned both from annoyance into blocker.
- `speak()` aborts a superseded synthesis through an `AbortSignal` instead of only fencing it with a token, and detaches media handlers before clearing `src` — an empty source fires an `error` event, which otherwise surfaced as a bogus "Playback failed" after every *successful* utterance.
- `stripThinkTags` moves to `lib/message-text.ts` so autoplay speaks the same cleaned text the renderer shows, rather than reading `<think>` blocks out loud.

## Two of the app's own security headers blocked this

One of them was already breaking the shipped microphone feature:

- CSP had no `media-src`, so `default-src` refused the `blob:` URL that synthesized audio arrives as. Playback failed **silently** — the request returned 200 and the UI state cycled normally.
- `Permissions-Policy` sent `microphone=()`, an empty allowlist that denies the page its own microphone. Verified in a browser against the built UI: `document.featurePolicy.allowsFeature('microphone')` returned `false` before, `true` after. Browser voice input could never have worked.

Both are fixed; camera and geolocation stay denied. If you would rather see the `Permissions-Policy` fix as its own PR, say so and I will split it out — I bundled it because it blocks the same capability this PR is about.

## Verification

Tested on Windows 11, Python 3.12, against a live server with a real local TTS backend:

- Autoplay confirmed end to end in the browser: sending a message produced `POST /v1/speech/synthesize → 200 OK` with no click on any button, and no `media-src` CSP violation in the console.
- `GET /v1/speech/tts/health` reports the resolved backend and voice; `POST /v1/speech/synthesize` returns `audio/wav` with `X-Voice-Id` / `X-Sample-Rate`; empty text → 400, oversized text → 413.
- A browser check also caught a defect no unit test would have: `available` is only set by the health probe, which ran solely from the per-message button — a button that does not exist until a reply is already on screen. The very first reply could therefore never autoplay. Fixed by probing when voice output is switched on.

Frontend: `npm run build` (tsc + vite) clean, 76 vitest tests pass, 8 of them new and covering the guarantees the hook documents — supersede-aborts-the-previous-request, no double revoke, no false error after a clean finish, one health probe per document.

Python suite, run before and after on the same machine:

| | `a7c233c` (base) | this branch |
| --- | --- | --- |
| passed | 8317 | 8329 |
| failed | 246 | 247 |

The failure delta is two flaky tests, not regressions: `TestCheckpoints` fails on a different test of the same class in each run, and an MLX conversion test is environment-dependent on Windows. Nothing under `speech/`, `server/` or `cli/` differs. `ruff check` and `ruff format --check` are clean.

## Note on process

CONTRIBUTING asks for an issue first on non-trivial changes. I opened this as a PR because the change is self-contained and the code makes the trade-offs concrete — happy to move the discussion to an issue instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
