### PR TITLE
fix(cli): avoid premature daemon PID registration

### DIFF
--- a/src/openjarvis/cli/daemon_cmd.py
+++ b/src/openjarvis/cli/daemon_cmd.py
@@ -230,11 +230,6 @@ def start(
         stderr=log_fh,
         **spawn_kwargs,
     )
-    try:
-        _write_pid(proc.pid, bind_host, bind_port, ready=False)
-    except RuntimeError as exc:
-        terminate_process(proc.pid, grace_seconds=10.0)
-        raise click.ClickException(str(exc)) from exc
 
     console.print(
         f"[green]OpenJarvis server starting[/green] (PID {proc.pid})\n"

--- a/tests/cli/test_daemon_cmd.py
+++ b/tests/cli/test_daemon_cmd.py
@@ -166,6 +166,22 @@ class TestDaemonDetachment:
             assert spawns, f"start did not spawn the server: {popen.call_args_list}"
             return spawns[-1].kwargs
 
+    def test_start_does_not_register_parent_pid(self) -> None:
+        """``jarvis start`` must let the spawned server register its own PID."""
+        with (
+            patch("openjarvis.cli.daemon_cmd._read_pid", return_value=None),
+            patch("openjarvis.cli.daemon_cmd.load_config"),
+            patch("openjarvis.cli.daemon_cmd.subprocess.Popen") as popen,
+            patch("builtins.open", MagicMock()),
+            patch("openjarvis.cli.daemon_cmd._write_pid") as write_pid,
+        ):
+            popen.return_value = MagicMock(pid=4321)
+
+            result = CliRunner().invoke(cli, ["start"])
+
+            assert result.exit_code == 0, result.output
+            write_pid.assert_not_called()
+
     def test_windows_spawn_is_detached_from_the_console(self) -> None:
         # These constants are only exported by ``subprocess`` on Windows.
         # Supply their documented values so the simulated Windows branch is


### PR DESCRIPTION
## What does this PR do?

Fix a race condition during daemon startup where the CLI registers the parent process PID before the spawned server has completed startup.

This could cause `jarvis start` to incorrectly report that another server was already running, particularly on Windows.

The fix removes the premature PID registration from the CLI and lets the server register its own PID after successful startup.

A regression test was added to ensure the CLI does not register the parent PID during the initial spawn.

## How was this tested?

- `tests/cli/test_daemon_cmd.py` — 15 passed
- `tests/cli/test_daemon_state.py` + `tests/server/test_daemon_lifecycle.py` — 22 passed
- Manual Windows validation:
  - `jarvis start` starts successfully
  - `jarvis status` reports the actual server PID after startup
  - A subsequent `jarvis start` correctly reports that the server is already running
- `uv run ruff check src/ tests/` — passed
- `uv run ruff format --check src/ tests/` — passed

The full test suite was also executed on Windows. It completed with 8,325 passed, 109 skipped, 239 failed, and 4 errors. The failures are predominantly environment/platform-dependent (including missing native `openjarvis_rust`, POSIX-only APIs, permissions, and optional live integrations) and are outside the scope of this change.

## Checklist

- [ ] Tests pass (`uv run pytest tests/ -v`)
- [x] Linter passes (`uv run ruff check src/ tests/`)
- [x] Formatter passes (`uv run ruff format --check src/ tests/`)
- [ ] New/changed public API has docstrings
- [ ] Follows registry pattern (if adding new component)
- [ ] Documentation updated (if applicable)