### PR TITLE
docs: document hardware recommendations for jarvis init

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -234,6 +234,98 @@ See the [Python SDK guide](../user-guide/python-sdk.md) for the full API referen
 
 ---
 
+## Hardware
+
+OpenJarvis has no special hardware requirements of its own — the CLI, server, and
+SDK run anywhere the software [Requirements](#requirements) below are met. What
+your hardware determines is which **local model** you can run comfortably, and you
+do not have to work that out yourself: `jarvis init` detects your CPU, RAM, and GPU,
+then writes a config with a matching inference engine and default model.
+
+```bash
+jarvis init          # detect hardware, write a matching config
+```
+
+### Recommended configurations
+
+| System RAM | GPU VRAM | Default model | Download |
+|------------|----------|---------------|----------|
+| 8 GB | Up to 8 GB | `qwen3.5:2b` | ~1.1 GB |
+| 16 GB | 12–16 GB | `qwen3.5:4b` | ~2.2 GB |
+| 32 GB | 24–32 GB | `qwen3.5:9b` | ~5.0 GB |
+| 64 GB or more | 48 GB or more | `qwen3.5:27b` | ~14.9 GB |
+
+The GPU and RAM columns are alternatives, not requirements to satisfy together —
+when a GPU with usable VRAM is detected the model is sized against VRAM, otherwise
+against system RAM.
+
+### How the model is chosen
+
+`jarvis init` first computes usable memory:
+
+| Detected | Usable memory |
+|----------|---------------|
+| GPU reporting VRAM | `VRAM × GPU count × 0.9` |
+| No GPU, or VRAM unavailable | `(total RAM − 4 GB) × 0.8` |
+
+That figure then selects the first tier it fits:
+
+| Usable memory | Model |
+|---------------|-------|
+| Up to 8 GB | `qwen3.5:2b` |
+| Up to 16 GB | `qwen3.5:4b` |
+| Up to 32 GB | `qwen3.5:9b` |
+| More than 32 GB | `qwen3.5:27b` |
+
+All four are Qwen3.5 MoE models, which activate only a fraction of their parameters
+per token — a 27B model activates 3B — so quality per gigabyte is better than a
+dense model of the same size.
+
+### Inference engine
+
+The detected GPU vendor selects the engine:
+
+| Detected GPU | Engine |
+|--------------|--------|
+| None | `llamacpp` |
+| Apple Silicon | `mlx` |
+| NVIDIA consumer (GeForce, RTX) | `ollama` |
+| NVIDIA datacenter (A100, H100, H200, L40, A10, A30) | `vllm` |
+| AMD consumer (Radeon) | `lemonade` |
+| AMD datacenter (MI300, MI325, MI350, MI355) | `vllm` |
+
+See [Setting Up an Inference Backend](#setting-up-an-inference-backend) for
+installing the engine `jarvis init` picks.
+
+### Minimum
+
+There is no enforced CPU minimum — any x86-64 or ARM64 processor supported by your
+Python build will run OpenJarvis, and core count affects CPU-only inference speed
+rather than whether a model loads.
+
+Memory is the real floor. With 4 GB of RAM or less and no GPU, usable memory
+computes to zero and no local model is recommended.
+
+!!! tip "Low-memory and headless machines"
+    You do not need a local model at all. Point OpenJarvis at a hosted API with the
+    [cloud quick-path](install.md#cloud-quick-path) and the hardware tiers above
+    stop applying.
+
+### Storage
+
+Model weights dominate disk usage — between ~1.1 GB and ~14.9 GB for the defaults
+above. Budget additional space for the Python environment and whichever inference
+engine you install.
+
+!!! note "Overriding the detected defaults"
+    These are defaults, not limits. The generated config records what was detected
+    in a comment at the top of the file, and `default_model` under `[intelligence]`
+    in `~/.openjarvis/config.toml` can be set to anything larger or smaller — see
+    the [Configuration guide](configuration.md). Re-run `jarvis init --force` to
+    re-detect and overwrite an existing config.
+
+---
+
 ## Requirements
 
 | Requirement | Version | Install | Notes |

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -248,16 +248,16 @@ jarvis init          # detect hardware, write a matching config
 
 ### Recommended configurations
 
-| System RAM | GPU VRAM | Default model | Download |
-|------------|----------|---------------|----------|
-| 8 GB | Up to 8 GB | `qwen3.5:2b` | ~1.1 GB |
-| 16 GB | 12–16 GB | `qwen3.5:4b` | ~2.2 GB |
-| 32 GB | 24–32 GB | `qwen3.5:9b` | ~5.0 GB |
-| 64 GB or more | 48 GB or more | `qwen3.5:27b` | ~14.9 GB |
+| System RAM (no GPU) | GPU VRAM | Default model | Download |
+|---------------------|----------|---------------|----------|
+| 5–14 GB | Up to 8 GB | `qwen3.5:2b` | ~1.1 GB |
+| 15–24 GB | 9–17 GB | `qwen3.5:4b` | ~2.2 GB |
+| 25–44 GB | 18–35 GB | `qwen3.5:9b` | ~5.0 GB |
+| 45 GB or more | 36 GB or more | `qwen3.5:27b` | ~14.9 GB |
 
-The GPU and RAM columns are alternatives, not requirements to satisfy together —
-when a GPU with usable VRAM is detected the model is sized against VRAM, otherwise
-against system RAM.
+The two memory columns are alternatives, not requirements to satisfy together: when
+a GPU reporting VRAM is detected the model is sized against VRAM, otherwise against
+system RAM.
 
 ### How the model is chosen
 


### PR DESCRIPTION
## Where this came from

Discussion #732 asked for minimum and recommended hardware, CPU/GPU/RAM/storage, before installing. That became #900.

## The problem

There's no hardware guidance anywhere in `docs/`. Grepping for minimum/recommended CPU/RAM/GPU/storage returns nothing under Getting Started, and the installation guide's `## Requirements` table stops at software: Python, uv, Git, Rust, a backend, Node.

The code already answers the question. `jarvis init` calls `detect_hardware()`, and `recommend_engine()` and `recommend_model()` size an engine and a default model against usable memory. None of it was written down, so the answer only existed in the source.

## What's in here

A `## Hardware` section in `docs/getting-started/installation.md`, immediately before the existing `## Requirements`. No heading or anchor changes, so inbound links keep working. It covers:

- the RAM and VRAM bands, and the model `jarvis init` picks for each
- how usable memory is computed (`vram_gb * count * 0.9`, or `(ram_gb - 4) * 0.8`), and which tier that selects
- the GPU vendor to engine mapping, including the datacenter card cases
- the floor at 4 GB, where usable memory computes to zero and no local model is recommended
- model download sizes

Every figure comes from `_available_memory_gb()`, `_MODEL_TIERS`, `recommend_engine()` and `estimated_download_gb()` in `openjarvis/core/config.py`, generated by running that code rather than working the arithmetic out by hand.

The bands are continuous rather than a list of common configurations (8/16/32/64 GB), which would have left someone with 20 GB of VRAM unable to find their row.

## On scope

Docs only. No behaviour changes. No new page, and `mkdocs.yml` is untouched.

Two code bugs surfaced while deriving the tiers. Both are left alone here and filed separately:

- `jarvis init --engine lmstudio|exo|nexa` reports "Not enough memory to run any local model" on any machine, however large. All three are registered in `EngineRegistry`, but no catalog entry lists them in `supported_engines`, so `recommend_model()` returns `""` and `init_cmd` reads that as a memory failure.
- For consumer AMD GPUs, `recommend_engine()` returns `lemonade` and `recommend_model()` returns the hardcoded `Qwen3.6-35B-A3B-GGUF`, which isn't in the catalog. `find_model_spec()` returns `None`, so the size prints as `~0.0 GB` and the download prompt is skipped silently.

Documenting current behaviour in those two paths would mean writing down a bug.

## Validation

Boundaries were generated, not hand-derived. `recommend_model()` and `recommend_engine()` ran across a RAM sweep (0 to 120 GB) and a VRAM sweep (0 to 90 GB), then again at integer granularity to confirm each band is continuous and correctly bounded.

- They agree with `tests/core/test_recommend_model.py`: 8 GB → 2b, 16 GB → 4b, 32 GB → 9b, 64 GB → 27b.
- Real hardware (Windows 11, 15.4 GB RAM, RTX 5070 Ti Laptop, 11.9 GB VRAM) yields `ollama` and `qwen3.5:4b`, the 9-17 GB band.
- `uv run mkdocs build` built in 98.36 seconds with no warning referencing `installation.md`; all four new links resolve.
- `uv run pytest tests/core/test_recommend_model.py tests/hardware/ -q`: 62 passed, 2 skipped.
- `ruff check` and `ruff format --check` clean across 1,383 files.

The full suite wasn't run; this change touches no Python.

## Open question

The tables restate constants from `_MODEL_TIERS` and `recommend_engine()`, so they can drift when a tier or a datacenter card keyword changes. Generating the section from `core/config.py` at docs build time would make that impossible. Happy to switch, split the bands differently, or move the section after `## Requirements` instead of before it.

Fixes #900
