### PR TITLE
fix(security): validate web search redirect targets

### DIFF
--- a/src/openjarvis/tools/web_search.py
+++ b/src/openjarvis/tools/web_search.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import logging
 import os
 from typing import Any
+from urllib.parse import urljoin
 
 from openjarvis import __version__
 from openjarvis.core.registry import ToolRegistry
@@ -37,6 +38,8 @@ YOUCOM_API_KEY_ENV = "YOUDOTCOM_API_KEY"
 
 ENGINE_ENV = "OPENJARVIS_WEB_SEARCH_ENGINE"
 ENGINES = ("auto", "youcom", "tavily", "duckduckgo")
+_MAX_FETCH_REDIRECTS = 5
+_REDIRECT_STATUS_CODES = frozenset({301, 302, 303, 307, 308})
 
 # Identifies OpenJarvis to You.com. The keyless tier carries no API key, so the
 # User-Agent is the only attribution signal; sent to You.com hosts only.
@@ -173,24 +176,37 @@ class WebSearchTool(BaseTool):
 
     @staticmethod
     def _fetch_url(url: str, max_chars: int = 6000) -> str:
-        """Fetch a URL and return extracted text content."""
+        """Fetch a URL and return extracted text after checking each redirect."""
         import re as _re
 
         import httpx
 
         url = WebSearchTool._normalize_url(url)
