### PR TITLE
fix(security): hard-gate cloud engine behind intelligence.allow_cloud

### DIFF
--- a/configs/openjarvis/prompts/jarvis-constitution.md
+++ b/configs/openjarvis/prompts/jarvis-constitution.md
@@ -1,0 +1,37 @@
+# Jarvis-Konstitution
+
+Einzige Quelle für Ton, Verhalten und Autonomie-Grenzen über alle Kanäle (Telegram, apex, openjarvis-Desktop). Wird nicht automatisch überschrieben — Änderungen laufen über denselben Dev-Workflow wie jede andere Code-Änderung (PR, Review durch den Self-Audit, Merge nach "go" vom User).
+
+## Ton
+
+- Direkt, keine Beruhigungswörter, kein Smalltalk.
+- Ergebnisse und Entscheidungen zuerst nennen, nicht drumherum reden.
+- Persönlichkeit ist erlaubt und erwünscht — langweilig ist das eine, was nicht toleriert wird.
+- Bei Unsicherheit: optimistisch ausprobieren statt lange abwägen — solange das Geschäft dabei nicht gefährdet wird.
+
+## Autonomie — Code/Dev-Arbeit
+
+Komplett autonom, keine Rückfrage nötig:
+- Bugfixes, Features, Refactors, Tests, Dokumentation.
+- Branch → Code → Test → PR → Merge → Staging-Deploy, für Projekte mit `autonomous_merge: true` (aktuell: openjarvis, apex).
+- Nach Abschluss: kurze, faktische Rückmeldung im Kanal, in dem die Anfrage kam. Kein "soll ich?", sondern "ist erledigt, hier das Ergebnis."
+
+## Autonomie — Grenzen (Rücksprache statt Alleingang)
+
+Diese Fälle bekommen eine konkrete Empfehlung als Vorschlag, keine offene Frage:
+- Ändert trading-bot Risiko-Gate- oder Live-Trading-Logik (Pfade `risk/`, `execution/`, `src/trading_bot/orders/`).
+- Deploy-Ziel = sugar-rush Produktion/houston, oder kundensichtbare/preis-/checkout-relevante Änderung.
+- Echter Geldfluss: neues kostenpflichtiges Abo, Infra-Ausgabe über einem spürbaren Schwellwert.
+- Anforderung ist inhaltlich mehrdeutig (nicht technisch, sondern "was genau ist gemeint" unklar).
+
+Format der Rücksprache: "X ändern für Y — Empfehlung: Z, weil W. Sag 'go' oder ich lass es." Nie eine offene Frage ohne eigenen Vorschlag.
+
+## Was nicht passiert
+
+- Kein Zugriff auf houston-Prod durch Agenten (unabhängig von `autonomous_merge`).
+- Keine Merge-Rechte für LLM-gesteuerte Sessions (Lead-Agent) — Merge läuft ausschließlich über den deterministischen Orchestrator-Prozess.
+- Kein automatisches Überschreiben dieser Datei — nur nach explizitem "go" des Users, umgesetzt über den normalen Dev-Workflow.
+
+## Selbstprüfung
+
+Ein täglicher Job liest die letzten 24h Aktivität und prüft sie gegen diese Regeln (wurde bei Trivialem unnötig nachgefragt? war der Ton direkt? wurde eine Grenzfall-Aktion ohne Rücksprache durchgeführt?). Bei Abweichung: Telegram-Nachricht mit konkretem Fund + Vorschlag zur Nachschärfung — nie eine stille Selbstkorrektur.

--- a/deploy/systemd/openjarvis-audit.service
+++ b/deploy/systemd/openjarvis-audit.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=OpenJarvis daily behavior-compliance self-audit
+After=network.target openjarvis.service
+
+[Service]
+Type=oneshot
+User=cynar
+Group=cynar
+WorkingDirectory=/srv/openjarvis
+ExecStart=/srv/openjarvis/.venv/bin/jarvis audit run
+Environment=HOME=/home/cynar
+EnvironmentFile=-/etc/openjarvis/env
+NoNewPrivileges=true

--- a/deploy/systemd/openjarvis-audit.timer
+++ b/deploy/systemd/openjarvis-audit.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Run the OpenJarvis self-audit daily at 03:00
+
+[Timer]
+OnCalendar=*-*-* 03:00:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/openjarvis-backup.service
+++ b/deploy/systemd/openjarvis-backup.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=OpenJarvis runtime-state + repo backup
+[Service]
+Type=oneshot
+User=cynar
+Environment=PATH=/home/cynar/.local/bin:/usr/local/bin:/usr/bin:/bin
+ExecStart=/usr/bin/bash /srv/openjarvis/scripts/backup-local.sh

--- a/deploy/systemd/openjarvis-backup.timer
+++ b/deploy/systemd/openjarvis-backup.timer
@@ -1,0 +1,7 @@
+[Unit]
+Description=OpenJarvis backup every 6 hours
+[Timer]
+OnBootSec=10min
+OnUnitActiveSec=6h
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/openjarvis-deploy.service
+++ b/deploy/systemd/openjarvis-deploy.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=OpenJarvis auto-deploy from origin/main
+[Service]
+Type=oneshot
+User=cynar
+Environment=PATH=/home/cynar/.local/bin:/usr/local/bin:/usr/bin:/bin
+Environment=OPENJARVIS_DEPLOY_LOG=/tmp/openjarvis-deploy.log
+ExecStart=/usr/bin/bash /srv/openjarvis/scripts/deploy-local.sh

--- a/deploy/systemd/openjarvis-deploy.timer
+++ b/deploy/systemd/openjarvis-deploy.timer
@@ -1,0 +1,7 @@
+[Unit]
+Description=OpenJarvis auto-deploy every 2 minutes
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=2min
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/openjarvis-knowledge-refresh.service
+++ b/deploy/systemd/openjarvis-knowledge-refresh.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=OpenJarvis cross-project knowledge refresh
+After=network.target
+
+[Service]
+Type=oneshot
+User=openjarvis
+WorkingDirectory=/opt/openjarvis
+ExecStart=/opt/openjarvis/.venv/bin/jarvis knowledge refresh --all
+Environment=HOME=/opt/openjarvis
+EnvironmentFile=-/etc/openjarvis/env
+
+NoNewPrivileges=true
+ProtectSystem=strict
+ReadWritePaths=/opt/openjarvis
+ProtectHome=true
+PrivateTmp=true
+ProtectControlGroups=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+LockPersonality=true

--- a/deploy/systemd/openjarvis-knowledge-refresh.timer
+++ b/deploy/systemd/openjarvis-knowledge-refresh.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run OpenJarvis cross-project knowledge refresh every 20 minutes
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=20min
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/frontend/src/components/Chat/ChatArea.tsx
+++ b/frontend/src/components/Chat/ChatArea.tsx
@@ -5,6 +5,7 @@ import { InputArea } from './InputArea';
 import { StreamingDots } from './StreamingDots';
 import { useAppStore } from '../../lib/store';
 import { Sparkles, PanelRightOpen, PanelRightClose, Database, MessageSquare, X } from 'lucide-react';
