### PR TITLE
fix(security): protect sensitive files from symlink aliases

### DIFF
--- a/rust/crates/openjarvis-security/src/file_policy.rs
+++ b/rust/crates/openjarvis-security/src/file_policy.rs
@@ -2,7 +2,7 @@
 
 use once_cell::sync::Lazy;
 use std::collections::HashSet;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 static SENSITIVE_PATTERNS: Lazy<HashSet<&'static str>> = Lazy::new(|| {
     HashSet::from([
@@ -26,9 +26,38 @@ static SENSITIVE_PREFIXES: Lazy<Vec<&'static str>> = Lazy::new(|| {
     vec![".env.", "credentials."]
 });
 
-/// Return `true` if path matches a sensitive file pattern.
+/// Resolve a path for policy checks without requiring the final target to exist.
+///
+/// `canonicalize` handles normal existing paths and symlink chains. When the
+/// final target does not exist (for example, a write through `notes.txt ->
+/// .env`), follow the link entries manually so the sensitive target name is
+/// still checked.
+fn path_for_policy(path: &Path) -> PathBuf {
+    if let Ok(resolved) = std::fs::canonicalize(path) {
+        return resolved;
+    }
+
+    let mut candidate = path.to_path_buf();
+    for _ in 0..40 {
+        let Ok(target) = std::fs::read_link(&candidate) else {
+            break;
+        };
+        candidate = if target.is_absolute() {
+            target
+        } else {
+            candidate
+                .parent()
+                .unwrap_or_else(|| Path::new(""))
+                .join(target)
+        };
+    }
+    candidate
+}
+
+/// Return `true` if path or its resolved target matches a sensitive pattern.
 pub fn is_sensitive_file(path: &Path) -> bool {
-    let name = match path.file_name().and_then(|n| n.to_str()) {
+    let checked_path = path_for_policy(path);
+    let name = match checked_path.file_name().and_then(|n| n.to_str()) {
         Some(n) => n,
         None => return false,
     };
@@ -80,5 +109,40 @@ mod tests {
         assert!(!is_sensitive_file(Path::new("main.py")));
         assert!(!is_sensitive_file(Path::new("README.md")));
         assert!(!is_sensitive_file(Path::new("config.toml")));
+    }
+
+    #[test]
+    fn test_sensitive_symlink_alias() {
+        let dir = tempfile::tempdir().unwrap();
+        let sensitive = dir.path().join(".env");
+        std::fs::write(&sensitive, "SENSITIVE-SENTINEL").unwrap();
+        let alias = dir.path().join("notes.txt");
+
+        #[cfg(unix)]
+        let link_result = std::os::unix::fs::symlink(&sensitive, &alias);
+        #[cfg(windows)]
+        let link_result = std::os::windows::fs::symlink_file(&sensitive, &alias);
+        if link_result.is_err() {
+            return;
+        }
+
+        assert!(is_sensitive_file(&alias));
+    }
+
+    #[test]
+    fn test_sensitive_symlink_alias_to_missing_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let alias = dir.path().join("notes.txt");
+        let sensitive = dir.path().join(".env");
+
+        #[cfg(unix)]
+        let link_result = std::os::unix::fs::symlink(&sensitive, &alias);
+        #[cfg(windows)]
+        let link_result = std::os::windows::fs::symlink_file(&sensitive, &alias);
+        if link_result.is_err() {
+            return;
+        }
+
+        assert!(is_sensitive_file(&alias));
     }
 }