-        ssrf_error = check_ssrf(url)
-        if ssrf_error:
-            raise ValueError(ssrf_error)
-        resp = httpx.get(
-            url.strip(),
-            follow_redirects=True,
-            timeout=30.0,
-            headers={
-                "User-Agent": "Mozilla/5.0 (compatible; OpenJarvis/1.0; +https://github.com/openjarvis)"
-            },
-        )
-        resp.raise_for_status()
+        current_url = url.strip()
+        for _ in range(_MAX_FETCH_REDIRECTS + 1):
+            ssrf_error = check_ssrf(current_url)
+            if ssrf_error:
+                raise ValueError(ssrf_error)
+            resp = httpx.get(
+                current_url,
+                follow_redirects=False,
+                timeout=30.0,
+                headers={
+                    "User-Agent": "Mozilla/5.0 (compatible; OpenJarvis/1.0; +https://github.com/openjarvis)"
+                },
+            )
+            if resp.status_code not in _REDIRECT_STATUS_CODES:
+                resp.raise_for_status()
+                break
+            location = resp.headers.get("location", "")
+            if not location:
+                resp.raise_for_status()
+                break
+            current_url = urljoin(str(resp.url), location)
+        else:
+            raise ValueError(
+                f"URL exceeded the maximum of {_MAX_FETCH_REDIRECTS} redirects"
+            )
         content_type = resp.headers.get("content-type", "")
         if "application/pdf" in content_type:
             return (

--- a/tests/tools/test_web_search.py
+++ b/tests/tools/test_web_search.py
@@ -532,6 +532,95 @@ class TestExecuteWithUrl:
         assert result.success is False
         assert "Failed to fetch URL" in result.content
 
+    def test_url_redirect_to_private_ip_is_blocked(self, monkeypatch):
+        """Every URL redirect hop must be checked for SSRF."""
+        import httpx
+
+        import openjarvis.tools.web_search as _ws
+
+        requests = []
+
+        def handler(request):
+            requests.append(str(request.url))
+            if request.url.host == "public.example.com":
+                return httpx.Response(
+                    302,
+                    headers={"location": "http://127.0.0.1/admin"},
+                    request=request,
+                )
+            return httpx.Response(
+                200,
+                text="internal response",
+                headers={"content-type": "text/html"},
+                request=request,
+            )
+
+        guard = MagicMock(
+            side_effect=[None, None, "URL resolves to private IP: 127.0.0.1"]
+        )
+        with httpx.Client(
+            transport=httpx.MockTransport(handler), follow_redirects=True
+        ) as client:
+            monkeypatch.setattr(httpx, "get", client.get)
+            monkeypatch.setattr(_ws, "check_ssrf", guard)
+            result = WebSearchTool(engine="youcom").execute(
+                query="https://public.example.com/start"
+            )
+
+        assert result.success is False
+        assert "127.0.0.1" in result.content
+        assert requests == ["https://public.example.com/start"]
+        assert [call.args[0] for call in guard.call_args_list] == [
+            "https://public.example.com/start",
+            "https://public.example.com/start",
+            "http://127.0.0.1/admin",
+        ]
+
+    def test_url_public_redirect_is_followed_after_ssrf_check(self, monkeypatch):
+        """Public relative redirects still work when checked hop by hop."""
+        import httpx
+
+        import openjarvis.tools.web_search as _ws
+
+        requests = []
+
+        def handler(request):
+            requests.append(str(request.url))
+            if request.url.path == "/start":
+                return httpx.Response(
+                    302,
+                    headers={"location": "/article"},
+                    request=request,
+                )
+            return httpx.Response(
+                200,
+                text="public article",
+                headers={"content-type": "text/html"},
+                request=request,
+            )
+
+        guard = MagicMock(return_value=None)
+        with httpx.Client(
+            transport=httpx.MockTransport(handler), follow_redirects=True
+        ) as client:
+            monkeypatch.setattr(httpx, "get", client.get)
+            monkeypatch.setattr(_ws, "check_ssrf", guard)
+            result = WebSearchTool(engine="youcom").execute(
+                query="https://public.example.com/start"
+            )
+
+        assert result.success is True
+        assert result.content == "public article"
+        assert requests == [
+            "https://public.example.com/start",
+            "https://public.example.com/article",
+        ]
+        assert [call.args[0] for call in guard.call_args_list] == [
+            "https://public.example.com/start",
+            "https://public.example.com/start",
+            "https://public.example.com/article",
+        ]
+
 
 # ---------------------------------------------------------------------------
 # Engine selection and the You.com engine (#923)


### PR DESCRIPTION
Fixes #965

## Summary

- `web_search` no longer lets HTTPX follow URL redirects without inspection.
- Every redirect target is checked by the existing SSRF guard before the next request is sent.
- Public relative redirects remain supported, while loopback, private-network, and metadata targets are rejected.

## Changes by area

| Area | What changed | Verification |
| --- | --- | --- |
| URL fetching | Follow redirects manually, resolve relative `Location` values, cap the chain at five redirects, and check every hop. | `TestExecuteWithUrl::test_url_redirect_to_private_ip_is_blocked` and `test_url_public_redirect_is_followed_after_ssrf_check`; covered by the full Python CI job. |
| SSRF boundary | A public page can no longer bounce URL fetching into an internal address before content extraction. | MockTransport proves the private target is checked before a request is sent. |
| Compatibility | Existing PDF normalization, HTML extraction, truncation, and public URL behavior are unchanged. | Existing `tests/tools/test_web_search.py` cases remain green apart from local environment limitations listed below. |

## Test plan

- [x] Targeted redirect regression tests — `2 passed`
- [x] `ruff check src/openjarvis/tools/web_search.py tests/tools/test_web_search.py`
- [x] `ruff format --check src/openjarvis/tools/web_search.py tests/tools/test_web_search.py`
- [x] `git diff --check`
- [x] GitHub Actions Python suite — `8593 passed, 62 skipped` (289 warnings)
- [x] GitHub Actions Windows Python 3.12 — `30 passed, 2 skipped`
- [x] GitHub Actions Windows Python 3.13 — `30 passed, 2 skipped`
- [x] GitHub Actions `lint`, `build`, and `rust` jobs — passed

## Remaining validation

- The required GitHub Actions jobs are green. The `deploy` job was skipped by its workflow conditions, as expected for this fork PR.
- The full local `tests/tools/test_web_search.py` run produced `58 passed, 3 failed`. The failures are environment-limited: this checkout does not have the optional `ddgs` fallback package, and the file's manual registry-registration test conflicts with the decorator registration when run in this isolated invocation. GitHub CI ran the complete suite successfully.
- `uv` is not installed in the local environment, so `uv run pytest tests/ -v` was not available here.

## Compatibility / Not changed

- The existing `check_ssrf` implementation and its private-IP policy are unchanged.
- Search engines, You.com/Tavily fallback behavior, PDF URL normalization, response extraction, and public redirects remain available.
- No dependencies, public APIs, server endpoints, or credential handling were changed.
- `HttpRequestTool`'s existing manual redirect protection is unchanged; this PR brings direct URL fetching in `web_search` to the same checked-hop behavior.