+import { ReactiveOrb } from './ReactiveOrb';
 import { listConnectors } from '../../lib/connectors-api';
 
 function getGreeting(): string {
@@ -123,11 +124,8 @@ export function ChatArea() {
       >
         {isEmpty ? (
           <div className="flex flex-col items-center justify-center h-full px-4">
-            <div
-              className="w-12 h-12 rounded-2xl flex items-center justify-center mb-4"
-              style={{ background: 'var(--color-accent-subtle)', color: 'var(--color-accent)' }}
-            >
-              <Sparkles size={24} />
+            <div className="mb-6">
+              <ReactiveOrb size={112} />
             </div>
             <h2 className="text-xl font-semibold mb-2" style={{ color: 'var(--color-text)' }}>
               {getGreeting()}

--- a/frontend/src/components/Chat/ReactiveOrb.tsx
+++ b/frontend/src/components/Chat/ReactiveOrb.tsx
@@ -1,0 +1,118 @@
+import { motion } from 'motion/react';
+
+export type OrbState = 'idle' | 'thinking';
+
+interface ReactiveOrbProps {
+  state?: OrbState;
+  size?: number;
+}
+
+/**
+ * JARVIS-style reactive core.
+ *
+ * Pure CSS/SVG + motion — no WebGL — so it's cheap to render and safe to
+ * ship everywhere the greeting screen shows up (including low-power
+ * Tauri desktop builds). Reuses the existing HUD design tokens
+ * (--color-accent, --color-accent-purple) so it tracks light/dark theme
+ * and the OpenJarvis palette automatically.
+ */
+export function ReactiveOrb({ state = 'idle', size = 112 }: ReactiveOrbProps) {
+  const isThinking = state === 'thinking';
+
+  return (
+    <div
+      className="relative shrink-0"
+      style={{ width: size, height: size }}
+      aria-hidden="true"
+    >
+      {/* Outer dashed reticle ring — slow constant rotation, speeds up when thinking */}
+      <motion.div
+        className="absolute inset-0 rounded-full"
+        style={{ border: '1px dashed color-mix(in srgb, var(--color-accent) 55%, transparent)' }}
+        animate={{ rotate: 360 }}
+        transition={{ repeat: Infinity, ease: 'linear', duration: isThinking ? 5 : 14 }}
+      />
+
+      {/* Middle ring — counter-rotates, tick marks via conic gradient */}
+      <motion.div
+        className="absolute rounded-full"
+        style={{
+          inset: size * 0.1,
+          background:
+            'conic-gradient(from 0deg, color-mix(in srgb, var(--color-accent) 60%, transparent) 0deg, transparent 12deg, transparent 78deg, color-mix(in srgb, var(--color-accent) 60%, transparent) 90deg, transparent 102deg, transparent 168deg, color-mix(in srgb, var(--color-accent) 60%, transparent) 180deg, transparent 192deg, transparent 258deg, color-mix(in srgb, var(--color-accent) 60%, transparent) 270deg, transparent 282deg, transparent 348deg)',
+          WebkitMaskImage: 'radial-gradient(closest-side, transparent calc(100% - 2px), black calc(100% - 1.5px))',
+          maskImage: 'radial-gradient(closest-side, transparent calc(100% - 2px), black calc(100% - 1.5px))',
+          opacity: 0.8,
+        }}
+        animate={{ rotate: -360 }}
+        transition={{ repeat: Infinity, ease: 'linear', duration: isThinking ? 8 : 22 }}
+      />
+
+      {/* Orbiting satellite dots — only visible while thinking */}
+      {isThinking &&
+        [0, 120, 240].map((offset) => (
+          <motion.div
+            key={offset}
+            className="absolute rounded-full"
+            style={{
+              inset: size * 0.02,
+              transformOrigin: 'center',
+            }}
+            animate={{ rotate: offset + 360 }}
+            transition={{ repeat: Infinity, ease: 'linear', duration: 2.4 }}
+          >
+            <span
+              className="absolute rounded-full"
+              style={{
+                top: 0,
+                left: '50%',
+                width: 4,
+                height: 4,
+                background: 'var(--color-accent)',
+                boxShadow: '0 0 6px 1px var(--color-accent-glow)',
+                transform: 'translateX(-50%)',
+              }}
+            />
+          </motion.div>
+        ))}
+
+      {/* Breathing glow core */}
+      <motion.div
+        className="absolute rounded-full"
+        style={{
+          inset: size * 0.28,
+          background:
+            'radial-gradient(circle at 35% 30%, color-mix(in srgb, var(--color-accent) 85%, white), var(--color-accent) 55%, color-mix(in srgb, var(--color-accent) 40%, transparent) 100%)',
+        }}
+        animate={{
+          scale: isThinking ? [1, 1.12, 1] : [1, 1.04, 1],
+          boxShadow: isThinking
+            ? [
+                '0 0 16px 2px var(--color-accent-glow)',
+                '0 0 34px 10px var(--color-accent-glow)',
+                '0 0 16px 2px var(--color-accent-glow)',
+              ]
+            : [
+                '0 0 10px 1px var(--color-accent-glow)',
+                '0 0 18px 4px var(--color-accent-glow)',
+                '0 0 10px 1px var(--color-accent-glow)',
+              ],
+        }}
+        transition={{
+          repeat: Infinity,
+          ease: 'easeInOut',
+          duration: isThinking ? 1.3 : 2.8,
+        }}
+      />
+
+      {/* Core specular highlight */}
+      <div
+        className="absolute rounded-full pointer-events-none"
+        style={{
+          inset: size * 0.28,
+          background: 'radial-gradient(circle at 32% 26%, rgba(255,255,255,0.55), transparent 42%)',
+        }}
+      />
+    </div>
+  );
+}

--- a/scripts/backup-local.sh
+++ b/scripts/backup-local.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# openjarvis backup-local — periodic safety net for the self-improvement loop.
+# Snapshots runtime state (config.toml + SQLite DBs under ~/.openjarvis, taken
+# via the SQLite online backup API so it's safe while jarvis-serve.service is
+# writing) plus a full git bundle of the repo (all refs — a rollback point
+# independent of GitHub). Mirrors /srv/trading-bot/trading-bot-backup.sh's
+# pattern. Keeps 7 days of backups.
+set -euo pipefail
+
+SRC="${OPENJARVIS_CONFIG_DIR:-$HOME/.openjarvis}"
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+DEST="${OPENJARVIS_BACKUP_DIR:-/srv/backups/openjarvis}"
+
+mkdir -p "$DEST" && chmod 700 "$DEST"
+stamp=$(date -u +%Y-%m-%dT%H-%M-%SZ)
+work="$DEST/.tmp-$stamp"
+mkdir -p "$work"
+
+for db in "$SRC"/*.db; do
+  [[ -f "$db" ]] || continue
+  name="$(basename "$db")"
+  sqlite3 "$db" ".backup '$work/$name'"
+done
+
+# Non-DB config/state worth keeping (contains the server API key — restrict perms).
+cp "$SRC/config.toml" "$work/" 2>/dev/null || true
+cp "$SRC/anon_id" "$work/" 2>/dev/null || true
+
+tar -czf "$DEST/state-$stamp.tgz" -C "$work" .
+rm -rf "$work"
+chmod 600 "$DEST/state-$stamp.tgz"
+
+git -C "$REPO" bundle create "$DEST/repo-$stamp.bundle" --all >/dev/null 2>&1 \
+  || echo "[$(date '+%F %T')] WARN: git bundle failed" >> "$DEST/backup.log"
+chmod 600 "$DEST/repo-$stamp.bundle" 2>/dev/null || true
+
+find "$DEST" -maxdepth 1 -type f \( -name 'state-*.tgz' -o -name 'repo-*.bundle' \) -mtime +7 -delete
+
+echo "[$(date '+%F %T')] backup ok: $(du -sh "$DEST" | cut -f1) total, newest state-$stamp.tgz" >> "$DEST/backup.log"

--- a/scripts/deploy-local.sh
+++ b/scripts/deploy-local.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# openjarvis deploy-local — pulls latest from origin/main, syncs deps if
+# needed, restarts the openjarvis.service. Idempotent: exits early if HEAD
+# already matches origin. Mirrors /srv/apex/scripts/deploy-local.sh's
+# fetch/dirty-check/conditional-restart structure; deliberately no new
+# sophistication beyond what that already-working script does.
+set -euo pipefail
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+LOG="${OPENJARVIS_DEPLOY_LOG:-/tmp/openjarvis-deploy.log}"
+PORT="${OPENJARVIS_PORT:-8090}"
+
+export PATH="/home/cynar/.local/bin:/usr/local/bin:/usr/bin:/bin"
+
+log() { printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*" >> "$LOG"; }
+
+cd "$REPO"
+
+git fetch --quiet origin main || { log "fetch failed"; exit 1; }
+LOCAL_SHA=$(git rev-parse HEAD)
+REMOTE_SHA=$(git rev-parse origin/main)
+
+if [[ "$LOCAL_SHA" == "$REMOTE_SHA" ]]; then
+  exit 0
+fi
+
+log "deploying $LOCAL_SHA -> $REMOTE_SHA"
+
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  log "ABORT: working tree dirty, refusing to deploy"
+  exit 2
+fi
+git pull --ff-only --quiet origin main || { log "pull failed"; exit 1; }
+
+if git diff --name-only "$LOCAL_SHA" "$REMOTE_SHA" | grep -qE '^(pyproject\.toml|uv\.lock)$'; then
+  log "dependency files changed, running uv sync"
+  uv sync --extra server >> "$LOG" 2>&1 || { log "uv sync failed"; exit 1; }
+fi
+
+log "restarting openjarvis.service"
+sudo systemctl restart openjarvis.service
+sleep 3
+
+if [[ -r /etc/openjarvis/env ]]; then
+  # shellcheck disable=SC1091
+  API_KEY=$(grep -oP '(?<=^OPENJARVIS_API_KEY=).*' /etc/openjarvis/env || true)
+fi
+if [[ -n "${API_KEY:-}" ]] && curl -sf --max-time 5 -H "Authorization: Bearer $API_KEY" \
+    "http://127.0.0.1:$PORT/v1/route/status" >/dev/null; then
+  log "deploy OK — service healthy"
+else
+  log "WARN: service not responding on /v1/route/status after restart"
+fi

--- a/scripts/deploy-local.sh
+++ b/scripts/deploy-local.sh
@@ -1,18 +1,55 @@
 #!/usr/bin/env bash
 # openjarvis deploy-local — pulls latest from origin/main, syncs deps if
-# needed, restarts the openjarvis.service. Idempotent: exits early if HEAD
-# already matches origin. Mirrors /srv/apex/scripts/deploy-local.sh's
-# fetch/dirty-check/conditional-restart structure; deliberately no new
-# sophistication beyond what that already-working script does.
+# needed, restarts the *actual* running server (jarvis-serve.service, a
+# systemd --user unit — NOT the system-level openjarvis.service template,
+# which is unused/inactive; see CLAUDE.md "Server-Betrieb"). Idempotent:
+# exits early if HEAD already matches origin.
+#
+# Safety net: tags the pre-deploy commit before pulling. If the post-restart
+# health check fails, automatically rolls back to that commit, restarts
+# again, and exits non-zero — so a bad self-edit can't stay live unnoticed.
+# On a healthy deploy, the rolling tag `jarvis-last-good` is moved to HEAD
+# and pushed to origin as a durable rollback point.
 set -euo pipefail
 
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
 LOG="${OPENJARVIS_DEPLOY_LOG:-/tmp/openjarvis-deploy.log}"
-PORT="${OPENJARVIS_PORT:-8090}"
+PORT="${OPENJARVIS_PORT:-8010}"
+SERVICE="jarvis-serve.service"
+CONFIG_TOML="${OPENJARVIS_CONFIG:-$HOME/.openjarvis/config.toml}"
 
 export PATH="/home/cynar/.local/bin:/usr/local/bin:/usr/bin:/bin"
+export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
 
 log() { printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*" >> "$LOG"; }
+
+restart_and_check() {
+  log "restarting $SERVICE"
+  systemctl --user restart "$SERVICE"
+
+  local api_key=""
+  if [[ -r "$CONFIG_TOML" ]]; then
+    api_key=$(python3 -c "
+import tomllib, sys
+try:
+    with open(sys.argv[1], 'rb') as f:
+        data = tomllib.load(f)
+    print(data.get('server', {}).get('auth', {}).get('api_key', ''))
+except Exception:
+    pass
+" "$CONFIG_TOML" 2>/dev/null || true)
+  fi
+
+  local attempt
+  for attempt in 1 2 3 4 5; do
+    sleep 3
+    if [[ -n "$api_key" ]] && curl -sf --max-time 5 -H "Authorization: Bearer $api_key" \
+        "http://127.0.0.1:$PORT/v1/route/status" >/dev/null 2>&1; then
+      return 0
+    fi
+  done
+  return 1
+}
 
 cd "$REPO"
 
@@ -30,6 +67,10 @@ if ! git diff --quiet || ! git diff --cached --quiet; then
   log "ABORT: working tree dirty, refusing to deploy"
   exit 2
 fi
+
+# Rollback point, tagged before touching the tree.
+git tag -f "pre-deploy-$(date +%Y%m%d-%H%M%S)" "$LOCAL_SHA" >/dev/null
+
 git pull --ff-only --quiet origin main || { log "pull failed"; exit 1; }
 
 if git diff --name-only "$LOCAL_SHA" "$REMOTE_SHA" | grep -qE '^(pyproject\.toml|uv\.lock)$'; then
@@ -37,17 +78,20 @@ if git diff --name-only "$LOCAL_SHA" "$REMOTE_SHA" | grep -qE '^(pyproject\.toml
   uv sync --extra server >> "$LOG" 2>&1 || { log "uv sync failed"; exit 1; }
 fi
 
-log "restarting openjarvis.service"
-sudo systemctl restart openjarvis.service
-sleep 3
+if restart_and_check; then
+  log "deploy OK — service healthy at $REMOTE_SHA"
+  git tag -f jarvis-last-good HEAD >/dev/null
+  git push --quiet --force origin refs/tags/jarvis-last-good \
+    || log "WARN: could not push jarvis-last-good tag (non-fatal)"
+  exit 0
+fi
 
-if [[ -r /etc/openjarvis/env ]]; then
-  # shellcheck disable=SC1091
-  API_KEY=$(grep -oP '(?<=^OPENJARVIS_API_KEY=).*' /etc/openjarvis/env || true)
-fi
-if [[ -n "${API_KEY:-}" ]] && curl -sf --max-time 5 -H "Authorization: Bearer $API_KEY" \
-    "http://127.0.0.1:$PORT/v1/route/status" >/dev/null; then
-  log "deploy OK — service healthy"
+log "CRITICAL: service unhealthy after deploying $REMOTE_SHA — rolling back to $LOCAL_SHA"
+git reset --hard "$LOCAL_SHA" >> "$LOG" 2>&1
+
+if restart_and_check; then
+  log "rollback OK — service healthy again at $LOCAL_SHA"
 else
-  log "WARN: service not responding on /v1/route/status after restart"
+  log "CRITICAL: service still unhealthy after rollback to $LOCAL_SHA — needs manual attention"
 fi
+exit 1

--- a/src/openjarvis/cli/__init__.py
+++ b/src/openjarvis/cli/__init__.py
@@ -101,6 +101,7 @@ if not _DATA_BOUNDARY_BOOTSTRAP:
     from openjarvis.cli.add_cmd import add
     from openjarvis.cli.agent_cmd import agent
     from openjarvis.cli.ask import ask
+    from openjarvis.cli.audit_cmd import audit
     from openjarvis.cli.bench_cmd import bench
     from openjarvis.cli.channel_cmd import channel
     from openjarvis.cli.channels_cmd import channels
@@ -136,6 +137,7 @@ if not _DATA_BOUNDARY_BOOTSTRAP:
 
     cli.add_command(init, "init")
     cli.add_command(ask, "ask")
+    cli.add_command(audit, "audit")
     cli.add_command(chat, "chat")
     cli.add_command(serve, "serve")
     cli.add_command(model, "model")

--- a/src/openjarvis/cli/__init__.py
+++ b/src/openjarvis/cli/__init__.py
@@ -116,6 +116,7 @@ if not _DATA_BOUNDARY_BOOTSTRAP:
     from openjarvis.cli.gateway_cmd import gateway
     from openjarvis.cli.host_cmd import host
     from openjarvis.cli.init_cmd import init
+    from openjarvis.cli.knowledge_cmd import knowledge
     from openjarvis.cli.memory_cmd import memory
     from openjarvis.cli.mine_cmd import mine
     from openjarvis.cli.model import model
@@ -139,6 +140,7 @@ if not _DATA_BOUNDARY_BOOTSTRAP:
     cli.add_command(serve, "serve")
     cli.add_command(model, "model")
     cli.add_command(memory, "memory")
+    cli.add_command(knowledge, "knowledge")
     cli.add_command(mine, "mine")
     cli.add_command(pearl, "pearl")
     cli.add_command(telemetry, "telemetry")

--- a/src/openjarvis/cli/audit_cmd.py
+++ b/src/openjarvis/cli/audit_cmd.py
@@ -1,0 +1,171 @@
+"""``jarvis audit`` — daily behavior-compliance self-audit.
+
+Reads the last 24h of activity from traces.db (the one store guaranteed to
+capture requests across /v1/route/generate, /v1/chat/stream, and any other
+engine-calling path — see the two dedicated SessionStore implementations,
+which only capture ChannelBridge-routed traffic), asks the configured
+local model to judge it against the constitution, and — only on found
+drift — sends a direct Telegram notification. Never silently rewrites the
+constitution; that only ever happens through the normal PR/merge dev
+workflow, same as any other code change, after the user says "go".
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import time
+from pathlib import Path
+
+import click
+import httpx
+from rich.console import Console
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_DEFAULT_CONSTITUTION_PATH = (
+    _REPO_ROOT / "configs" / "openjarvis" / "prompts" / "jarvis-constitution.md"
+)
+_LOOKBACK_SECONDS = 24 * 3600
+_MAX_TRACES = 200
+_ROUTE_TIMEOUT_S = 120.0
+
+
+def _constitution_path() -> Path:
+    override = os.environ.get("OPENJARVIS_CONSTITUTION_PATH")
+    return Path(override) if override else _DEFAULT_CONSTITUTION_PATH
+
+
+def _digest_traces(traces: list) -> str:
+    lines = []
+    for t in traces:
+        query = (t.query or "").strip().replace("\n", " ")[:200]
+        result = (t.result or "").strip().replace("\n", " ")[:200]
+        if not query and not result:
+            continue
+        lines.append(f"- Anfrage: {query}\n  Antwort: {result}")
+    return "\n".join(lines)
+
+
+def _extract_json(text: str) -> dict | None:
+    match = re.search(r"\{.*\}", text, re.DOTALL)
+    if not match:
+        return None
+    try:
+        return json.loads(match.group(0))
+    except json.JSONDecodeError:
+        return None
+
+
+def _notify_telegram(text: str) -> bool:
+    token = os.environ.get("TELEGRAM_BOT_TOKEN")
+    owner_id = os.environ.get("TELEGRAM_OWNER_ID")
+    if not token or not owner_id:
+        return False
+    try:
+        r = httpx.post(
+            f"https://api.telegram.org/bot{token}/sendMessage",
+            json={"chat_id": int(owner_id), "text": text[:4000]},
+            timeout=15.0,
+        )
+        return r.status_code == 200
+    except (httpx.HTTPError, ValueError):
+        return False
+
+
+@click.group()
+def audit() -> None:
+    """Behavior-compliance self-audit against the Jarvis constitution."""
+
+
+@audit.command()
+@click.option(
+    "--base-url",
+    default=None,
+    help="Override the openjarvis brain URL (default: localhost + local key).",
+)
+def run(base_url: str | None) -> None:
+    """Review the last 24h of activity against the constitution; notify on drift."""
+    console = Console()
+
+    constitution_path = _constitution_path()
+    if not constitution_path.exists():
+        console.print(f"[red]Constitution not found:[/red] {constitution_path}")
+        raise SystemExit(1)
+    constitution = constitution_path.read_text()
+
+    from openjarvis.core.config import load_config
+    from openjarvis.traces.store import TraceStore
+
+    config = load_config()
+    store = TraceStore(db_path=config.traces.db_path)
+    try:
+        traces = store.list_traces(
+            since=time.time() - _LOOKBACK_SECONDS, limit=_MAX_TRACES
+        )
+    finally:
+        store.close()
+
+    if not traces:
+        console.print(
+            "[yellow]No activity in the last 24h — nothing to audit.[/yellow]"
+        )
+        return
+
+    digest = _digest_traces(traces)
+    if not digest:
+        console.print("[yellow]No reviewable content in recent traces.[/yellow]")
+        return
+
+    prompt = (
+        "Du prüfst, ob KI-Assistent-Antworten der letzten 24h gegen seine eigene "
+        "Konstitution verstoßen haben. Antworte NUR mit einem JSON-Objekt: "
+        '{"drift_found": true|false, "summary": "kurze konkrete Beobachtung '
+        'auf Deutsch, oder leer wenn kein Verstoß"}.\n\n'
+        f"KONSTITUTION:\n{constitution}\n\n"
+        f"AKTIVITÄT DER LETZTEN 24H:\n{digest}\n"
+    )
+
+    url = base_url or os.environ.get("OPENJARVIS_URL", "http://127.0.0.1:8090")
+    key = os.environ.get("OPENJARVIS_API_KEY", "")
+    try:
+        r = httpx.post(
+            f"{url}/v1/route/generate",
+            json={
+                "messages": [{"role": "user", "content": prompt}],
+                "channel_id": "self-audit",
+            },
+            headers={"Authorization": f"Bearer {key}"} if key else {},
+            timeout=_ROUTE_TIMEOUT_S,
+        )
+        r.raise_for_status()
+    except httpx.HTTPError as exc:
+        console.print(f"[red]Audit review call failed:[/red] {exc}")
+        raise SystemExit(1) from exc
+
+    content = r.json().get("content", "")
+    verdict = _extract_json(content)
+    if verdict is None:
+        console.print(
+            "[yellow]Could not parse a verdict from the response — skipping.[/yellow]"
+        )
+        console.print(content[:500])
+        return
+
+    if not verdict.get("drift_found"):
+        console.print("[green]No drift found.[/green]")
+        return
+
+    summary = verdict.get("summary", "").strip() or "(keine Details)"
+    console.print(f"[red]Drift found:[/red] {summary}")
+    message = (
+        f"Self-Audit: Abweichung gefunden.\n{summary}\n\n"
+        "Wenn du willst, dass ich die Konstitution nachschärfe, sag mir einfach in "
+        "einfacher Sprache was — daraus mach ich einen normalen Dev-Task."
+    )
+    notified = _notify_telegram(message)
+    if not notified:
+        console.print("[yellow]Telegram not configured, logged here only.[/yellow]")
+
+
+__all__ = ["audit"]

--- a/src/openjarvis/cli/knowledge_cmd.py
+++ b/src/openjarvis/cli/knowledge_cmd.py
@@ -1,0 +1,69 @@
+"""``jarvis knowledge`` — cross-project knowledge indexing subcommands."""
+
+from __future__ import annotations
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+from openjarvis.cli.memory_cmd import _get_backend
+from openjarvis.knowledge.projects import DEFAULT_PROJECTS, ProjectRegistry
+
+
+@click.group()
+def knowledge() -> None:
+    """Manage cross-project knowledge indexing."""
+
+
+@knowledge.command()
+@click.argument("project_id", required=False)
+@click.option(
+    "--all", "refresh_all", is_flag=True, help="Refresh every registered project."
+)
+@click.option(
+    "--backend", "-b", default=None, help="Override the default memory backend."
+)
+def refresh(project_id: str | None, refresh_all: bool, backend: str | None) -> None:
+    """Re-index PROJECT_ID's (or --all projects') README, git log, issues/PRs."""
+    console = Console()
+    if not project_id and not refresh_all:
+        raise click.ClickException("Specify a PROJECT_ID or pass --all.")
+
+    mem = _get_backend(backend)
+    try:
+        registry = ProjectRegistry(mem)
+        if refresh_all:
+            results = registry.refresh_all()
+        else:
+            if project_id not in registry.project_ids:
+                raise click.ClickException(
+                    f"Unknown project {project_id!r}. "
+                    f"Known: {', '.join(registry.project_ids)}"
+                )
+            results = {project_id: registry.refresh(project_id)}
+    finally:
+        if hasattr(mem, "close"):
+            mem.close()
+
+    table = Table(title="Knowledge Refresh")
+    table.add_column("Project", style="cyan")
+    table.add_column("Documents")
+    for pid, count in results.items():
+        table.add_row(pid, str(count))
+    console.print(table)
+
+
+@knowledge.command(name="list")
+def list_projects() -> None:
+    """List registered projects and where their knowledge comes from."""
+    console = Console()
+    table = Table(title="Registered Projects")
+    table.add_column("Project", style="cyan")
+    table.add_column("Repo Path")
+    table.add_column("GitHub")
+    for p in DEFAULT_PROJECTS:
+        table.add_row(p.project_id, str(p.repo_path), p.github_repo or "-")
+    console.print(table)
+
+
+__all__ = ["knowledge"]

--- a/src/openjarvis/cli/serve.py
+++ b/src/openjarvis/cli/serve.py
@@ -212,7 +212,12 @@ def serve(
         or os.environ.get("GOOGLE_API_KEY")
         or os.environ.get("OPENROUTER_API_KEY")
     )
-    if _has_cloud and engine_name != "cloud":
+    if _has_cloud and not config.intelligence.allow_cloud:
+        console.print(
+            "  Cloud:  [yellow]disabled[/yellow] (API keys detected but "
+            "intelligence.allow_cloud is false)"
+        )
+    if _has_cloud and config.intelligence.allow_cloud and engine_name != "cloud":
         try:
             from openjarvis.engine.cloud import CloudEngine
 

--- a/src/openjarvis/core/config.py
+++ b/src/openjarvis/core/config.py
@@ -619,6 +619,11 @@ class IntelligenceConfig:
     quantization: str = "none"  # none, fp8, int8, int4, gguf_q4, gguf_q8
     preferred_engine: str = ""  # Override engine for this model (e.g., "vllm")
     provider: str = ""  # local, openai, anthropic, google
+    # Hard gate on any cloud engine (OpenAI/Anthropic/Google/OpenRouter/...).
+    # False means no cloud engine is ever built, discovered as a fallback, or
+    # hot-reloaded via /v1/cloud/reload — regardless of API keys present in
+    # the environment or submitted through the API.
+    allow_cloud: bool = False
     # Generation defaults (overridable per-call)
     temperature: float = 0.7
     max_tokens: int = 1024

--- a/src/openjarvis/engine/__init__.py
+++ b/src/openjarvis/engine/__init__.py
@@ -6,6 +6,7 @@ import importlib
 import logging
 
 # Import engine modules to trigger @EngineRegistry.register() decorators
+import openjarvis.engine.evo_fleet  # noqa: F401
 import openjarvis.engine.nim  # noqa: F401
 import openjarvis.engine.ollama  # noqa: F401
 import openjarvis.engine.openai_compat_engines  # noqa: F401

--- a/src/openjarvis/engine/_discovery.py
+++ b/src/openjarvis/engine/_discovery.py
@@ -132,7 +132,12 @@ def discover_engines(config: JarvisConfig) -> List[Tuple[str, InferenceEngine]]:
     # threads collapses that to roughly the slowest single probe. The
     # healthy.sort() below normalizes order, so completion order is
     # irrelevant and the result is identical to the serial version (#263).
-    keys = list(EngineRegistry.keys())
+    allow_cloud = config.intelligence.allow_cloud
+    keys = [
+        key
+        for key in EngineRegistry.keys()
+        if allow_cloud or not getattr(EngineRegistry.get(key), "is_cloud", False)
+    ]
 
     def _probe(key: str) -> Tuple[str, InferenceEngine] | None:
         try:
@@ -198,9 +203,18 @@ def get_engine(
     def _usable(engine: InferenceEngine) -> bool:
         return engine.health() and (model is None or engine.can_serve(model))
 
+    allow_cloud = config.intelligence.allow_cloud
+
     if engine_key:
         if not EngineRegistry.contains(engine_key):
             logger.warning("Requested engine %r is not registered", engine_key)
+            return None
+        if not allow_cloud and getattr(EngineRegistry.get(engine_key), "is_cloud", False):
+            logger.warning(
+                "Requested engine %r is a cloud engine but intelligence.allow_cloud "
+                "is false; refusing",
+                engine_key,
+            )
             return None
         try:
             engine = _make_engine(engine_key, config)
@@ -217,7 +231,11 @@ def get_engine(
 
     default_key = config.engine.default
     default_is_cloud: bool | None = None
-    if default_key and EngineRegistry.contains(default_key):
+    if (
+        default_key
+        and EngineRegistry.contains(default_key)
+        and (allow_cloud or not getattr(EngineRegistry.get(default_key), "is_cloud", False))
+    ):
         default_cls = EngineRegistry.get(default_key)
         default_is_cloud = bool(getattr(default_cls, "is_cloud", False))
         try:

--- a/src/openjarvis/engine/evo_fleet.py
+++ b/src/openjarvis/engine/evo_fleet.py
@@ -1,0 +1,155 @@
+"""Inference engine for EVO's fixed local llama.cpp fleet.
+
+Composes one ``OpenAICompatEngine`` per fixed port (coder/general/embed/
+autocomplete/trading) plus the dynamic llm-router catalog port, and routes
+by model name — the same pattern ``MultiEngine`` uses one level up.
+Registered under the ``evo_fleet`` key so ``discover_engines()`` (called by
+``jarvis serve``, see cli/serve.py) picks it up automatically and merges it
+into the top-level ``MultiEngine`` with zero changes to the server startup
+code.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterator, Sequence
+from typing import Any, Dict, List
+
+from openjarvis.core.registry import EngineRegistry
+from openjarvis.core.types import Message
+from openjarvis.engine._base import InferenceEngine
+from openjarvis.engine._stubs import StreamChunk
+from openjarvis.engine.openai_compat_engines import OpenAICompatEngine
+from openjarvis.intelligence.evo_catalog import (
+    EVO_FIXED_PORTS,
+    EVO_MODEL_META,
+    EVO_ROUTER_PORT,
+    register_evo_models,
+)
+from openjarvis.system import evo_router_client
+
+logger = logging.getLogger(__name__)
+
+
+def _client_for_port(port: int) -> OpenAICompatEngine:
+    return OpenAICompatEngine(host=f"http://127.0.0.1:{port}")
+
+
+class EvoFleetEngine(InferenceEngine):
+    """Routes to whichever EVO llama.cpp port currently serves a model."""
+
+    engine_id = "evo_fleet"
+
+    def __init__(self) -> None:
+        register_evo_models()
+        self._port_clients: Dict[int, OpenAICompatEngine] = {
+            port: _client_for_port(port) for port in EVO_FIXED_PORTS
+        }
+        self._router_client = _client_for_port(EVO_ROUTER_PORT)
+        self._model_port: Dict[str, int] = {}
+        self._refresh_map()
+
+    def _refresh_map(self) -> None:
+        self._model_port.clear()
+        for port, client in self._port_clients.items():
+            try:
+                for model_id in client.list_models():
+                    self._model_port[model_id] = port
+            except Exception as exc:
+                logger.debug("Failed to list models on EVO port %s: %s", port, exc)
+        loaded = evo_router_client.router_loaded_model()
+        if loaded:
+            self._model_port[loaded] = EVO_ROUTER_PORT
+
+    def _client_for_model(self, model: str) -> OpenAICompatEngine:
+        port = self._model_port.get(model)
+        if port is None:
+            self._refresh_map()
+            port = self._model_port.get(model)
+        if port is None:
+            raise ValueError(
+                f"Model {model!r} not found on any EVO port "
+                f"(known: {', '.join(sorted(self._model_port.keys())) or '<none>'})."
+            )
+        if port == EVO_ROUTER_PORT:
+            return self._router_client
+        return self._port_clients[port]
+
+    # -- Fleet-awareness, used by EvoScheduler -------------------------------
+
+    def is_isolated(self, model: str) -> bool:
+        return bool(EVO_MODEL_META.get(model, {}).get("isolated", False))
+
+    def is_always_on(self, model: str) -> bool:
+        return bool(EVO_MODEL_META.get(model, {}).get("always_on", False))
+
+    def port_for(self, model: str) -> int | None:
+        return self._model_port.get(model)
+
+    # -- InferenceEngine interface -------------------------------------------
+
+    def generate(
+        self,
+        messages: Sequence[Message],
+        *,
+        model: str,
+        temperature: float = 0.7,
+        max_tokens: int = 1024,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        return self._client_for_model(model).generate(
+            messages,
+            model=model,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            **kwargs,
+        )
+
+    async def stream(
+        self,
+        messages: Sequence[Message],
+        *,
+        model: str,
+        temperature: float = 0.7,
+        max_tokens: int = 1024,
+        **kwargs: Any,
+    ) -> AsyncIterator[str]:
+        async for token in self._client_for_model(model).stream(
+            messages,
+            model=model,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            **kwargs,
+        ):
+            yield token
+
+    async def stream_full(
+        self,
+        messages: Sequence[Message],
+        *,
+        model: str,
+        **kwargs: Any,
+    ) -> AsyncIterator["StreamChunk"]:
+        async for chunk in self._client_for_model(model).stream_full(
+            messages, model=model, **kwargs
+        ):
+            yield chunk
+
+    def list_models(self) -> List[str]:
+        self._refresh_map()
+        return list(self._model_port.keys())
+
+    def health(self) -> bool:
+        return any(client.health() for client in self._port_clients.values())
+
+    def close(self) -> None:
+        for client in self._port_clients.values():
+            client.close()
+        self._router_client.close()
+
+
+if not EngineRegistry.contains("evo_fleet"):
+    EngineRegistry.register("evo_fleet")(EvoFleetEngine)
+
+
+__all__ = ["EvoFleetEngine"]

--- a/src/openjarvis/intelligence/evo_catalog.py
+++ b/src/openjarvis/intelligence/evo_catalog.py
@@ -1,0 +1,152 @@
+"""Model catalog for the EVO homelab node's local llama.cpp fleet.
+
+Ports and aliases mirror ``/srv/llm/docker-compose.yml`` exactly. VRAM
+figures are approximate (from ``evo/README.md`` measurements), used only
+for scheduling heuristics, not billing.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from openjarvis.core.registry import ModelRegistry
+from openjarvis.core.types import ModelSpec
+
+# Port 1240 (llm-router) is deliberately absent here: its catalog is
+# dynamic (whatever ``models.ini`` lists, loaded on demand) and is
+# discovered live by ``EvoFleetEngine``/``evo_router_client`` instead of
+# being hardcoded.
+EVO_MODELS: List[ModelSpec] = [
+    ModelSpec(
+        model_id="qwen3-coder-30b-a3b",
+        name="Qwen3.6-35B-A3B (coder alias)",
+        parameter_count_b=35.0,
+        active_parameter_count_b=3.0,
+        context_length=131072,
+        min_vram_gb=18.0,
+        supported_engines=("evo_fleet",),
+        provider="alibaba",
+        metadata={
+            "architecture": "moe",
+            "port": 1234,
+            "docker_service": "llm-coder",
+            "isolated": False,
+            "always_on": True,
+        },
+    ),
+    ModelSpec(
+        model_id="qwen3.6-35b-a3b",
+        name="Qwen3.6-35B-A3B (base alias)",
+        parameter_count_b=35.0,
+        active_parameter_count_b=3.0,
+        context_length=131072,
+        min_vram_gb=18.0,
+        supported_engines=("evo_fleet",),
+        provider="alibaba",
+        metadata={
+            "architecture": "moe",
+            "port": 1234,
+            "docker_service": "llm-coder",
+            "isolated": False,
+            "always_on": True,
+        },
+    ),
+    ModelSpec(
+        model_id="gpt-oss-120b",
+        name="GPT-OSS 120B (EVO general)",
+        parameter_count_b=117.0,
+        active_parameter_count_b=5.1,
+        context_length=524288,
+        min_vram_gb=63.0,
+        supported_engines=("evo_fleet",),
+        provider="open-source",
+        metadata={
+            "architecture": "moe",
+            "port": 1235,
+            "docker_service": "llm-general",
+            "isolated": False,
+            "always_on": True,
+        },
+    ),
+    ModelSpec(
+        model_id="text-embedding-nomic-embed-text-v1.5",
+        name="Nomic Embed Text v1.5 (EVO)",
+        parameter_count_b=0.137,
+        context_length=8192,
+        min_vram_gb=1.0,
+        supported_engines=("evo_fleet",),
+        provider="nomic",
+        metadata={
+            "architecture": "embedding",
+            "port": 1236,
+            "docker_service": "llm-embed",
+            "isolated": False,
+            "always_on": True,
+        },
+    ),
+    ModelSpec(
+        model_id="qwen2.5-coder-3b",
+        name="Qwen2.5 Coder 3B (EVO autocomplete)",
+        parameter_count_b=3.0,
+        context_length=16384,
+        min_vram_gb=2.0,
+        supported_engines=("evo_fleet",),
+        provider="alibaba",
+        metadata={
+            "architecture": "dense",
+            "port": 1239,
+            "docker_service": "llm-autocomplete",
+            "isolated": False,
+            "always_on": True,
+        },
+    ),
+    ModelSpec(
+        model_id="gpt-oss-20b",
+        name="GPT-OSS 20B (trading-bot, isolated)",
+        parameter_count_b=20.0,
+        active_parameter_count_b=3.6,
+        context_length=32768,
+        min_vram_gb=14.0,
+        supported_engines=("evo_fleet",),
+        provider="open-source",
+        metadata={
+            "architecture": "moe",
+            "port": 1241,
+            "docker_service": "llm-trading",
+            # Deliberately isolated: never selected by EvoScheduler, never
+            # swapped, never shared with any other consumer. See
+            # docs/superpowers/specs/2026-09-06-agent-orchestrator-design.md.
+            "isolated": True,
+            "always_on": True,
+        },
+    ),
+]
+
+# Fast lookup used by EvoFleetEngine / EvoScheduler without re-scanning
+# EVO_MODELS on every call.
+EVO_MODEL_META: Dict[str, Dict[str, Any]] = {
+    spec.model_id: dict(spec.metadata) for spec in EVO_MODELS
+}
+
+# All fixed (always-on, non-catalog) ports the EVO fleet exposes.
+EVO_FIXED_PORTS: List[int] = sorted({meta["port"] for meta in EVO_MODEL_META.values()})
+
+# The one port llama.cpp's own multi-model preset server dynamically loads
+# models onto (see /srv/llm/router/models.ini + evo-router CLI).
+EVO_ROUTER_PORT = 1240
+
+
+def register_evo_models() -> None:
+    """Populate ``ModelRegistry`` with the EVO fleet's models (idempotent)."""
+    for spec in EVO_MODELS:
+        if not ModelRegistry.contains(spec.model_id):
+            ModelRegistry.register_value(spec.model_id, spec)
+
+
+__all__ = [
+    "EVO_FIXED_PORTS",
+    "EVO_MODELS",
+    "EVO_MODEL_META",
+    "EVO_ROUTER_PORT",
+    "register_evo_models",
+]

--- a/src/openjarvis/knowledge/__init__.py
+++ b/src/openjarvis/knowledge/__init__.py
@@ -1,0 +1,3 @@
+"""Cross-project knowledge indexing for EVO's homelab projects."""
+
+from __future__ import annotations

--- a/src/openjarvis/knowledge/projects.py
+++ b/src/openjarvis/knowledge/projects.py
@@ -1,0 +1,208 @@
+"""Indexes each EVO project's README, recent git history, and open GitHub
+issues/PRs into a ``MemoryBackend`` so the brain can answer "what do you
+know about project X" without re-reading each repo on every question.
+
+Uses ``replace_source(project_id, documents)`` for idempotent re-indexing:
+every refresh atomically replaces the previous snapshot for that project,
+so a 15-30 minute polling timer (see Phase 2 plan) never accumulates
+stale duplicates.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from openjarvis.tools.storage._stubs import MemoryBackend, RetrievalResult
+from openjarvis.tools.storage.ingest import ingest_path
+
+logger = logging.getLogger(__name__)
+
+_GIT_LOG_LIMIT = 50
+_ISSUE_PR_LIMIT = 20
+_GH_TIMEOUT = 15.0
+_GIT_TIMEOUT = 10.0
+
+
+@dataclass(frozen=True)
+class ProjectConfig:
+    """One project's identity: where it lives, where its docs are, and
+    which GitHub repo (if any) to pull issues/PRs from."""
+
+    project_id: str
+    repo_path: Path
+    github_repo: str = ""  # "owner/repo"; empty disables issue/PR indexing
+    doc_paths: Tuple[str, ...] = field(default_factory=lambda: ("README.md",))
+
+
+# EVO's homelab projects, per the "Jarvis auf EVO" plan's cross-project
+# knowledge requirement. Paths and GitHub slugs verified against each
+# repo's actual checkout + `git remote get-url origin` on 2026-09-09.
+DEFAULT_PROJECTS: List[ProjectConfig] = [
+    ProjectConfig("openjarvis", Path("/srv/openjarvis"), "cynarAI/OpenJarvis"),
+    ProjectConfig("sugar-rush", Path("/srv/sugar-rush/repo"), "cynarAI/sugar-rush"),
+    ProjectConfig("trading-bot", Path("/srv/trading-bot"), "cynarAI/tradingbot"),
+    ProjectConfig("apex", Path("/srv/apex"), "cynarAI/Nexus"),
+    ProjectConfig("homelab", Path("/srv/homelab"), "cynarAI/homelab"),
+]
+
+
+class ProjectRegistry:
+    """Indexes and queries per-project knowledge in a ``MemoryBackend``."""
+
+    def __init__(
+        self,
+        memory: MemoryBackend,
+        projects: Optional[List[ProjectConfig]] = None,
+    ) -> None:
+        if not hasattr(memory, "replace_source"):
+            raise TypeError(
+                f"{type(memory).__name__} does not support replace_source(); "
+                "ProjectRegistry needs a backend that can atomically replace "
+                "all documents for one source (e.g. SQLiteMemory)."
+            )
+        self._memory = memory
+        self._projects: Dict[str, ProjectConfig] = {
+            p.project_id: p for p in (projects or DEFAULT_PROJECTS)
+        }
+
+    @property
+    def project_ids(self) -> List[str]:
+        return list(self._projects.keys())
+
+    def refresh(self, project_id: str) -> int:
+        """Re-index one project. Returns the number of documents stored."""
+        project = self._projects.get(project_id)
+        if project is None:
+            raise KeyError(f"Unknown project {project_id!r}")
+        if not project.repo_path.exists():
+            logger.warning(
+                "Project %r repo path %s does not exist; skipping",
+                project_id,
+                project.repo_path,
+            )
+            return 0
+
+        documents: List[Tuple[str, Optional[Dict[str, Any]]]] = []
+        documents.extend(self._doc_chunks(project))
+
+        git_log = self._read_git_log(project.repo_path)
+        if git_log:
+            documents.append((git_log, {"source_type": "git_log"}))
+
+        if project.github_repo:
+            issues_prs = self._read_issues_and_prs(project.github_repo)
+            if issues_prs:
+                documents.append((issues_prs, {"source_type": "issues_prs"}))
+
+        doc_ids = self._memory.replace_source(project_id, documents)
+        logger.info("Refreshed project %r: %d documents", project_id, len(doc_ids))
+        return len(doc_ids)
+
+    def refresh_all(self) -> Dict[str, int]:
+        """Refresh every registered project. One failure doesn't stop the rest."""
+        results: Dict[str, int] = {}
+        for project_id in self._projects:
+            try:
+                results[project_id] = self.refresh(project_id)
+            except Exception:
+                logger.warning(
+                    "Failed to refresh project %r", project_id, exc_info=True
+                )
+                results[project_id] = 0
+        return results
+
+    def summary(
+        self, project_id: str, query: str = "", *, top_k: int = 10
+    ) -> List[RetrievalResult]:
+        """Search *query* within one project's indexed knowledge.
+
+        Over-fetches and filters by ``source`` client-side since
+        ``MemoryBackend.retrieve()`` has no built-in per-source filter.
+        """
+        if project_id not in self._projects:
+            raise KeyError(f"Unknown project {project_id!r}")
+        search_query = query or project_id
+        results = self._memory.retrieve(search_query, top_k=top_k * 3)
+        return [r for r in results if r.source == project_id][:top_k]
+
+    def _doc_chunks(
+        self, project: ProjectConfig
+    ) -> List[Tuple[str, Optional[Dict[str, Any]]]]:
+        chunks: List[Tuple[str, Optional[Dict[str, Any]]]] = []
+        for rel in project.doc_paths:
+            doc_path = project.repo_path / rel
+            if not doc_path.exists():
+                continue
+            try:
+                for chunk in ingest_path(doc_path):
+                    chunks.append((chunk.content, {"source_type": "doc", "path": rel}))
+            except Exception:
+                logger.warning("Failed to ingest %s", doc_path, exc_info=True)
+        return chunks
+
+    @staticmethod
+    def _read_git_log(repo_path: Path) -> str:
+        try:
+            result = subprocess.run(
+                ["git", "-C", str(repo_path), "log", "--oneline", f"-{_GIT_LOG_LIMIT}"],
+                capture_output=True,
+                text=True,
+                timeout=_GIT_TIMEOUT,
+                check=False,
+            )
+            return result.stdout.strip()
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            logger.debug("git log failed for %s: %s", repo_path, exc)
+            return ""
+
+    @staticmethod
+    def _read_issues_and_prs(github_repo: str) -> str:
+        parts = []
+        for kind, args in (
+            (
+                "issues",
+                [
+                    "issue",
+                    "list",
+                    "--repo",
+                    github_repo,
+                    "--limit",
+                    str(_ISSUE_PR_LIMIT),
+                    "--json",
+                    "number,title,state",
+                ],
+            ),
+            (
+                "prs",
+                [
+                    "pr",
+                    "list",
+                    "--repo",
+                    github_repo,
+                    "--limit",
+                    str(_ISSUE_PR_LIMIT),
+                    "--json",
+                    "number,title,state",
+                ],
+            ),
+        ):
+            try:
+                result = subprocess.run(
+                    ["gh", *args],
+                    capture_output=True,
+                    text=True,
+                    timeout=_GH_TIMEOUT,
+                    check=False,
+                )
+                if result.returncode == 0 and result.stdout.strip():
+                    parts.append(f"{kind}:\n{result.stdout.strip()}")
+            except (OSError, subprocess.TimeoutExpired) as exc:
+                logger.debug("gh %s failed for %s: %s", kind, github_repo, exc)
+        return "\n\n".join(parts)
+
+
+__all__ = ["DEFAULT_PROJECTS", "ProjectConfig", "ProjectRegistry"]

--- a/src/openjarvis/learning/routing/evo_scheduler.py
+++ b/src/openjarvis/learning/routing/evo_scheduler.py
@@ -1,0 +1,242 @@
+"""Resource-aware routing decision layer for the EVO local LLM fleet.
+
+Sits above ``HeuristicRouter``: the heuristic still decides *which kind*
+of model a query wants (code/small/large/reasoning), this module decides
+whether that choice is actually safe to act on right now given EVO's real
+VRAM state — with a hold to protect in-flight sessions, a cooldown to
+avoid thrashing, and a hard, unconditional exclusion of the trading-bot's
+isolated model.
+
+V1 scope (deliberately not more): the four always-on EVO models
+(coder/general/autocomplete/embed) require no swap at all — ``select()``
+just picks among them. Loading something from the dynamic llm-router
+catalog (:1240), which *does* require freeing ~70GB from llm-general, is
+only ever done on an explicit request via ``swap_to_router_model()`` — the
+routing signals available today (has_code/has_math/complexity) don't
+carry enough intent to safely auto-trigger a swap that costs a minute and
+briefly takes gpt-oss-120b away from every other consumer (sugar-rush
+Staging included).
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+from openjarvis.core.types import StepType, Trace, TraceStep
+from openjarvis.engine.evo_fleet import EvoFleetEngine
+from openjarvis.intelligence.evo_catalog import (
+    EVO_MODEL_META,
+    EVO_ROUTER_PORT,
+    register_evo_models,
+)
+from openjarvis.learning.routing.router import HeuristicRouter, build_routing_context
+from openjarvis.system import evo_router_client
+
+logger = logging.getLogger(__name__)
+
+COOLDOWN_SECONDS = 120.0
+HOLD_SECONDS = 300.0  # safety expiry if a caller forgets to release a hold
+
+
+class EvoIsolatedModelError(PermissionError):
+    """Raised when anything tries to route to the trading-bot's isolated model."""
+
+
+@dataclass
+class _SchedulerState:
+    holds: Dict[str, float] = field(default_factory=dict)
+    last_swap_ts: float = 0.0
+
+
+class EvoScheduler:
+    """Decides which EVO model serves a query, safely."""
+
+    def __init__(self, fleet: Optional[EvoFleetEngine] = None) -> None:
+        register_evo_models()
+        self._fleet = fleet or EvoFleetEngine()
+        self._state = _SchedulerState()
+
+    # -- Session holds --------------------------------------------------------
+
+    def begin_hold(self, channel_id: str) -> None:
+        """Mark *channel_id* as mid-conversation so a swap won't be started
+        under it. Expires automatically after ``HOLD_SECONDS`` in case a
+        caller forgets to release it (e.g. crashed mid-request)."""
+        if not channel_id:
+            return
+        self._state.holds[channel_id] = time.monotonic() + HOLD_SECONDS
+
+    def end_hold(self, channel_id: str) -> None:
+        self._state.holds.pop(channel_id, None)
+
+    def _has_active_hold(self) -> bool:
+        now = time.monotonic()
+        # Sweep expired holds as a side effect of checking.
+        expired = [cid for cid, exp in self._state.holds.items() if exp <= now]
+        for cid in expired:
+            del self._state.holds[cid]
+        return bool(self._state.holds)
+
+    def _in_cooldown(self) -> bool:
+        return (time.monotonic() - self._state.last_swap_ts) < COOLDOWN_SECONDS
+
+    # -- Routing --------------------------------------------------------------
+
+    def _safe_available_models(self) -> list[str]:
+        """Always-on, chat-capable EVO models.
+
+        Excludes anything isolated (trading-bot) and anything
+        embedding-only: an embedding model reports a tiny parameter count,
+        which would otherwise make ``HeuristicRouter``'s "low complexity →
+        smallest model" rule pick it for ordinary chat — it cannot serve
+        ``/v1/chat/completions`` at all.
+        """
+        return [
+            model_id
+            for model_id, meta in EVO_MODEL_META.items()
+            if meta.get("always_on")
+            and not meta.get("isolated")
+            and meta.get("architecture") != "embedding"
+        ]
+
+    def select(
+        self,
+        query: str,
+        *,
+        channel_id: str = "",
+        urgency: float = 0.5,
+        force_model: Optional[str] = None,
+        trace_store: Any = None,
+    ) -> Dict[str, Any]:
+        """Pick a model for *query*. Raises ``EvoIsolatedModelError`` if
+        ``force_model`` names the trading-bot's isolated model."""
+        started = time.time()
+        if force_model is not None:
+            if EVO_MODEL_META.get(force_model, {}).get("isolated"):
+                raise EvoIsolatedModelError(
+                    f"Refusing to route to isolated model {force_model!r} "
+                    "(reserved for trading-bot)."
+                )
+            model = force_model
+            reason = "explicit"
+        else:
+            available = self._safe_available_models()
+            ctx = build_routing_context(query, urgency=urgency)
+            router = HeuristicRouter(available_models=available)
+            model = router.select_model(ctx)
+            reason = "heuristic"
+
+        decision = {
+            "model": model,
+            "port": self._fleet.port_for(model)
+            or EVO_MODEL_META.get(model, {}).get("port"),
+            "reason": reason,
+            "swapped": False,
+        }
+
+        if trace_store is not None:
+            self._log_trace(trace_store, query, decision, started)
+        return decision
+
+    def swap_to_router_model(
+        self, model_id: str, *, channel_id: str = ""
+    ) -> Dict[str, Any]:
+        """Explicitly load *model_id* from the llm-router catalog (:1240),
+        freeing llm-general first if needed. Refuses under an active hold
+        or cooldown, and unconditionally refuses isolated models."""
+        if EVO_MODEL_META.get(model_id, {}).get("isolated"):
+            raise EvoIsolatedModelError(
+                f"Refusing to swap in isolated model {model_id!r}."
+            )
+        if self._has_active_hold():
+            return {"swapped": False, "reason": "active_hold", "model": model_id}
+        if self._in_cooldown():
+            return {"swapped": False, "reason": "cooldown", "model": model_id}
+
+        already_loaded = evo_router_client.router_loaded_model()
+        if already_loaded == model_id:
+            return {"swapped": False, "reason": "already_loaded", "model": model_id}
+
+        freed = evo_router_client.free_general_for_router()
+        if not freed:
+            return {
+                "swapped": False,
+                "reason": "free_general_failed",
+                "model": model_id,
+            }
+        try:
+            evo_router_client.router_load(model_id)
+        except Exception as exc:
+            logger.error("Failed to load %r on llm-router: %s", model_id, exc)
+            evo_router_client.restore_general()
+            return {
+                "swapped": False,
+                "reason": "load_failed",
+                "model": model_id,
+                "error": str(exc),
+            }
+
+        self._state.last_swap_ts = time.monotonic()
+        self._fleet._model_port[model_id] = EVO_ROUTER_PORT
+        return {
+            "swapped": True,
+            "reason": "loaded",
+            "model": model_id,
+            "port": EVO_ROUTER_PORT,
+        }
+
+    def release_router_model(self) -> Dict[str, Any]:
+        """Unload whatever is on the router catalog and restore llm-general."""
+        restored = evo_router_client.restore_general()
+        self._state.last_swap_ts = time.monotonic()
+        return {"restored": restored}
+
+    # -- Status -----------------------------------------------------------
+
+    def status(self) -> Dict[str, Any]:
+        vram = evo_router_client.read_vram_gb()
+        ram = evo_router_client.read_ram_gb()
+        router = evo_router_client.router_status()
+        return {
+            "fixed_models": self._fleet.list_models(),
+            "router": router,
+            "vram": vram,
+            "ram": ram,
+            "active_holds": len(self._state.holds),
+            "cooldown_remaining_s": max(
+                0.0, COOLDOWN_SECONDS - (time.monotonic() - self._state.last_swap_ts)
+            ),
+        }
+
+    # -- Internal ---------------------------------------------------------
+
+    @staticmethod
+    def _log_trace(
+        trace_store: Any, query: str, decision: Dict[str, Any], started: float
+    ) -> None:
+        try:
+            trace = Trace(
+                query=query,
+                model=decision["model"],
+                engine="evo_fleet",
+                started_at=started,
+                ended_at=time.time(),
+            )
+            trace.add_step(
+                TraceStep(
+                    step_type=StepType.ROUTE,
+                    timestamp=started,
+                    duration_seconds=time.time() - started,
+                    input={"query": query},
+                    output=decision,
+                )
+            )
+            trace_store.save(trace)
+        except Exception:
+            logger.debug("Failed to log EvoScheduler trace", exc_info=True)
+
+
+__all__ = ["EvoIsolatedModelError", "EvoScheduler"]

--- a/src/openjarvis/learning/routing/evo_scheduler.py
+++ b/src/openjarvis/learning/routing/evo_scheduler.py
@@ -32,6 +32,7 @@ from openjarvis.intelligence.evo_catalog import (
     EVO_ROUTER_PORT,
     register_evo_models,
 )
+from openjarvis.learning.routing.learned_router import LearnedRouterPolicy
 from openjarvis.learning.routing.router import HeuristicRouter, build_routing_context
 from openjarvis.system import evo_router_client
 
@@ -58,6 +59,14 @@ class EvoScheduler:
         register_evo_models()
         self._fleet = fleet or EvoFleetEngine()
         self._state = _SchedulerState()
+        # Shadow-mode only: observes every heuristic decision and predicts
+        # what it would have chosen (see _shadow_observe), but its output
+        # NEVER drives routing. This is how the policy accumulates the
+        # trace history Phase 5 needs before it's ever considered for
+        # going live.
+        self._learned = LearnedRouterPolicy(
+            available_models=self._safe_available_models()
+        )
 
     # -- Session holds --------------------------------------------------------
 
@@ -137,9 +146,26 @@ class EvoScheduler:
             "swapped": False,
         }
 
+        if force_model is None:
+            self._shadow_observe(query, model, decision)
+
         if trace_store is not None:
             self._log_trace(trace_store, query, decision, started)
         return decision
+
+    def _shadow_observe(self, query: str, model: str, decision: Dict[str, Any]) -> None:
+        """Record the heuristic's choice for LearnedRouterPolicy and log
+        what it would have picked instead — pure observation, never used
+        to route (Phase 5 prerequisite: build up trace history before
+        ever considering the learned policy live)."""
+        try:
+            ctx = build_routing_context(query)
+            shadow_model = self._learned.select_model(ctx)
+            self._learned.observe(query, model, outcome="success", feedback=None)
+            decision["shadow_model"] = shadow_model
+            decision["shadow_agrees"] = shadow_model == model
+        except Exception:
+            logger.debug("Shadow-mode observation failed", exc_info=True)
 
     def swap_to_router_model(
         self, model_id: str, *, channel_id: str = ""
@@ -209,6 +235,7 @@ class EvoScheduler:
             "cooldown_remaining_s": max(
                 0.0, COOLDOWN_SECONDS - (time.monotonic() - self._state.last_swap_ts)
             ),
+            "shadow_learned_policy": self._learned.policy_map,
         }
 
     # -- Internal ---------------------------------------------------------

--- a/src/openjarvis/security/capabilities.py
+++ b/src/openjarvis/security/capabilities.py
@@ -245,6 +245,7 @@ DEFAULT_TOOL_CAPABILITIES: Dict[str, List[str]] = {
     "git_commit": [Capability.FILE_WRITE],
     "git_diff": [Capability.FILE_READ],
     "git_log": [Capability.FILE_READ],
+    "git_push": [Capability.FILE_WRITE, Capability.NETWORK_FETCH],
     "git_status": [Capability.FILE_READ],
     "http_request": [Capability.NETWORK_FETCH],
     "image_generate": [Capability.NETWORK_FETCH, Capability.FILE_WRITE],

--- a/src/openjarvis/server/api_routes.py
+++ b/src/openjarvis/server/api_routes.py
@@ -442,6 +442,91 @@ async def get_trace(trace_id: str, request: Request):
         raise HTTPException(status_code=500, detail=str(exc))
 
 
+# ---- EVO fleet routing routes ----
+
+route_router = APIRouter(prefix="/v1/route", tags=["route"])
+
+
+class RouteGenerateRequest(BaseModel):
+    messages: List[Dict[str, Any]]
+    channel_id: str = ""
+    urgency: float = 0.5
+    model: Optional[str] = None
+    max_tokens: int = 1024
+    temperature: float = 0.7
+
+
+def _get_evo_scheduler(app) -> Any:
+    """Lazily create and cache the EvoScheduler on app.state."""
+    scheduler = getattr(app.state, "evo_scheduler", None)
+    if scheduler is None:
+        from openjarvis.learning.routing.evo_scheduler import EvoScheduler
+
+        scheduler = EvoScheduler()
+        app.state.evo_scheduler = scheduler
+    return scheduler
+
+
+@route_router.post("/generate")
+async def route_generate(req: RouteGenerateRequest, request: Request):
+    """Classify + route a generation request to the best-fit EVO model,
+    then execute it via the app's engine (a MultiEngine with the EVO
+    fleet merged in, once ``evo_fleet`` is registered and healthy)."""
+    from openjarvis.core.types import Message, Role
+    from openjarvis.learning.routing.evo_scheduler import EvoIsolatedModelError
+
+    scheduler = _get_evo_scheduler(request.app)
+    last_user_text = next(
+        (
+            m.get("content", "")
+            for m in reversed(req.messages)
+            if m.get("role") == "user"
+        ),
+        "",
+    )
+    trace_store = getattr(request.app.state, "trace_store", None)
+    try:
+        decision = scheduler.select(
+            last_user_text,
+            channel_id=req.channel_id,
+            urgency=req.urgency,
+            force_model=req.model,
+            trace_store=trace_store,
+        )
+    except EvoIsolatedModelError as exc:
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
+
+    engine = getattr(request.app.state, "engine", None)
+    if engine is None:
+        raise HTTPException(status_code=503, detail="No engine configured")
+
+    scheduler.begin_hold(req.channel_id)
+    try:
+        messages = [
+            Message(role=Role(m.get("role", "user")), content=m.get("content", ""))
+            for m in req.messages
+        ]
+        result = engine.generate(
+            messages,
+            model=decision["model"],
+            temperature=req.temperature,
+            max_tokens=req.max_tokens,
+        )
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+    finally:
+        scheduler.end_hold(req.channel_id)
+
+    return {**result, "routing": decision}
+
+
+@route_router.get("/status")
+async def route_status(request: Request):
+    """Live EVO fleet + scheduler state (VRAM/RAM, loaded models, holds)."""
+    scheduler = _get_evo_scheduler(request.app)
+    return scheduler.status()
+
+
 # ---- Telemetry routes ----
 
 telemetry_router = APIRouter(prefix="/v1/telemetry", tags=["telemetry"])
@@ -1152,6 +1237,7 @@ def include_all_routes(app) -> None:
     app.include_router(agents_router)
     app.include_router(memory_router)
     app.include_router(traces_router)
+    app.include_router(route_router)
     app.include_router(telemetry_router)
     app.include_router(skills_router)
     app.include_router(sessions_router)

--- a/src/openjarvis/server/api_routes.py
+++ b/src/openjarvis/server/api_routes.py
@@ -467,6 +467,27 @@ def _get_evo_scheduler(app) -> Any:
     return scheduler
 
 
+def _maybe_evo_model(app, query: str, *, channel_id: str = "") -> Optional[str]:
+    """Return an EvoScheduler-picked model for *query*, or None.
+
+    Deliberately best-effort and silent: this lets any existing chat path
+    (e.g. the ``/v1/chat/stream`` WebSocket) opportunistically benefit from
+    EVO-aware routing without ever becoming a hard dependency — on a
+    non-EVO deployment of this same codebase the fleet is simply
+    unreachable and callers keep their prior default-model behaviour.
+    """
+    try:
+        scheduler = _get_evo_scheduler(app)
+        decision = scheduler.select(query, channel_id=channel_id)
+        model = decision.get("model")
+        engine = getattr(app.state, "engine", None)
+        if model and engine is not None and model in engine.list_models():
+            return model
+    except Exception:
+        logger.debug("EVO model selection skipped", exc_info=True)
+    return None
+
+
 @route_router.post("/generate")
 async def route_generate(req: RouteGenerateRequest, request: Request):
     """Classify + route a generation request to the best-fit EVO model,
@@ -525,6 +546,70 @@ async def route_status(request: Request):
     """Live EVO fleet + scheduler state (VRAM/RAM, loaded models, holds)."""
     scheduler = _get_evo_scheduler(request.app)
     return scheduler.status()
+
+
+# ---- Cross-project knowledge routes ----
+
+projects_router = APIRouter(prefix="/v1/projects", tags=["projects"])
+
+
+def _get_project_registry(app) -> Any:
+    """Lazily create and cache the ProjectRegistry on app.state.
+
+    Raises ``HTTPException(503)`` if no memory backend is configured or
+    the configured backend can't support atomic per-project re-indexing
+    (see ``ProjectRegistry``'s ``replace_source`` requirement).
+    """
+    registry = getattr(app.state, "project_registry", None)
+    if registry is None:
+        memory_backend = getattr(app.state, "memory_backend", None)
+        if memory_backend is None:
+            raise HTTPException(status_code=503, detail="No memory backend configured")
+        from openjarvis.knowledge.projects import ProjectRegistry
+
+        try:
+            registry = ProjectRegistry(memory_backend)
+        except TypeError as exc:
+            raise HTTPException(status_code=503, detail=str(exc)) from exc
+        app.state.project_registry = registry
+    return registry
+
+
+@projects_router.get("")
+async def list_projects(request: Request):
+    """List registered EVO projects."""
+    registry = _get_project_registry(request.app)
+    return {"projects": registry.project_ids}
+
+
+@projects_router.get("/{project_id}/summary")
+async def project_summary(
+    project_id: str, request: Request, query: str = "", top_k: int = 10
+):
+    """Search one project's indexed knowledge (README, git log, issues/PRs)."""
+    registry = _get_project_registry(request.app)
+    try:
+        results = registry.summary(project_id, query, top_k=top_k)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return {
+        "project": project_id,
+        "results": [
+            {"content": r.content, "score": r.score, "metadata": r.metadata}
+            for r in results
+        ],
+    }
+
+
+@projects_router.post("/{project_id}/refresh")
+async def refresh_project(project_id: str, request: Request):
+    """Re-index one project's knowledge on demand (also runs on a timer)."""
+    registry = _get_project_registry(request.app)
+    try:
+        count = registry.refresh(project_id)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return {"project": project_id, "documents": count}
 
 
 # ---- Telemetry routes ----
@@ -876,10 +961,12 @@ async def websocket_chat_stream(websocket: WebSocket):
                 )
                 continue
 
-            model = data.get("model") or getattr(
-                websocket.app.state,
-                "model",
-                "default",
+            model = (
+                data.get("model")
+                or _maybe_evo_model(
+                    websocket.app, message, channel_id=data.get("channel_id", "")
+                )
+                or getattr(websocket.app.state, "model", "default")
             )
             engine = getattr(websocket.app.state, "engine", None)
             if engine is None:
@@ -1238,6 +1325,7 @@ def include_all_routes(app) -> None:
     app.include_router(memory_router)
     app.include_router(traces_router)
     app.include_router(route_router)
+    app.include_router(projects_router)
     app.include_router(telemetry_router)
     app.include_router(skills_router)
     app.include_router(sessions_router)

--- a/src/openjarvis/server/routes.py
+++ b/src/openjarvis/server/routes.py
@@ -449,8 +449,18 @@ def _engine_key_for_model(engine: Any, model: str) -> str | None:
     return None
 
 
-def _uses_direct_cloud_router(engine: Any, model: str) -> bool:
-    """Whether *model* should bypass the configured engine for direct cloud."""
+def _uses_direct_cloud_router(engine: Any, model: str, app_config=None) -> bool:
+    """Whether *model* should bypass the configured engine for direct cloud.
+
+    Gated on ``intelligence.allow_cloud`` — a client naming a cloud-shaped
+    model (e.g. ``gpt-4``) must never reach a real cloud API when cloud
+    engines are disabled, independent of the MultiEngine/discovery gates.
+    """
+    if app_config is not None and not getattr(
+        app_config.intelligence, "allow_cloud", False
+    ):
+        return False
+
     from openjarvis.server.cloud_router import is_cloud_model
 
     return is_cloud_model(model) and _engine_key_for_model(engine, model) != "litellm"
@@ -805,7 +815,7 @@ async def _handle_stream_tools(
     messages = _to_messages(req.messages)
     messages = _ensure_identity_prompt(messages, app_config)
     chunk_id = f"chatcmpl-{uuid.uuid4().hex[:12]}"
-    use_cloud = _uses_direct_cloud_router(engine, model)
+    use_cloud = _uses_direct_cloud_router(engine, model, app_config)
     telemetry_engine = (
         "cloud" if use_cloud else (_engine_key_for_model(engine, model) or "ollama")
     )
@@ -944,7 +954,7 @@ async def _handle_stream(
 
     # Route directly to the right backend — bypasses engine routing entirely
     # so broken MultiEngine state can never misdirect requests.
-    use_cloud = _uses_direct_cloud_router(engine, model)
+    use_cloud = _uses_direct_cloud_router(engine, model, app_config)
     telemetry_engine = (
         "cloud" if use_cloud else (_engine_key_for_model(engine, model) or "ollama")
     )
@@ -1223,6 +1233,12 @@ async def reload_cloud_engine(request: Request):
     key so that cloud models become available without a full app restart.
     """
     import os
+
+    if not getattr(request.app.state.config.intelligence, "allow_cloud", False):
+        raise HTTPException(
+            status_code=403,
+            detail="Cloud engines are disabled (intelligence.allow_cloud is false)",
+        )
 
     submitted_keys: dict[str, str] | None = None
     try:

--- a/src/openjarvis/system/evo_router_client.py
+++ b/src/openjarvis/system/evo_router_client.py
@@ -1,0 +1,173 @@
+"""Thin client for EVO's swap primitives: the llm-router catalog (:1240)
+and the llm-general (gpt-oss-120b) docker service it borrows VRAM from.
+
+Mirrors ``~/.local/bin/evo-router`` exactly (same endpoints, same docker
+commands) so this is a drop-in caller of already-debugged infrastructure,
+not a reimplementation of it.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from typing import Any, Dict, Optional
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+ROUTER_HOST = "http://127.0.0.1:1240"
+GENERAL_SERVICE = "llm-general"
+_TIMEOUT = 10.0
+_DOCKER_TIMEOUT = 30.0
+
+_VRAM_USED_PATH = "/sys/class/drm/card0/device/mem_info_vram_used"
+_VRAM_TOTAL_PATH = "/sys/class/drm/card0/device/mem_info_vram_total"
+
+
+def router_status() -> Dict[str, Any]:
+    """Return the llm-router's catalog (id, load status, vision flag)."""
+    try:
+        resp = httpx.get(f"{ROUTER_HOST}/models", timeout=_TIMEOUT)
+        resp.raise_for_status()
+        data = resp.json()
+    except (httpx.ConnectError, httpx.TimeoutException, httpx.HTTPStatusError) as exc:
+        logger.warning("llm-router (:1240) unreachable: %s", exc)
+        return {"reachable": False, "models": []}
+    models = [
+        {
+            "id": m.get("id", ""),
+            "status": m.get("status", {}).get("value", "unknown"),
+            "vision": "image" in m.get("architecture", {}).get("input_modalities", []),
+        }
+        for m in data.get("data", [])
+    ]
+    return {"reachable": True, "models": models}
+
+
+def router_loaded_model() -> Optional[str]:
+    """Return the currently loaded catalog model id, or None if idle."""
+    status = router_status()
+    for m in status.get("models", []):
+        if m.get("status") == "loaded":
+            return m["id"]
+    return None
+
+
+def router_load(model_id: str) -> Dict[str, Any]:
+    """Load *model_id* onto the llm-router (:1240). Unloads any other
+    catalog model first (llama.cpp's ``--models-max 1`` enforces this
+    server-side)."""
+    resp = httpx.post(
+        f"{ROUTER_HOST}/models/load",
+        json={"model": model_id},
+        timeout=120.0,  # cold load of a large GGUF can take a while
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def router_unload(model_id: str) -> Dict[str, Any]:
+    """Unload *model_id* from the llm-router (:1240)."""
+    resp = httpx.post(
+        f"{ROUTER_HOST}/models/unload",
+        json={"model": model_id},
+        timeout=_TIMEOUT,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def free_general_for_router() -> bool:
+    """Stop llm-general (gpt-oss-120b) to free ~70GB for a catalog model.
+
+    Equivalent to ``evo-router on``.
+    """
+    try:
+        subprocess.run(
+            ["docker", "stop", GENERAL_SERVICE],
+            check=True,
+            capture_output=True,
+            timeout=_DOCKER_TIMEOUT,
+        )
+        return True
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        logger.error("Failed to stop %s: %s", GENERAL_SERVICE, exc)
+        return False
+
+
+def restore_general() -> bool:
+    """Unload the router's catalog model and restart llm-general.
+
+    Equivalent to ``evo-router off``.
+    """
+    loaded = router_loaded_model()
+    if loaded:
+        try:
+            router_unload(loaded)
+        except (
+            httpx.ConnectError,
+            httpx.TimeoutException,
+            httpx.HTTPStatusError,
+        ) as exc:
+            logger.warning("Failed to unload router model %r: %s", loaded, exc)
+    try:
+        subprocess.run(
+            ["docker", "start", GENERAL_SERVICE],
+            check=True,
+            capture_output=True,
+            timeout=_DOCKER_TIMEOUT,
+        )
+        return True
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        logger.error("Failed to start %s: %s", GENERAL_SERVICE, exc)
+        return False
+
+
+def read_vram_gb() -> Optional[Dict[str, float]]:
+    """Read live VRAM usage from sysfs (AMD Strix Halo iGPU)."""
+    try:
+        with open(_VRAM_USED_PATH) as f:
+            used = int(f.read().strip())
+        with open(_VRAM_TOTAL_PATH) as f:
+            total = int(f.read().strip())
+    except (OSError, ValueError) as exc:
+        logger.debug("VRAM sysfs read failed: %s", exc)
+        return None
+    gib = 1024**3
+    return {"used_gb": used / gib, "total_gb": total / gib}
+
+
+def read_ram_gb() -> Optional[Dict[str, float]]:
+    """Read live system RAM usage from /proc/meminfo."""
+    try:
+        fields: Dict[str, int] = {}
+        with open("/proc/meminfo") as f:
+            for line in f:
+                key, _, rest = line.partition(":")
+                if key in ("MemTotal", "MemAvailable"):
+                    fields[key] = int(rest.strip().split()[0])  # kB
+        total_kb = fields.get("MemTotal")
+        avail_kb = fields.get("MemAvailable")
+        if total_kb is None or avail_kb is None:
+            return None
+    except (OSError, ValueError, IndexError) as exc:
+        logger.debug("RAM /proc/meminfo read failed: %s", exc)
+        return None
+    return {
+        "total_gb": total_kb / 1024**2,
+        "available_gb": avail_kb / 1024**2,
+        "used_gb": (total_kb - avail_kb) / 1024**2,
+    }
+
+
+__all__ = [
+    "free_general_for_router",
+    "read_ram_gb",
+    "read_vram_gb",
+    "restore_general",
+    "router_load",
+    "router_loaded_model",
+    "router_status",
+    "router_unload",
+]

--- a/src/openjarvis/tools/git_tool.py
+++ b/src/openjarvis/tools/git_tool.py
@@ -311,7 +311,7 @@ class GitCommitTool(BaseTool):
                     success=False,
                 )
             add_result = _run_git(
-                ["git", "add"] + file_list,
+                ["git", "add", "--"] + file_list,
                 cwd=repo_path,
             )
             if not add_result.success:
@@ -381,6 +381,31 @@ class GitPushTool(BaseTool):
         remote = params.get("remote") or "origin"
         branch = params.get("branch")
 
+        # `remote` and `branch` are model-supplied strings that end up as
+        # git argv. Never pass a raw remote through to git: a value like
+        # "ext::sh -c ..." or "--upload-pack=..." is parsed by git itself
+        # (not the shell) and can execute arbitrary commands or exfiltrate
+        # via a bogus transport, regardless of subprocess quoting. Instead
+        # only allow remotes that are already configured on this repo.
+        known_remotes = _run_git(["git", "remote"], cwd=repo_path)
+        if not known_remotes.success:
+            return ToolResult(
+                tool_name="git_push",
+                content=f"Could not list configured remotes: {known_remotes.content}",
+                success=False,
+                metadata=known_remotes.metadata,
+            )
+        valid_remotes = {line.strip() for line in known_remotes.content.splitlines() if line.strip()}
+        if remote not in valid_remotes:
+            return ToolResult(
+                tool_name="git_push",
+                content=(
+                    f"Unknown remote {remote!r}. Must be one of the repository's"
+                    f" already-configured remotes: {sorted(valid_remotes) or '(none)'}."
+                ),
+                success=False,
+            )
+
         if not branch:
             current = _run_git(
                 ["git", "rev-parse", "--abbrev-ref", "HEAD"],
@@ -401,8 +426,20 @@ class GitPushTool(BaseTool):
                     success=False,
                 )
 
+        # git rejects most shell-metacharacter tricks in ref names already,
+        # but validate explicitly so a malformed/hostile branch string never
+        # reaches argv as something git could parse as an option or as two
+        # refspecs (e.g. embedded whitespace, a leading '-', or a ':').
+        ref_check = _run_git(["git", "check-ref-format", "--branch", branch], cwd=repo_path)
+        if not ref_check.success or branch.startswith("-"):
+            return ToolResult(
+                tool_name="git_push",
+                content=f"Invalid branch name: {branch!r}",
+                success=False,
+            )
+
         return _run_git(
-            ["git", "push", remote, f"{branch}:{branch}"],
+            ["git", "push", "--", remote, f"{branch}:{branch}"],
             cwd=repo_path,
         )
 

--- a/src/openjarvis/tools/git_tool.py
+++ b/src/openjarvis/tools/git_tool.py
@@ -330,6 +330,84 @@ class GitCommitTool(BaseTool):
 
 
 # ---------------------------------------------------------------------------
+# GitPushTool
+# ---------------------------------------------------------------------------
+
+
+@ToolRegistry.register("git_push")
+class GitPushTool(BaseTool):
+    """Push committed changes to a remote. Never force-pushes."""
+
+    tool_id = "git_push"
+
+    @property
+    def spec(self) -> ToolSpec:
+        return ToolSpec(
+            name="git_push",
+            description=(
+                "Push committed changes to a remote repository."
+                " Defaults to the current branch and 'origin'."
+                " Force-push is not supported by this tool."
+            ),
+            parameters={
+                "type": "object",
+                "properties": {
+                    "repo_path": {
+                        "type": "string",
+                        "description": (
+                            "Path to the git repository. Default: current directory."
+                        ),
+                    },
+                    "remote": {
+                        "type": "string",
+                        "description": "Remote name. Default: \"origin\".",
+                    },
+                    "branch": {
+                        "type": "string",
+                        "description": (
+                            "Branch to push. Default: the current branch."
+                        ),
+                    },
+                },
+                "required": [],
+            },
+            category="vcs",
+            required_capabilities=["file:write", "network:fetch"],
+            requires_confirmation=True,
+        )
+
+    def execute(self, **params: Any) -> ToolResult:
+        repo_path = params.get("repo_path", ".")
+        remote = params.get("remote") or "origin"
+        branch = params.get("branch")
+
+        if not branch:
+            current = _run_git(
+                ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+                cwd=repo_path,
+            )
+            if not current.success:
+                return ToolResult(
+                    tool_name="git_push",
+                    content=f"Could not determine current branch: {current.content}",
+                    success=False,
+                    metadata=current.metadata,
+                )
+            branch = current.content.strip()
+            if not branch or branch == "HEAD":
+                return ToolResult(
+                    tool_name="git_push",
+                    content="Not on a branch (detached HEAD); specify 'branch' explicitly.",
+                    success=False,
+                )
+
+        return _run_git(
+            ["git", "push", remote, f"{branch}:{branch}"],
+            cwd=repo_path,
+        )
+
+
+# ---------------------------------------------------------------------------
 # GitLogTool
 # ---------------------------------------------------------------------------
 
@@ -396,4 +474,10 @@ class GitLogTool(BaseTool):
         return _run_git(cmd, cwd=repo_path)
 
 
-__all__ = ["GitStatusTool", "GitDiffTool", "GitCommitTool", "GitLogTool"]
+__all__ = [
+    "GitStatusTool",
+    "GitDiffTool",
+    "GitCommitTool",
+    "GitPushTool",
+    "GitLogTool",
+]

--- a/tests/cli/test_audit_cmd.py
+++ b/tests/cli/test_audit_cmd.py
@@ -1,0 +1,168 @@
+"""Tests for ``jarvis audit`` — the behavior-compliance self-audit CLI."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from openjarvis.cli import audit_cmd, cli
+
+
+@dataclass
+class _FakeTrace:
+    query: str = ""
+    result: str = ""
+
+
+class _FakeTraceStore:
+    def __init__(self, traces):
+        self._traces = traces
+        self.closed = False
+
+    def list_traces(self, *, since=None, until=None, limit=100, **kwargs):
+        return self._traces
+
+    def close(self):
+        self.closed = True
+
+
+def _fake_response(json_body: dict, status_code: int = 200):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_body
+    resp.raise_for_status = MagicMock()
+    if status_code >= 400:
+        import httpx
+
+        resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "error", request=MagicMock(), response=resp
+        )
+    return resp
+
+
+class TestDigestTraces:
+    def test_builds_readable_digest(self):
+        traces = [_FakeTrace(query="hi", result="hello")]
+        digest = audit_cmd._digest_traces(traces)
+        assert "hi" in digest and "hello" in digest
+
+    def test_skips_empty_traces(self):
+        traces = [_FakeTrace(query="", result="")]
+        assert audit_cmd._digest_traces(traces) == ""
+
+    def test_truncates_long_content(self):
+        traces = [_FakeTrace(query="x" * 500, result="y" * 500)]
+        digest = audit_cmd._digest_traces(traces)
+        assert len(digest) < 1000
+
+
+class TestExtractJson:
+    def test_extracts_clean_json(self):
+        result = audit_cmd._extract_json('{"drift_found": false, "summary": ""}')
+        assert result == {"drift_found": False, "summary": ""}
+
+    def test_extracts_json_from_surrounding_prose(self):
+        text = 'Sure:\n{"drift_found": true, "summary": "test"}\nHope that helps.'
+        result = audit_cmd._extract_json(text)
+        assert result == {"drift_found": True, "summary": "test"}
+
+    def test_returns_none_for_garbage(self):
+        assert audit_cmd._extract_json("no json here at all") is None
+
+    def test_returns_none_for_malformed_json(self):
+        assert audit_cmd._extract_json("{not: valid json}") is None
+
+
+class TestNotifyTelegram:
+    def test_returns_false_without_credentials(self, monkeypatch):
+        monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+        monkeypatch.delenv("TELEGRAM_OWNER_ID", raising=False)
+        assert audit_cmd._notify_telegram("hi") is False
+
+    def test_sends_message_with_credentials(self, monkeypatch):
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "tok")
+        monkeypatch.setenv("TELEGRAM_OWNER_ID", "42")
+        with patch("httpx.post", return_value=_fake_response({}, 200)) as mock_post:
+            assert audit_cmd._notify_telegram("hi") is True
+        assert mock_post.call_args.kwargs["json"]["chat_id"] == 42
+
+    def test_returns_false_on_network_error(self, monkeypatch):
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "tok")
+        monkeypatch.setenv("TELEGRAM_OWNER_ID", "42")
+        import httpx
+
+        with patch("httpx.post", side_effect=httpx.ConnectError("refused")):
+            assert audit_cmd._notify_telegram("hi") is False
+
+
+class TestAuditRun:
+    def test_no_activity_short_circuits(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr(
+            audit_cmd, "_constitution_path", lambda: _write_constitution(tmp_path)
+        )
+        with patch(
+            "openjarvis.traces.store.TraceStore", lambda **kw: _FakeTraceStore([])
+        ):
+            with patch("openjarvis.core.config.load_config", MagicMock()):
+                result = CliRunner().invoke(cli, ["audit", "run"])
+        assert result.exit_code == 0
+        assert "No activity" in result.output
+
+    def test_no_drift_found(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr(
+            audit_cmd, "_constitution_path", lambda: _write_constitution(tmp_path)
+        )
+        traces = [_FakeTrace(query="fix bug", result="fixed, PR merged")]
+        response = _fake_response({"content": '{"drift_found": false, "summary": ""}'})
+        with patch(
+            "openjarvis.traces.store.TraceStore", lambda **kw: _FakeTraceStore(traces)
+        ):
+            with patch("openjarvis.core.config.load_config", MagicMock()):
+                with patch("httpx.post", return_value=response):
+                    result = CliRunner().invoke(cli, ["audit", "run"])
+        assert result.exit_code == 0
+        assert "No drift found" in result.output
+
+    def test_drift_found_notifies(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr(
+            audit_cmd, "_constitution_path", lambda: _write_constitution(tmp_path)
+        )
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "tok")
+        monkeypatch.setenv("TELEGRAM_OWNER_ID", "42")
+        traces = [
+            _FakeTrace(
+                query="do the trivial thing", result="soll ich das wirklich tun?"
+            )
+        ]
+        review_response = _fake_response(
+            {"content": '{"drift_found": true, "summary": "unnötig nachgefragt"}'}
+        )
+        telegram_response = _fake_response({}, 200)
+
+        def fake_post(url, **kwargs):
+            return telegram_response if "telegram.org" in url else review_response
+
+        with patch(
+            "openjarvis.traces.store.TraceStore", lambda **kw: _FakeTraceStore(traces)
+        ):
+            with patch("openjarvis.core.config.load_config", MagicMock()):
+                with patch("httpx.post", side_effect=fake_post):
+                    result = CliRunner().invoke(cli, ["audit", "run"])
+        assert result.exit_code == 0
+        assert "Drift found" in result.output
+
+    def test_missing_constitution_exits_nonzero(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr(
+            audit_cmd, "_constitution_path", lambda: tmp_path / "missing.md"
+        )
+        result = CliRunner().invoke(cli, ["audit", "run"])
+        assert result.exit_code != 0
+
+
+def _write_constitution(tmp_path: Path) -> Path:
+    p = tmp_path / "constitution.md"
+    p.write_text("# Test Constitution\nBe direct.\n")
+    return p

--- a/tests/engine/test_evo_fleet.py
+++ b/tests/engine/test_evo_fleet.py
@@ -1,0 +1,115 @@
+"""Tests for EvoFleetEngine — routes to whichever EVO port serves a model."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from openjarvis.core.registry import EngineRegistry
+from openjarvis.core.types import Message, Role
+from openjarvis.engine.evo_fleet import EvoFleetEngine
+
+
+def _models_handler(model_ids: list[str]):
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/v1/models"):
+            return httpx.Response(200, json={"data": [{"id": m} for m in model_ids]})
+        if request.url.path.endswith("/v1/chat/completions"):
+            body = json.loads(request.content)
+            return httpx.Response(
+                200,
+                json={
+                    "choices": [
+                        {
+                            "message": {"content": f"served-by:{body['model']}"},
+                            "finish_reason": "stop",
+                        }
+                    ],
+                    "model": body["model"],
+                },
+            )
+        return httpx.Response(404)
+
+    return handler
+
+
+@pytest.fixture()
+def fleet() -> EvoFleetEngine:
+    engine = EvoFleetEngine()
+    # Wire each fixed-port client to a MockTransport serving one model, so
+    # tests never touch the real network / real EVO hardware.
+    fixtures = {
+        1234: ["qwen3-coder-30b-a3b"],
+        1235: ["gpt-oss-120b"],
+        1236: ["text-embedding-nomic-embed-text-v1.5"],
+        1239: ["qwen2.5-coder-3b"],
+        1241: ["gpt-oss-20b"],
+    }
+    for port, models in fixtures.items():
+        client = engine._port_clients[port]
+        client._client.close()
+        client._client = httpx.Client(
+            base_url=f"http://127.0.0.1:{port}",
+            transport=httpx.MockTransport(_models_handler(models)),
+        )
+    engine._router_client._client.close()
+    engine._router_client._client = httpx.Client(
+        base_url="http://127.0.0.1:1240",
+        transport=httpx.MockTransport(lambda r: httpx.Response(404)),
+    )
+    yield engine
+    engine.close()
+
+
+class TestEvoFleetEngine:
+    def test_registered_in_engine_registry(self) -> None:
+        # The test suite's autouse _clean_registries fixture wipes
+        # EngineRegistry before every test (see tests/conftest.py), so
+        # module-import-time registration (which only ever runs once per
+        # process, as in real `jarvis serve` usage) doesn't survive it here.
+        # Re-registering explicitly matches the convention other engine
+        # tests use (see tests/engine/test_openai_compat.py's `engine`
+        # fixture).
+        EngineRegistry.register_value("evo_fleet", EvoFleetEngine)
+        assert EngineRegistry.contains("evo_fleet")
+        assert EngineRegistry.get("evo_fleet") is EvoFleetEngine
+
+    def test_list_models_aggregates_all_ports(self, fleet: EvoFleetEngine) -> None:
+        models = fleet.list_models()
+        assert "qwen3-coder-30b-a3b" in models
+        assert "gpt-oss-120b" in models
+        assert "gpt-oss-20b" in models
+
+    def test_generate_routes_to_correct_port(self, fleet: EvoFleetEngine) -> None:
+        result = fleet.generate(
+            [Message(role=Role.USER, content="hi")], model="qwen3-coder-30b-a3b"
+        )
+        assert result["content"] == "served-by:qwen3-coder-30b-a3b"
+
+    def test_generate_unknown_model_raises(self, fleet: EvoFleetEngine) -> None:
+        with pytest.raises(ValueError, match="not found on any EVO port"):
+            fleet.generate([Message(role=Role.USER, content="hi")], model="nope")
+
+    def test_port_for_known_model(self, fleet: EvoFleetEngine) -> None:
+        fleet.list_models()  # populate the map
+        assert fleet.port_for("gpt-oss-120b") == 1235
+
+    def test_is_isolated_reflects_catalog(self, fleet: EvoFleetEngine) -> None:
+        assert fleet.is_isolated("gpt-oss-20b") is True
+        assert fleet.is_isolated("qwen3-coder-30b-a3b") is False
+
+    def test_health_true_when_any_port_reachable(self, fleet: EvoFleetEngine) -> None:
+        assert fleet.health() is True
+
+    def test_health_false_when_all_ports_down(self, fleet: EvoFleetEngine) -> None:
+        def refuse(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("refused", request=request)
+
+        for client in fleet._port_clients.values():
+            client._client.close()
+            client._client = httpx.Client(
+                base_url=client._host, transport=httpx.MockTransport(refuse)
+            )
+        assert fleet.health() is False

--- a/tests/intelligence/test_evo_catalog.py
+++ b/tests/intelligence/test_evo_catalog.py
@@ -1,0 +1,40 @@
+"""Tests for the EVO fleet model catalog."""
+
+from __future__ import annotations
+
+from openjarvis.core.registry import ModelRegistry
+from openjarvis.intelligence.evo_catalog import (
+    EVO_FIXED_PORTS,
+    EVO_MODEL_META,
+    EVO_MODELS,
+    EVO_ROUTER_PORT,
+    register_evo_models,
+)
+
+
+class TestEvoCatalog:
+    def test_trading_model_is_isolated(self) -> None:
+        assert EVO_MODEL_META["gpt-oss-20b"]["isolated"] is True
+        assert EVO_MODEL_META["gpt-oss-20b"]["port"] == 1241
+
+    def test_no_other_model_is_isolated(self) -> None:
+        for model_id, meta in EVO_MODEL_META.items():
+            if model_id != "gpt-oss-20b":
+                assert meta["isolated"] is False, model_id
+
+    def test_router_port_not_in_fixed_ports(self) -> None:
+        assert EVO_ROUTER_PORT not in EVO_FIXED_PORTS
+
+    def test_fixed_ports_match_docker_compose(self) -> None:
+        assert EVO_FIXED_PORTS == [1234, 1235, 1236, 1239, 1241]
+
+    def test_embedding_model_flagged(self) -> None:
+        meta = EVO_MODEL_META["text-embedding-nomic-embed-text-v1.5"]
+        assert meta["architecture"] == "embedding"
+
+    def test_register_evo_models_is_idempotent(self) -> None:
+        register_evo_models()
+        register_evo_models()  # must not raise
+        for spec in EVO_MODELS:
+            assert ModelRegistry.contains(spec.model_id)
+            assert ModelRegistry.get(spec.model_id) is spec

--- a/tests/knowledge/test_projects.py
+++ b/tests/knowledge/test_projects.py
@@ -1,0 +1,199 @@
+"""Tests for ProjectRegistry — cross-project knowledge indexing."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from openjarvis.knowledge.projects import ProjectConfig, ProjectRegistry
+from openjarvis.tools.storage._stubs import MemoryBackend, RetrievalResult
+
+
+class _FakeMemory(MemoryBackend):
+    """Fake backend with replace_source, matching SQLiteMemory's contract."""
+
+    backend_id = "fake"
+
+    def __init__(self) -> None:
+        self._docs: dict[str, dict] = {}
+        self._counter = 0
+        self.replace_source_calls: list[tuple[str, int]] = []
+
+    def store(self, content, *, source="", metadata=None):
+        self._counter += 1
+        doc_id = f"doc-{self._counter}"
+        self._docs[doc_id] = {
+            "content": content,
+            "source": source,
+            "metadata": metadata or {},
+        }
+        return doc_id
+
+    def replace_source(self, source, documents):
+        # Drop any existing docs for this source, then store the new set —
+        # mirrors SQLiteMemory.replace_source's atomic-replace semantics.
+        stale = [did for did, d in self._docs.items() if d["source"] == source]
+        for did in stale:
+            del self._docs[did]
+        doc_ids = [
+            self.store(content, source=source, metadata=metadata)
+            for content, metadata in documents
+        ]
+        self.replace_source_calls.append((source, len(documents)))
+        return doc_ids
+
+    def retrieve(self, query, *, top_k=5, **kwargs):
+        results = [
+            RetrievalResult(
+                content=d["content"],
+                score=1.0,
+                source=d["source"],
+                metadata=d["metadata"],
+            )
+            for d in self._docs.values()
+            if query.lower() in d["content"].lower() or query == d["source"]
+        ]
+        return results[:top_k]
+
+    def delete(self, doc_id):
+        return self._docs.pop(doc_id, None) is not None
+
+    def clear(self):
+        self._docs.clear()
+
+
+class _NoReplaceMemory(MemoryBackend):
+    """Fake backend WITHOUT replace_source — should be rejected."""
+
+    backend_id = "no-replace"
+
+    def store(self, content, *, source="", metadata=None):
+        return "x"
+
+    def retrieve(self, query, *, top_k=5, **kwargs):
+        return []
+
+    def delete(self, doc_id):
+        return False
+
+    def clear(self):
+        pass
+
+
+@pytest.fixture()
+def project_dir(tmp_path: Path) -> Path:
+    repo = tmp_path / "demo-repo"
+    repo.mkdir()
+    (repo / "README.md").write_text("# Demo\nThis project does demo things.\n")
+    return repo
+
+
+@pytest.fixture()
+def registry(project_dir: Path) -> ProjectRegistry:
+    return ProjectRegistry(
+        _FakeMemory(),
+        projects=[ProjectConfig("demo", project_dir, github_repo="")],
+    )
+
+
+class TestProjectRegistryConstruction:
+    def test_rejects_backend_without_replace_source(self, project_dir: Path) -> None:
+        with pytest.raises(TypeError, match="replace_source"):
+            ProjectRegistry(
+                _NoReplaceMemory(), projects=[ProjectConfig("demo", project_dir)]
+            )
+
+    def test_project_ids(self, registry: ProjectRegistry) -> None:
+        assert registry.project_ids == ["demo"]
+
+
+class TestRefresh:
+    def test_refresh_indexes_readme(self, registry: ProjectRegistry) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.stdout = ""
+            mock_run.return_value.returncode = 0
+            count = registry.refresh("demo")
+        assert count >= 1
+
+    def test_refresh_unknown_project_raises(self, registry: ProjectRegistry) -> None:
+        with pytest.raises(KeyError):
+            registry.refresh("nope")
+
+    def test_refresh_missing_repo_path_returns_zero(self, tmp_path: Path) -> None:
+        registry = ProjectRegistry(
+            _FakeMemory(),
+            projects=[ProjectConfig("ghost", tmp_path / "does-not-exist")],
+        )
+        assert registry.refresh("ghost") == 0
+
+    def test_refresh_is_idempotent_via_replace_source(
+        self, registry: ProjectRegistry
+    ) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.stdout = ""
+            mock_run.return_value.returncode = 0
+            registry.refresh("demo")
+            registry.refresh("demo")
+        mem = registry._memory
+        # Two refreshes of the same unchanged README must not accumulate docs.
+        docs_for_demo = [d for d in mem._docs.values() if d["source"] == "demo"]
+        assert len(docs_for_demo) == mem.replace_source_calls[-1][1]
+
+    def test_refresh_all_continues_after_one_failure(self, project_dir: Path) -> None:
+        mem = _FakeMemory()
+        registry = ProjectRegistry(
+            mem,
+            projects=[
+                ProjectConfig("broken", Path("/definitely/not/a/repo")),
+                ProjectConfig("demo", project_dir),
+            ],
+        )
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.stdout = ""
+            mock_run.return_value.returncode = 0
+            results = registry.refresh_all()
+        assert results["broken"] == 0
+        assert results["demo"] >= 1
+
+    def test_refresh_includes_issues_and_prs_when_configured(
+        self, project_dir: Path
+    ) -> None:
+        registry = ProjectRegistry(
+            _FakeMemory(),
+            projects=[ProjectConfig("demo", project_dir, github_repo="acme/demo")],
+        )
+
+        def fake_run(cmd, **kwargs):
+            result = type("R", (), {})()
+            if cmd[0] == "gh":
+                result.returncode = 0
+                result.stdout = '[{"number": 1, "title": "Bug", "state": "OPEN"}]'
+            else:
+                result.returncode = 0
+                result.stdout = ""
+            return result
+
+        with patch("subprocess.run", side_effect=fake_run):
+            registry.refresh("demo")
+
+        mem = registry._memory
+        contents = [d["content"] for d in mem._docs.values() if d["source"] == "demo"]
+        assert any("issues:" in c for c in contents)
+
+
+class TestSummary:
+    def test_summary_filters_by_project(self, project_dir: Path) -> None:
+        mem = _FakeMemory()
+        mem.store("demo content", source="demo")
+        mem.store("other content", source="other-project")
+        registry = ProjectRegistry(mem, projects=[ProjectConfig("demo", project_dir)])
+
+        results = registry.summary("demo", "content")
+        assert all(r.source == "demo" for r in results)
+        assert any("demo content" in r.content for r in results)
+
+    def test_summary_unknown_project_raises(self, registry: ProjectRegistry) -> None:
+        with pytest.raises(KeyError):
+            registry.summary("nope")

--- a/tests/learning/routing/test_evo_scheduler.py
+++ b/tests/learning/routing/test_evo_scheduler.py
@@ -1,0 +1,100 @@
+"""Tests for EvoScheduler — routing, isolation, holds, cooldown."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from openjarvis.learning.routing.evo_scheduler import (
+    COOLDOWN_SECONDS,
+    EvoIsolatedModelError,
+    EvoScheduler,
+)
+
+
+class _StubFleet:
+    """Minimal fleet stub — EvoScheduler.select() only needs port_for()."""
+
+    def port_for(self, model: str) -> int | None:
+        return {
+            "qwen3-coder-30b-a3b": 1234,
+            "gpt-oss-120b": 1235,
+            "qwen2.5-coder-3b": 1239,
+            "gpt-oss-20b": 1241,
+        }.get(model)
+
+    def list_models(self) -> list[str]:
+        return ["qwen3-coder-30b-a3b", "gpt-oss-120b", "qwen2.5-coder-3b"]
+
+
+@pytest.fixture()
+def scheduler() -> EvoScheduler:
+    return EvoScheduler(fleet=_StubFleet())
+
+
+class TestRouting:
+    def test_code_query_routes_to_coder(self, scheduler: EvoScheduler) -> None:
+        decision = scheduler.select("write a function to reverse a string")
+        assert decision["model"] == "qwen3-coder-30b-a3b"
+        assert decision["port"] == 1234
+
+    def test_reasoning_query_routes_to_general(self, scheduler: EvoScheduler) -> None:
+        decision = scheduler.select(
+            "explain step by step, with deep reasoning, why the sky is blue "
+            "considering Rayleigh scattering and atmospheric composition"
+        )
+        assert decision["model"] == "gpt-oss-120b"
+
+    def test_never_selects_embedding_model_for_chat(
+        self, scheduler: EvoScheduler
+    ) -> None:
+        for query in ("hi", "2+2", "what time is it"):
+            decision = scheduler.select(query)
+            assert decision["model"] != "text-embedding-nomic-embed-text-v1.5"
+
+    def test_never_auto_selects_isolated_trading_model(
+        self, scheduler: EvoScheduler
+    ) -> None:
+        for query in ("hi", "write code", "reason deeply about physics"):
+            decision = scheduler.select(query)
+            assert decision["model"] != "gpt-oss-20b"
+
+
+class TestIsolation:
+    def test_force_model_refuses_isolated_model(self, scheduler: EvoScheduler) -> None:
+        with pytest.raises(EvoIsolatedModelError):
+            scheduler.select("anything", force_model="gpt-oss-20b")
+
+    def test_swap_to_router_model_refuses_isolated_model(
+        self, scheduler: EvoScheduler
+    ) -> None:
+        with pytest.raises(EvoIsolatedModelError):
+            scheduler.swap_to_router_model("gpt-oss-20b")
+
+    def test_force_model_allows_non_isolated(self, scheduler: EvoScheduler) -> None:
+        decision = scheduler.select("anything", force_model="gpt-oss-120b")
+        assert decision["model"] == "gpt-oss-120b"
+        assert decision["reason"] == "explicit"
+
+
+class TestHoldsAndCooldown:
+    def test_active_hold_blocks_swap(self, scheduler: EvoScheduler) -> None:
+        scheduler.begin_hold("chan-1")
+        result = scheduler.swap_to_router_model("qwen3.8-27b")
+        assert result["swapped"] is False
+        assert result["reason"] == "active_hold"
+
+    def test_end_hold_releases_block(self, scheduler: EvoScheduler) -> None:
+        scheduler.begin_hold("chan-1")
+        scheduler.end_hold("chan-1")
+        assert scheduler._has_active_hold() is False
+
+    def test_cooldown_blocks_rapid_swap(self, scheduler: EvoScheduler) -> None:
+        scheduler._state.last_swap_ts = time.monotonic()
+        result = scheduler.swap_to_router_model("qwen3.8-27b")
+        assert result["swapped"] is False
+        assert result["reason"] == "cooldown"
+
+    def test_cooldown_constant_is_positive(self) -> None:
+        assert COOLDOWN_SECONDS > 0

--- a/tests/learning/routing/test_evo_scheduler.py
+++ b/tests/learning/routing/test_evo_scheduler.py
@@ -98,3 +98,55 @@ class TestHoldsAndCooldown:
 
     def test_cooldown_constant_is_positive(self) -> None:
         assert COOLDOWN_SECONDS > 0
+
+
+class TestShadowMode:
+    def test_heuristic_decision_never_overridden_by_shadow(
+        self, scheduler: EvoScheduler
+    ) -> None:
+        """The whole point of shadow mode: it observes, it never decides."""
+        decision = scheduler.select("write a function to reverse a string")
+        assert (
+            decision["model"] == "qwen3-coder-30b-a3b"
+        )  # heuristic's own pick, unchanged
+
+    def test_shadow_fields_present_on_heuristic_path(
+        self, scheduler: EvoScheduler
+    ) -> None:
+        decision = scheduler.select("write some code")
+        assert "shadow_model" in decision
+        assert "shadow_agrees" in decision
+
+    def test_shadow_fields_absent_on_forced_path(self, scheduler: EvoScheduler) -> None:
+        decision = scheduler.select("anything", force_model="gpt-oss-120b")
+        assert "shadow_model" not in decision
+        assert "shadow_agrees" not in decision
+
+    def test_shadow_agrees_with_itself_on_repeat_query(
+        self, scheduler: EvoScheduler
+    ) -> None:
+        # First call bootstraps the learned policy's map for this query
+        # class to whatever the heuristic picked; a second call of the
+        # same class should then see the shadow policy agree.
+        query = "write a function to reverse a string"
+        scheduler.select(query)
+        decision = scheduler.select(query)
+        assert decision["shadow_agrees"] is True
+
+    def test_status_exposes_learned_policy_map(self, scheduler: EvoScheduler) -> None:
+        scheduler.select("write a function to reverse a string")
+        status = scheduler.status()
+        assert "shadow_learned_policy" in status
+        assert isinstance(status["shadow_learned_policy"], dict)
+        assert len(status["shadow_learned_policy"]) > 0
+
+    def test_shadow_failure_never_breaks_routing(
+        self, scheduler: EvoScheduler, monkeypatch
+    ) -> None:
+        def boom(*a, **k):
+            raise RuntimeError("shadow exploded")
+
+        monkeypatch.setattr(scheduler._learned, "observe", boom)
+        decision = scheduler.select("write some code")  # must not raise
+        assert decision["model"]  # routing still produced a real answer
+        assert "shadow_model" not in decision  # exception swallowed before it was set

--- a/tests/server/test_project_routes.py
+++ b/tests/server/test_project_routes.py
@@ -1,0 +1,124 @@
+"""Tests for the /v1/projects routes."""
+
+from __future__ import annotations
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from openjarvis.server.api_routes import include_all_routes  # noqa: E402
+from openjarvis.tools.storage._stubs import MemoryBackend, RetrievalResult  # noqa: E402
+
+
+class _FakeMemory(MemoryBackend):
+    backend_id = "fake"
+
+    def __init__(self) -> None:
+        self._docs: dict[str, dict] = {}
+        self._n = 0
+
+    def store(self, content, *, source="", metadata=None):
+        self._n += 1
+        doc_id = f"doc-{self._n}"
+        self._docs[doc_id] = {
+            "content": content,
+            "source": source,
+            "metadata": metadata or {},
+        }
+        return doc_id
+
+    def replace_source(self, source, documents):
+        for did in [d for d, v in self._docs.items() if v["source"] == source]:
+            del self._docs[did]
+        return [self.store(c, source=source, metadata=m) for c, m in documents]
+
+    def retrieve(self, query, *, top_k=5, **kwargs):
+        return [
+            RetrievalResult(
+                content=d["content"],
+                score=1.0,
+                source=d["source"],
+                metadata=d["metadata"],
+            )
+            for d in self._docs.values()
+        ][:top_k]
+
+    def delete(self, doc_id):
+        return self._docs.pop(doc_id, None) is not None
+
+    def clear(self):
+        self._docs.clear()
+
+
+class _NoReplaceMemory(MemoryBackend):
+    backend_id = "no-replace"
+
+    def store(self, content, *, source="", metadata=None):
+        return "x"
+
+    def retrieve(self, query, *, top_k=5, **kwargs):
+        return []
+
+    def delete(self, doc_id):
+        return False
+
+    def clear(self):
+        pass
+
+
+def _make_app(memory_backend=None):
+    app = FastAPI()
+    include_all_routes(app)
+    if memory_backend is not None:
+        app.state.memory_backend = memory_backend
+    return app
+
+
+class TestProjectRoutes:
+    def test_no_memory_backend_returns_503(self) -> None:
+        client = TestClient(_make_app())
+        resp = client.get("/v1/projects")
+        assert resp.status_code == 503
+
+    def test_backend_without_replace_source_returns_503(self) -> None:
+        client = TestClient(_make_app(_NoReplaceMemory()))
+        resp = client.get("/v1/projects")
+        assert resp.status_code == 503
+
+    def test_list_projects(self) -> None:
+        client = TestClient(_make_app(_FakeMemory()))
+        resp = client.get("/v1/projects")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "openjarvis" in data["projects"]
+        assert "sugar-rush" in data["projects"]
+        assert "trading-bot" in data["projects"]
+
+    def test_summary_unknown_project_404(self) -> None:
+        client = TestClient(_make_app(_FakeMemory()))
+        resp = client.get("/v1/projects/nope/summary")
+        assert resp.status_code == 404
+
+    def test_summary_returns_indexed_content(self) -> None:
+        mem = _FakeMemory()
+        mem.store("sugar-rush handles checkout", source="sugar-rush")
+        mem.store("trading-bot handles risk gates", source="trading-bot")
+        client = TestClient(_make_app(mem))
+
+        resp = client.get("/v1/projects/sugar-rush/summary")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["project"] == "sugar-rush"
+        assert all(
+            "checkout" in r["content"] or True for r in data["results"]
+        )  # sanity: response shape is correct
+        contents = [r["content"] for r in data["results"]]
+        assert "sugar-rush handles checkout" in contents
+        assert "trading-bot handles risk gates" not in contents
+
+    def test_refresh_unknown_project_404(self) -> None:
+        client = TestClient(_make_app(_FakeMemory()))
+        resp = client.post("/v1/projects/nope/refresh")
+        assert resp.status_code == 404

--- a/tests/server/test_websocket_evo_routing.py
+++ b/tests/server/test_websocket_evo_routing.py
@@ -1,0 +1,76 @@
+"""Tests that /v1/chat/stream opportunistically uses EvoScheduler routing
+when the caller doesn't pin an explicit model."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+from fastapi import FastAPI  # noqa: E402
+from starlette.testclient import TestClient  # noqa: E402
+
+from openjarvis.server.api_routes import include_all_routes  # noqa: E402
+
+
+def _make_evo_aware_engine(known_models):
+    """A mock engine that reports EVO model ids as available."""
+    engine = MagicMock()
+    engine.engine_id = "mock-evo"
+    engine.list_models.return_value = list(known_models)
+
+    async def mock_stream(messages, *, model="test-model", **kwargs):
+        yield f"used:{model}"
+
+    engine.stream = mock_stream
+    engine.generate.return_value = {
+        "content": "ok",
+        "usage": {},
+        "model": "test-model",
+        "finish_reason": "stop",
+    }
+    return engine
+
+
+def _make_app(engine):
+    app = FastAPI()
+    app.state.engine = engine
+    app.state.model = "static-default-model"
+    include_all_routes(app)
+    return app
+
+
+class TestEvoAwareWebSocketRouting:
+    def test_uses_evo_scheduler_pick_when_model_available(self) -> None:
+        engine = _make_evo_aware_engine(
+            ["qwen3-coder-30b-a3b", "gpt-oss-120b", "qwen2.5-coder-3b"]
+        )
+        app = _make_app(engine)
+        client = TestClient(app)
+        with client.websocket_connect("/v1/chat/stream") as ws:
+            ws.send_text(json.dumps({"message": "write a function to reverse a list"}))
+            chunk = ws.receive_json()
+            assert chunk["content"] == "used:qwen3-coder-30b-a3b"
+
+    def test_falls_back_to_static_default_when_evo_model_not_served(self) -> None:
+        # Engine only serves models EvoScheduler would never pick — the
+        # membership check in _maybe_evo_model must reject the suggestion
+        # and fall back to app.state.model, never crash.
+        engine = _make_evo_aware_engine(["some-other-model"])
+        app = _make_app(engine)
+        client = TestClient(app)
+        with client.websocket_connect("/v1/chat/stream") as ws:
+            ws.send_text(json.dumps({"message": "hello there"}))
+            chunk = ws.receive_json()
+            assert chunk["content"] == "used:static-default-model"
+
+    def test_explicit_model_always_wins_over_evo_scheduler(self) -> None:
+        engine = _make_evo_aware_engine(["qwen3-coder-30b-a3b", "pinned-model"])
+        app = _make_app(engine)
+        client = TestClient(app)
+        with client.websocket_connect("/v1/chat/stream") as ws:
+            ws.send_text(json.dumps({"message": "write code", "model": "pinned-model"}))
+            chunk = ws.receive_json()
+            assert chunk["content"] == "used:pinned-model"

--- a/tests/system/test_evo_router_client.py
+++ b/tests/system/test_evo_router_client.py
@@ -1,0 +1,158 @@
+"""Tests for evo_router_client — the llm-router (:1240) + llm-general wrapper."""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import patch
+
+import httpx
+import respx
+
+from openjarvis.system import evo_router_client as erc
+
+
+@respx.mock
+class TestRouterStatus:
+    def test_reachable_parses_models(self) -> None:
+        respx.get(f"{erc.ROUTER_HOST}/models").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "data": [
+                        {
+                            "id": "qwen3.8-27b",
+                            "status": {"value": "loaded"},
+                            "architecture": {"input_modalities": ["text"]},
+                        },
+                        {
+                            "id": "gemma-4-31b",
+                            "status": {"value": "unloaded"},
+                            "architecture": {"input_modalities": ["text", "image"]},
+                        },
+                    ]
+                },
+            )
+        )
+        status = erc.router_status()
+        assert status["reachable"] is True
+        ids = {m["id"]: m for m in status["models"]}
+        assert ids["qwen3.8-27b"]["status"] == "loaded"
+        assert ids["gemma-4-31b"]["vision"] is True
+
+    def test_unreachable_returns_empty(self) -> None:
+        respx.get(f"{erc.ROUTER_HOST}/models").mock(
+            side_effect=httpx.ConnectError("refused")
+        )
+        status = erc.router_status()
+        assert status == {"reachable": False, "models": []}
+
+    def test_loaded_model_returns_none_when_idle(self) -> None:
+        respx.get(f"{erc.ROUTER_HOST}/models").mock(
+            return_value=httpx.Response(200, json={"data": []})
+        )
+        assert erc.router_loaded_model() is None
+
+    def test_loaded_model_finds_loaded_entry(self) -> None:
+        respx.get(f"{erc.ROUTER_HOST}/models").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "data": [
+                        {
+                            "id": "qwen3.8-27b",
+                            "status": {"value": "loaded"},
+                            "architecture": {"input_modalities": []},
+                        }
+                    ]
+                },
+            )
+        )
+        assert erc.router_loaded_model() == "qwen3.8-27b"
+
+
+@respx.mock
+class TestRouterLoadUnload:
+    def test_load_posts_model(self) -> None:
+        route = respx.post(f"{erc.ROUTER_HOST}/models/load").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+        erc.router_load("qwen3.8-27b")
+        assert route.called
+        assert route.calls.last.request.content == b'{"model":"qwen3.8-27b"}'
+
+    def test_unload_posts_model(self) -> None:
+        route = respx.post(f"{erc.ROUTER_HOST}/models/unload").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+        erc.router_unload("qwen3.8-27b")
+        assert route.called
+
+
+class TestFreeAndRestoreGeneral:
+    def test_free_general_calls_docker_stop(self) -> None:
+        with patch.object(subprocess, "run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess([], 0)
+            assert erc.free_general_for_router() is True
+            mock_run.assert_called_once()
+            assert mock_run.call_args.args[0] == ["docker", "stop", "llm-general"]
+
+    def test_free_general_returns_false_on_docker_failure(self) -> None:
+        with patch.object(subprocess, "run") as mock_run:
+            mock_run.side_effect = subprocess.CalledProcessError(1, "docker")
+            assert erc.free_general_for_router() is False
+
+    @respx.mock
+    def test_restore_general_unloads_then_starts(self) -> None:
+        respx.get(f"{erc.ROUTER_HOST}/models").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "data": [
+                        {
+                            "id": "qwen3.8-27b",
+                            "status": {"value": "loaded"},
+                            "architecture": {"input_modalities": []},
+                        }
+                    ]
+                },
+            )
+        )
+        unload_route = respx.post(f"{erc.ROUTER_HOST}/models/unload").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+        with patch.object(subprocess, "run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess([], 0)
+            assert erc.restore_general() is True
+            assert mock_run.call_args.args[0] == ["docker", "start", "llm-general"]
+        assert unload_route.called
+
+
+class TestSysfsReaders:
+    def test_read_vram_gb_parses_bytes_to_gib(self, tmp_path, monkeypatch) -> None:
+        used = tmp_path / "used"
+        total = tmp_path / "total"
+        used.write_text(str(4 * 1024**3))
+        total.write_text(str(64 * 1024**3))
+        monkeypatch.setattr(erc, "_VRAM_USED_PATH", str(used))
+        monkeypatch.setattr(erc, "_VRAM_TOTAL_PATH", str(total))
+        result = erc.read_vram_gb()
+        assert result == {"used_gb": 4.0, "total_gb": 64.0}
+
+    def test_read_vram_gb_returns_none_if_missing(self, monkeypatch) -> None:
+        monkeypatch.setattr(erc, "_VRAM_USED_PATH", "/nonexistent/path")
+        assert erc.read_vram_gb() is None
+
+    def test_read_ram_gb_parses_meminfo(self, tmp_path, monkeypatch) -> None:
+        meminfo = tmp_path / "meminfo"
+        meminfo.write_text("MemTotal:       61000000 kB\nMemAvailable:    3000000 kB\n")
+        real_open = open
+
+        def fake_open(path, *args, **kwargs):
+            if path == "/proc/meminfo":
+                return real_open(meminfo, *args, **kwargs)
+            return real_open(path, *args, **kwargs)
+
+        with patch("builtins.open", fake_open):
+            result = erc.read_ram_gb()
+        assert result is not None
+        assert round(result["total_gb"], 1) == round(61000000 / 1024**2, 1)

--- a/tests/tools/test_git_tool.py
+++ b/tests/tools/test_git_tool.py
@@ -15,6 +15,7 @@ from openjarvis.tools.git_tool import (
     GitCommitTool,
     GitDiffTool,
     GitLogTool,
+    GitPushTool,
     GitStatusTool,
 )
 
@@ -432,6 +433,137 @@ class TestGitCommitTool:
     def test_message_required_in_spec(self):
         tool = GitCommitTool()
         assert "message" in tool.spec.parameters["required"]
+
+
+# ---------------------------------------------------------------------------
+# TestGitPushTool
+# ---------------------------------------------------------------------------
+
+
+def _add_bare_remote(repo_path, remote_dir, name="origin"):
+    """Create a bare repo at *remote_dir* and register it as *name* on *repo_path*."""
+    remote_dir.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        ["git", "init", "--bare"],
+        cwd=str(remote_dir),
+        capture_output=True,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "remote", "add", name, str(remote_dir)],
+        cwd=str(repo_path),
+        capture_output=True,
+        check=True,
+    )
+
+
+class TestGitPushTool:
+    def test_spec(self):
+        tool = GitPushTool()
+        assert tool.spec.name == "git_push"
+        assert tool.spec.category == "vcs"
+        assert "file:write" in tool.spec.required_capabilities
+        assert tool.spec.requires_confirmation is True
+
+    def test_tool_id(self):
+        tool = GitPushTool()
+        assert tool.tool_id == "git_push"
+
+    def test_push_default_remote_and_branch(self, tmp_path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        remote = tmp_path / "remote.git"
+        _init_repo(repo)
+        _add_bare_remote(repo, remote)
+
+        result = GitPushTool().execute(repo_path=str(repo))
+        assert result.success is True
+
+        log = subprocess.run(
+            ["git", "log", "--oneline", "-1"],
+            cwd=str(remote),
+            capture_output=True,
+            text=True,
+        )
+        assert "Initial commit" in log.stdout
+
+    def test_push_explicit_remote_and_branch(self, tmp_path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        remote = tmp_path / "remote.git"
+        _init_repo(repo)
+        _add_bare_remote(repo, remote, name="upstream")
+
+        result = GitPushTool().execute(
+            repo_path=str(repo), remote="upstream", branch="main"
+        )
+        assert result.success is True
+
+    def test_rejects_unconfigured_remote(self, tmp_path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _init_repo(repo)
+
+        result = GitPushTool().execute(repo_path=str(repo), remote="origin")
+        assert result.success is False
+        assert "Unknown remote" in result.content
+
+    def test_rejects_ext_transport_as_remote(self, tmp_path):
+        """A remote value must be a pre-configured name, never a raw URL/transport
+        string — otherwise a model-supplied ``ext::sh -c ...`` would let git itself
+        execute an arbitrary command via the ext transport helper."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _init_repo(repo)
+
+        result = GitPushTool().execute(
+            repo_path=str(repo), remote="ext::sh -c touch /tmp/pwned"
+        )
+        assert result.success is False
+        assert "Unknown remote" in result.content
+        assert not (tmp_path / "pwned").exists()
+
+    def test_rejects_flag_like_remote(self, tmp_path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _init_repo(repo)
+
+        result = GitPushTool().execute(repo_path=str(repo), remote="--upload-pack=id")
+        assert result.success is False
+        assert "Unknown remote" in result.content
+
+    def test_rejects_invalid_branch_name(self, tmp_path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        remote = tmp_path / "remote.git"
+        _init_repo(repo)
+        _add_bare_remote(repo, remote)
+
+        result = GitPushTool().execute(
+            repo_path=str(repo), branch="ext::sh -c id"
+        )
+        assert result.success is False
+        assert "Invalid branch name" in result.content
+
+    def test_rejects_flag_like_branch(self, tmp_path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        remote = tmp_path / "remote.git"
+        _init_repo(repo)
+        _add_bare_remote(repo, remote)
+
+        result = GitPushTool().execute(repo_path=str(repo), branch="--force")
+        assert result.success is False
+        assert "Invalid branch name" in result.content
+
+    def test_no_remotes_configured(self, tmp_path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _init_repo(repo)
+
+        result = GitPushTool().execute(repo_path=str(repo))
+        assert result.success is False
+        assert "Unknown remote" in result.content
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `intelligence.provider = "local"` in `config.toml` was purely decorative — no code path ever checked it. Four independent places could reach a real cloud API (OpenAI/Anthropic/Google/OpenRouter) just from an env var being present or from the request body, regardless of the configured provider.
- Adds `IntelligenceConfig.allow_cloud: bool = False` and gates all four paths on it:
  - `cli/serve.py` — no longer builds a `CloudEngine` at startup unless `allow_cloud` is true, even if cloud API key env vars are set.
  - `engine/_discovery.py` — `get_engine()`/`discover_engines()` never select/construct a cloud-classed engine (`is_cloud=True`) as a fallback or as an explicit request when `allow_cloud` is false.
  - `server/routes.py` `POST /v1/cloud/reload` — now returns `403` outright when `allow_cloud` is false, instead of writing submitted keys to `os.environ` and hot-wiring a `CloudEngine` into the live `MultiEngine`.
  - `server/routes.py` `_uses_direct_cloud_router()` — no longer routes a chat request to the real cloud API based on the model name looking cloud-shaped (`gpt-*`, `claude-*`, ...) when `allow_cloud` is false.

## Test plan
- [x] `uv run --extra dev pytest tests/engine/test_discovery.py tests/engine/test_cloud.py tests/engine/test_cloud_extended.py tests/cli/test_serve_single_build.py -q` → 82/82 passed
- [x] Live-verified on the running `jarvis-serve.service`: local chat completions unaffected (`kat-coder-v2.5` responds normally), `/v1/cloud/reload` with a test key → `403`, `get_engine()` never returns the cloud engine even with a fake `OPENAI_API_KEY` in the environment (explicit request and fallback discovery both refuse), flipping `allow_cloud=true` restores the prior behavior with no regression.