--- a/src/openjarvis/security/file_policy.py
+++ b/src/openjarvis/security/file_policy.py
@@ -30,17 +30,28 @@ DEFAULT_SENSITIVE_PATTERNS: frozenset[str] = frozenset(
 def is_sensitive_file(path: Union[str, Path]) -> bool:
     """Return ``True`` if *path* matches a sensitive file pattern.
 
-    Checks both the filename and the full name against
-    ``DEFAULT_SENSITIVE_PATTERNS`` using :func:`fnmatch.fnmatch`.
+    Checks both the filename and the full name of the resolved path against
+    ``DEFAULT_SENSITIVE_PATTERNS`` using :func:`fnmatch.fnmatch`. Resolving
+    existing paths prevents a harmless-looking symlink from bypassing the
+    policy for a sensitive target such as ``.env``.
     Uses the Rust implementation when available, falls back to Python.
     """
+    path_obj = Path(path)
+    try:
+        checked_path = path_obj.resolve(strict=False)
+    except (OSError, RuntimeError):
+        # Keep the original path for missing paths and symlink loops. The
+        # filesystem operation will report its own error if the path is not
+        # usable, while ordinary new files retain the existing policy.
+        checked_path = path_obj
+
     try:
         from openjarvis._rust_bridge import get_rust_module
 
         _rust = get_rust_module()
-        return _rust.is_sensitive_file(str(path))
+        return _rust.is_sensitive_file(str(checked_path))
     except ImportError:
-        return _is_sensitive_file_py(str(path))
+        return _is_sensitive_file_py(str(checked_path))
 
 
 def _is_sensitive_file_py(path_str: str) -> bool:

--- a/tests/security/test_file_policy.py
+++ b/tests/security/test_file_policy.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from openjarvis.security.file_policy import filter_sensitive_paths, is_sensitive_file
 
 
@@ -68,6 +70,29 @@ class TestIsSensitiveFile:
     def test_path_object(self) -> None:
         assert is_sensitive_file(Path("server.pem")) is True
         assert is_sensitive_file(Path("main.py")) is False
+
+    @pytest.mark.parametrize(
+        "sensitive_name", [".env", "credentials.json", "server.pem"]
+    )
+    def test_sensitive_symlink_alias(self, tmp_path: Path, sensitive_name: str) -> None:
+        sensitive = tmp_path / sensitive_name
+        sensitive.write_text("SENSITIVE-SENTINEL", encoding="utf-8")
+        alias = tmp_path / "notes.txt"
+        try:
+            alias.symlink_to(sensitive)
+        except OSError:
+            pytest.skip("filesystem does not permit creating symlinks")
+
+        assert is_sensitive_file(alias) is True
+
+    def test_sensitive_symlink_alias_to_missing_target(self, tmp_path: Path) -> None:
+        alias = tmp_path / "notes.txt"
+        try:
+            alias.symlink_to(tmp_path / ".env")
+        except OSError:
+            pytest.skip("filesystem does not permit creating symlinks")
+
+        assert is_sensitive_file(alias) is True
 
 
 class TestFilterSensitivePaths:

--- a/tests/tools/test_apply_patch.py
+++ b/tests/tools/test_apply_patch.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from openjarvis.tools.apply_patch import ApplyPatchTool
 
 
@@ -132,6 +134,24 @@ class TestApplyPatchTool:
         result = tool.execute(patch=patch, path=str(f))
         assert result.success is False
         assert "sensitive" in result.content.lower()
+
+    def test_blocks_symlink_alias_to_sensitive_file(self, tmp_path):
+        sensitive = tmp_path / ".env"
+        sensitive.write_text("SECRET=foo\n", encoding="utf-8")
+        alias = tmp_path / "notes.txt"
+        try:
+            alias.symlink_to(sensitive)
+        except OSError:
+            pytest.skip("filesystem does not permit creating symlinks")
+        patch = (
+            "--- a/notes.txt\n+++ b/notes.txt\n@@ -1 +1 @@\n-SECRET=foo\n+SECRET=bar\n"
+        )
+
+        result = ApplyPatchTool().execute(patch=patch, path=str(alias), backup=False)
+
+        assert result.success is False
+        assert "sensitive" in result.content.lower()
+        assert sensitive.read_text(encoding="utf-8") == "SECRET=foo\n"
 
     def test_auto_detect_path_from_patch_header(self, tmp_path):
         f = tmp_path / "auto.txt"

--- a/tests/tools/test_file_read.py
+++ b/tests/tools/test_file_read.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from openjarvis.tools.file_read import FileReadTool
 
 
@@ -84,6 +86,20 @@ class TestFileReadTool:
         f.write_text('{"token": "abc"}', encoding="utf-8")
         tool = FileReadTool()
         result = tool.execute(path=str(f))
+        assert result.success is False
+        assert "sensitive" in result.content.lower()
+
+    def test_blocks_symlink_alias_to_sensitive_file(self, tmp_path):
+        sensitive = tmp_path / ".env"
+        sensitive.write_text("SECRET=foo", encoding="utf-8")
+        alias = tmp_path / "notes.txt"
+        try:
+            alias.symlink_to(sensitive)
+        except OSError:
+            pytest.skip("filesystem does not permit creating symlinks")
+
+        result = FileReadTool().execute(path=str(alias))
+
         assert result.success is False
         assert "sensitive" in result.content.lower()
 

--- a/tests/tools/test_file_write.py
+++ b/tests/tools/test_file_write.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from openjarvis.tools.file_write import FileWriteTool
 
 
@@ -82,6 +84,21 @@ class TestFileWriteTool:
         result = tool.execute(path=str(f), content='{"token": "abc"}')
         assert result.success is False
         assert "sensitive" in result.content.lower()
+
+    def test_blocks_symlink_alias_to_sensitive_file(self, tmp_path):
+        sensitive = tmp_path / ".env"
+        sensitive.write_text("SECRET=foo", encoding="utf-8")
+        alias = tmp_path / "notes.txt"
+        try:
+            alias.symlink_to(sensitive)
+        except OSError:
+            pytest.skip("filesystem does not permit creating symlinks")
+
+        result = FileWriteTool().execute(path=str(alias), content="SECRET=bar")
+
+        assert result.success is False
+        assert "sensitive" in result.content.lower()
+        assert sensitive.read_text(encoding="utf-8") == "SECRET=foo"
 
     def test_allowed_dirs_blocks(self, tmp_path):
         f = tmp_path / "test.txt"


### PR DESCRIPTION
Fixes #962

## Summary

- Prevent sensitive-file checks from being bypassed by a harmless-looking symlink alias such as `notes.txt -> .env`.
- Resolve paths before applying the shared policy in both the Python fallback and the Rust implementation, including links to targets that do not exist yet.
- Keep ordinary files, normal new-file writes, and the existing capability/allowlist controls unchanged.

## Changes by area

| Area | What changed | Verification |
| --- | --- | --- |
| Security policy | `is_sensitive_file` checks the resolved target path; the Rust policy follows existing links and handles a missing final target without reading file contents. | Policy regression tests cover `.env`, `credentials.json`, and `.pem` aliases, including a missing `.env` target. |
| Filesystem tools | `file_read`, `file_write`, and `apply_patch` now share the corrected policy, so aliases cannot read, overwrite, or patch protected files. | Tool regressions verify rejection and preservation of the sensitive target; the focused Python suite passes. |
| Compatibility | Non-sensitive regular paths and existing directory allowlists retain their behavior; no new dependency or public API is added. | Existing policy and tool tests remain green. |

## Test plan

- [x] Focused Python policy/tool tests: `tests/security/test_file_policy.py`, `tests/tools/test_file_read.py`, `tests/tools/test_file_write.py`, `tests/tools/test_apply_patch.py` — `72 passed`
- [x] Rust security tests: `CARGO_NET_OFFLINE=true cargo test -p openjarvis-security` — `56 passed`
- [x] Rust lint: `CARGO_NET_OFFLINE=true cargo clippy -p openjarvis-security --all-targets -- -D warnings`
- [x] Ruff check and format check on changed Python files.
- [x] Python compilation check for changed Python files.
- [x] `git diff --check`
- [x] GitHub Actions `test` job — repository Python test workflow passed.
- [x] GitHub Actions `test-windows (3.12)` and `test-windows (3.13)` jobs passed.
- [x] GitHub Actions `lint`, `rust`, and `build` jobs passed.
- [ ] Repository-wide local suite: `uv run pytest tests/ -v` (not run because `uv` is not installed in this checkout).

## Remaining validation

- All required GitHub Actions jobs passed: Linux test, Windows 3.12/3.13, lint, Rust, and build. The `deploy` job is skipped by workflow configuration.
- The exact local `uv run pytest tests/ -v` command was not run because `uv` is unavailable in this checkout; the repository test workflow completed successfully on Linux and Windows.
- The symlink cases intentionally skip on hosts where creating symlinks requires an OS privilege; the policy remains fail-closed whenever a link can be inspected.

## Compatibility / Not changed

- Direct sensitive paths continue to be blocked, and ordinary non-sensitive paths continue to work.
- `allowed_dirs` behavior is unchanged; resolving links strengthens the sensitive-name check independently of directory restrictions.
- No new dependencies, public API changes, storage changes, or server changes are introduced.
- This shared file-policy fix is separate from the imported-skill copy-boundary fix in #960.
